### PR TITLE
[One Hunter] Bump to 0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -144,7 +144,7 @@ version = "0.0.2"
 
 [one-hunter]
 path = "extensions/one-hunter"
-version = "0.0.1"
+version = "0.0.3"
 
 [pact]
 path = "extensions/pact"


### PR DESCRIPTION
Release notes: Added DEVELOPMENT.md, LICENSE and github action to repo

https://github.com/teziovsky/zed-one-hunter-theme/releases/tag/v0.0.3

> Created by [zed-extension-action](https://github.com/huacnlee/zed-extension-action).