### PR TITLE
catppuccin theme: point to org-managed repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	url = https://github.com/JosephTLyons/zed-brainfuck
 [submodule "extensions/catppuccin"]
 	path = extensions/catppuccin
-	url = https://github.com/ssaunderss/zed-catppuccin
+	url = https://github.com/catppuccin/zed
 [submodule "extensions/dockerfile"]
 	path = extensions/dockerfile
 	url = git@github.com:d1y/dockerfile.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -16,7 +16,7 @@ version = "0.0.1"
 
 [catppuccin]
 path = "extensions/catppuccin"
-version = "0.0.2"
+version = "0.0.1"
 
 [dockerfile]
 path = "extensions/dockerfile"


### PR DESCRIPTION
point the current Catppuccin Themes extensions to the org-managed repository. 

- includes correct coloring and visual bug fixes