### PR TITLE
New One Dark Pro Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -152,7 +152,7 @@
 
 [submodule "extensions/one-dark-pro"]
 	path = extensions/one-dark-pro
-	url = git@github.com:MordFustang21/zed-one-dark-pro.git
+	url = git@github.com:EvanZhouDev/zed-one-dark-pro.git
 
 [submodule "extensions/one-hunter"]
 	path = extensions/one-hunter

--- a/extensions.toml
+++ b/extensions.toml
@@ -152,7 +152,7 @@ version = "0.0.1"
 
 [one-dark-pro]
 path = "extensions/one-dark-pro"
-version = "0.0.2"
+version = "0.0.1"
 
 [one-hunter]
 path = "extensions/one-hunter"


### PR DESCRIPTION
I have completely redesigned the One Dark Pro theme, starting from Zed's original One Dark theme's JSON.
No theme porter was used, and each value was manually adjusted to integrate the One Dark Pro theme from VSCode into Zed. It was created to maintain the modern background of Zed but with the beautiful, contrasting syntax theme from the VSCode One Dark Pro theme.

Here's what it looks like.

<img width="836" alt="one-dark-pro-demo" src="https://github.com/zed-industries/extensions/assets/62189478/b9605118-25c8-4907-894e-5735dfe63426">

This theme has already been created by @MordFustang21. However, when it was ported using the Theme Porter, some issues remained despite its wonderful design.

I started my current implementation off, as mentioned, Zed's own One Dark, instead of @MordFustang21's, and thus I have created a new Extension repo, instead of simply contributing to his.

If @MordFustang21 would like me to create a new extension instead of overriding his, I would be glad to, but I believe that this extension has been more adapted for VSCode One Dark Pro users. I will also be glad to maintain this in the future.