### PR TITLE
Bump base16 to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 
 [base16]
 path = "extensions/base16"
-version = "0.0.2"
+version = "0.0.3"
 
 [beancount]
 path = "extensions/beancount"


### PR DESCRIPTION
This commit bumps the base16 theme to `v0.0.3`, which adds specific colors for:

- The background of tabs when they are being dragged
- The heading of search results
- Predictive text