### PR TITLE
Only checkout submodules of extensions that need publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           clean: false
-          submodules: "recursive"
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v3

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -105,6 +105,8 @@ try {
       `Packaging '${extensionId}'. Version: ${extensionInfo.version}`,
     );
 
+    await checkoutGitSubmodule(extensionInfo.path);
+
     await packageExtension(
       extensionId,
       extensionInfo.path,
@@ -372,6 +374,11 @@ async function changedExtensionIds(extensionsToml) {
 
   console.log("Extensions changed from main:", result.join(", "));
   return result;
+}
+
+/** @param {string} path */
+async function checkoutGitSubmodule(path) {
+  await exec("git", ["submodule", "update", path]);
 }
 
 /**


### PR DESCRIPTION
This PR changes the packaging script to only checkout the submodules for extensions that need publishing.

This should make CI run faster, as we don't need to checkout all of the submodules up front.