### PR TITLE
Add base16-zed extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -253,3 +253,6 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
+[submodule "extensions/base16-zed"]
+	path = extensions/base16-zed
+	url = git@github.com:timcki/base16-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -6,6 +6,10 @@ version = "0.0.1"
 path = "extensions/base16"
 version = "0.0.4"
 
+[base16-zed]
+path = "extensions/base16-zed"
+version = "0.0.1"
+
 [beancount]
 path = "extensions/beancount"
 version = "0.0.1"


### PR DESCRIPTION
The existing base16 extension is limited to 2 themes and lacks the ability to add new themes using a template. This PR adds support for all standard base16 themes and a template to allow for adding new ones.