### PR TITLE
Add local extension generation CLI

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+import * as p from "@clack/prompts";
+// import color from 'picocolors';
+import { exec, execFile } from "node:child_process";
+
+/**
+ * @param {"docker" | "node"} toolName
+ */
+async function getToolsVersion(toolName) {
+  return new Promise((resolve, reject) => {
+    exec(`${toolName} --version`, (err, stdout, stderr) => {
+      if (err) {
+        resolve(false);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+}
+
+async function doctor() {
+  let status = {
+    isDocker: false,
+    isNode: false,
+  };
+
+  status.isDocker = await getToolsVersion("docker");
+  status.isNode = await getToolsVersion("node");
+
+  return status;
+}
+
+const s = p.spinner();
+
+async function main() {
+  console.clear();
+
+  p.intro("Let's add a new extension to Zed!");
+
+  s.start("Checking for tools");
+
+  const { isDocker, isNode } = await doctor();
+
+  if (!isDocker) {
+    // p.log("Docker is not installed");
+    s.stop("Docker is not installed", 1);
+    process.exit(1);
+  } else {
+    p.log.success("Docker is installed");
+    // TODO: check if docker is running
+    // exec("docker ps", (err, stdout, stderr) => {
+    //  if (err) {
+    //   console.error("Docker is not running", stdout, stderr);
+    //  } else {
+    //    console.log("Docker is running", stdout, stderr);
+    //  }
+    // });
+  }
+
+  if (!isNode) {
+    s.stop("Node is not installed", 1);
+    process.exit(1);
+  } else {
+    p.log.success("Node is installed");
+  }
+
+  s.stop("All tools are installed", 0);
+
+  const project = await p.group(
+    {
+      language: () =>
+        p.text({
+          message: "What language is the grammar written for?",
+          placeholder: "javascript",
+          validate: (value) => {
+            if (!value) return "Please enter a language.";
+          },
+        }),
+      grammarPath: () =>
+        p.text({
+          message: "Where is the grammar located?",
+          placeholder: "../../relative-path/to/grammar.js",
+          validate: (value) => {
+            if (!value) return "Please enter a path.";
+            if (value[0] !== ".") return "Please enter a relative path.";
+          },
+        }),
+      install: () =>
+        p.confirm({
+          message: "Do you want to install the extension?",
+          initialValue: true,
+        }),
+    },
+    {
+      onCancel: () => {
+        p.cancel("Operation cancelled.");
+        process.exit(0);
+      },
+    },
+  );
+
+  s.start("Generating WASM file");
+
+  await new Promise((resolve, reject) => {
+    execFile(
+      "tree-sitter",
+      ["build-wasm"],
+      { cwd: project.grammarPath },
+      (err, stdout, stderr) => {
+        if (err) {
+          s.stop("Error generating WASM file", 1);
+          reject();
+        } else {
+          s.stop("WASM file generated", 0);
+          resolve();
+        }
+      },
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    exec(
+      `mv ${project.grammarPath}/tree-sitter-${project.language}.wasm ../extensions/${project.language}/grammars/`,
+      (err, stdout, stderr) => {
+        if (err) {
+          s.stop("Error moving WASM file", 1);
+          reject();
+        } else {
+          s.stop("WASM file moved", 0);
+          resolve();
+        }
+      },
+    );
+  });
+
+  if (project.install) {
+    s.start("Installing extension");
+    await new Promise((resolve, reject) => {
+      exec(
+        `cp -R ../extensions/pkl "${process.env.HOME}/Library/Application\ Support/Zed/extensions/installed/pkl"`,
+        (err, stdout, stderr) => {
+          if (err) {
+            s.stop("Error installing extension", 1);
+            reject();
+          } else {
+            s.stop("Extension installed", 0);
+            resolve();
+          }
+        },
+      );
+    });
+  }
+
+  p.outro(
+    `You can now use the ${project.language} grammar in Zed by opening a file with the .${project.language} extension.`,
+  );
+}
+
+main().catch(console.error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "zed-extensions",
+  "name": "extensions",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
         "@aws-sdk/client-s3": "3.454.0",
+        "@clack/prompts": "^0.7.0",
         "ajv": "^8.12.0",
         "toml": "3.0.0",
         "tree-sitter-cli": "0.21.0-pre-release-1"
@@ -766,6 +767,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.3.3.tgz",
+      "integrity": "sha512-5ZGyb75BUBjlll6eOa1m/IZBxwk91dooBWhPSL67sWcLS0zt9SnswRL0l26TVdBhb0wnWORRxUn//uH6n4z7+A==",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.7.0.tgz",
+      "integrity": "sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==",
+      "bundleDependencies": [
+        "is-unicode-supported"
+      ],
+      "dependencies": {
+        "@clack/core": "^0.3.3",
+        "is-unicode-supported": "*",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@smithy/abort-controller": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
@@ -1436,6 +1471,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1451,6 +1491,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/strnum": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "type": "module",
   "dependencies": {
     "@aws-sdk/client-s3": "3.454.0",
+    "@clack/prompts": "^0.7.0",
     "ajv": "^8.12.0",
     "toml": "3.0.0",
     "tree-sitter-cli": "0.21.0-pre-release-1"


### PR DESCRIPTION
# Local Extension Management/Installation CLI POC

## What is this?

I've been playing around with Zed extensions a bit more, trying to figure out how to make the process of developing and testing the extensions less frictional. What I've come up with is a simple CLI tool that can be run to both generate grammars and install extensions from a local directory.

## More words

I've cobbled together a quick CLI application that can ask for a few inputs like the name of the extension and the path to the extension grammar, and then generate the WASM grammar file for you, currently moving it to the extension directory inside extensioins.It will also ask you if you want to install the extension, and if you say yes, it will move the extension to the Zed extensions directory.

## How to use

1. Clone this repo
2. Run `npm install`.
3. `cd cli && node index.js` _(it is important to run it from the cli directory as it uses relative paths to the extension directory)_.
4. Follow the prompts.
5. If you choose to install the extension, it will be moved to the Zed extensions directory and you can start using it in Zed.

https://github.com/zed-industries/extensions/assets/16290753/ae71e2ff-cf51-4dad-a991-549aa728225f

## Current limitations

As I said, this is the most barebones POC because I'm not sure if this is the right direction to go in and I didn't want to spend too much time on it if it wasn't.

- The script uses relative paths, so it needs to be run from the `cli` directory. I just wanted to get it working at this point.
- Local extensions don't currently work as described in [this Discord message] (https://discord.com/channels/869392257814519848/873293828805771284/1208811412168638584).
- The tooling check is barebones and there to demonstrate the idea of checking for the required tools before running the script.
- The CLI flow is crude and could be improved.

The ideal way would be to refactor the already existing `package-extensions' file to export the existing functions to run during CLI execution. I have decided not to do this for this POC.

## End notes

Let me know if you have any thoughts on this.

This may eliminate the need for additional installation steps and make it easier to develop and test extensions locally. The CLI can be published to npm and used by anyone who wants to develop extensions for Zed by running `npx zed-extension-cli` or something similar.
