### PR TITLE
Smooth Theme: Bump version to 1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -184,7 +184,7 @@ version = "0.0.1"
 
 [smooth]
 path = "extensions/smooth"
-version = "0.0.1"
+version = "1.0.0"
 
 [solarized-fp]
 path = "extensions/solarized-fp"


### PR DESCRIPTION
### Changed
- Bumped version to `1.0.0`
- Adjusted error background color from `null` to `#d19a66` which fixes https://github.com/zed-industries/zed/issues/8254

![image](https://github.com/zed-industries/extensions/assets/10974647/383038c9-e465-49c7-b6b8-5cb484eb2848)
