### PR TITLE
Add caius/zed-make for Makefile support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -151,3 +151,6 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
+[submodule "extensions/make"]
+	path = extensions/make
+	url = https://github.com/caius/zed-make.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -78,6 +78,10 @@ version = "0.0.2"
 path = "extensions/macos-classic"
 version = "0.0.4"
 
+[make]
+path = "extensions/make"
+version = "0.0.1"
+
 [mau]
 path = "extensions/mau"
 version = "0.0.1"


### PR DESCRIPTION
Initial attempt, allows `Makefile` language to show up and hard tabs be configured in the settings to make editing the files easier. Doesn't contain any syntax highlighting yet as I can't get a valid `highlights.scm` file in place so far.

Haven't looked if the language toml or extension toml can set hard tabs or tab width settings, it's just in the readme for now for people to add to their Zed settings by hand.

This is extracted from https://github.com/zed-industries/zed/pull/7402 as that didn't land before Extensions came into the world 😻 