### PR TITLE
macos-classic 0.0.5-beta1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -76,7 +76,7 @@ version = "0.0.2"
 
 [macos-classic]
 path = "extensions/macos-classic"
-version = "0.0.4"
+version = "0.0.5-beta1"
 
 [mau]
 path = "extensions/mau"


### PR DESCRIPTION
Release notes:

https://github.com/huacnlee/zed-theme-macos-classic/releases/tag/v0.0.5-beta1

> Created by [zed-extension-action](https://github.com/huacnlee/zed-extension-action).