### PR TITLE
Use `dir` instead of `root` in Vitest config

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    root: "src/",
+    dir: "src/",
   },
 });


### PR DESCRIPTION
This PR changes the Vitest config to use `root` instead of `dir` to locate the right test files.

`dir` is what we want, as we just want to change where we're looking for tests, not what Vitest thinks is the root directory.