### PR TITLE
Add srcery theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
+[submodule "extensions/srcery"]
+	path = extensions/srcery
+	url = https://github.com/srcery-colors/srcery-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -97,3 +97,7 @@ version = "0.0.1"
 [zedspace]
 path = "extensions/zedspace"
 version = "0.0.1"
+
+[srcery]
+path = "extensions/srcery"
+version = "0.0.1"


### PR DESCRIPTION
This adds [the Srcery theme](https://srcery.sh/) for Zed, created by importing the srcery theme for vscode.

![Screenshot 2024-02-20 at 09 11 46@2x](https://github.com/zed-industries/extensions/assets/38924/ed86729f-0374-47d6-8433-7c79fb8e231c)

