### PR TITLE
Add Assembly Syntax Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "extensions/assembly"]
+	path = extensions/assembly
+	url = https://github.com/DevBlocky/zed-asm.git
 [submodule "extensions/beancount"]
 	path = extensions/beancount
 	url = https://github.com/zed-extensions/beancount
@@ -46,6 +49,3 @@
 [submodule "extensions/vscode-monokai-charcoal"]
 	path = extensions/vscode-monokai-charcoal
 	url = git@github.com:d1y/vscode-monokaicharcoal.zed.git
-[submodule "extensions/assembly"]
-	path = extensions/assembly
-	url = https://github.com/DevBlocky/zed-asm.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,6 @@
 [submodule "extensions/vscode-monokai-charcoal"]
 	path = extensions/vscode-monokai-charcoal
 	url = git@github.com:d1y/vscode-monokaicharcoal.zed.git
+[submodule "extensions/assembly"]
+	path = extensions/assembly
+	url = https://github.com/DevBlocky/zed-asm.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[assembly]
+path = "extensions/assembly"
+version = "0.0.1"
+
 [beancount]
 path = "extensions/beancount"
 version = "0.0.1"


### PR DESCRIPTION
Adds some basic syntax highlighting for assembly files (`.asm`, `.s`, `.S`)

Example:
<img width="647" alt="image" src="https://github.com/zed-industries/extensions/assets/16978528/7afd9739-373e-4952-99f6-f5fd7c6449ee">