### PR TITLE
Type-check packaging script using TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   },
   "scripts": {
     "fmt": "prettier --write .",
+    "build": "tsc -p .",
     "package-extensions": "node src/package-extensions.js"
   },
   "dependencies": {
@@ -15,6 +16,9 @@
     "tree-sitter-cli": "0.21.0-pre-release-1"
   },
   "devDependencies": {
-    "prettier": "3.2.5"
+    "@tsconfig/node20": "20.1.2",
+    "@tsconfig/strictest": "2.0.3",
+    "prettier": "3.2.5",
+    "typescript": "5.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,18 @@ dependencies:
     version: 0.21.0-pre-release-1
 
 devDependencies:
+  '@tsconfig/node20':
+    specifier: 20.1.2
+    version: 20.1.2
+  '@tsconfig/strictest':
+    specifier: 2.0.3
+    version: 2.0.3
   prettier:
     specifier: 3.2.5
     version: 3.2.5
+  typescript:
+    specifier: 5.3.3
+    version: 5.3.3
 
 packages:
 
@@ -1051,6 +1060,14 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /@tsconfig/node20@20.1.2:
+    resolution: {integrity: sha512-madaWq2k+LYMEhmcp0fs+OGaLFk0OenpHa4gmI4VEmCKX4PJntQ6fnnGADVFrVkBj0wIdAlQnK/MrlYTHsa1gQ==}
+    dev: true
+
+  /@tsconfig/strictest@2.0.3:
+    resolution: {integrity: sha512-MroLvRhMbqtXI5WBSwoomro6OQS4xnCoudUrMb20JO0vLKUs0bAaCEcvM/immEBSJjFAK1l6jW1oAO8q3Ancrg==}
+    dev: true
+
   /ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
     dependencies:
@@ -1121,6 +1138,12 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: false
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -483,7 +483,7 @@ async function changedExtensionIds(extensionsToml) {
  */
 async function checkoutGitRepo(name, repositoryUrl, commitSha) {
   const repoPath = await fs.mkdtemp(
-    path.join("build", `${name} - ${commitSha}.repo`),
+    path.join("build", `${name}-${commitSha}.repo`),
   );
   const processOptions = {
     cwd: repoPath,

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -248,7 +248,6 @@ async function packageExtension(
           config.repository,
           config.commit,
         );
-
         grammarRepoPaths[grammarRepoKey] = grammarRepoPath;
       }
 
@@ -416,7 +415,7 @@ function validateTheme(theme) {
 async function getPublishedVersionsByExtensionId() {
   const bucketList = await s3.listObjects({
     Bucket: S3_BUCKET,
-    Prefix: `${EXTENSIONS_PREFIX} / `,
+    Prefix: `${EXTENSIONS_PREFIX}/`,
   });
 
   /** @type {Record<string, string[]>} */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": [
+    "@tsconfig/node20/tsconfig.json",
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "checkJs": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["src/"]
+}


### PR DESCRIPTION
This PR sets up the packaging script to be type-checked using TypeScript.

Note that the files themselves are still 100% plain JS, so no transpilation step is needed. This is solely so we can get some more type safety in the code.