### PR TITLE
reservation for xcode-file-icons extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,10 @@
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl
 
+[submodule "extensions/xcode-file-icons"]
+	path = extensions/xcode-file-icons
+	url = https://github.com/evrsen/zed-xcode-file-icons
+
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes
 	url = https://github.com/skarline/zed-xcode-themes

--- a/extensions.toml
+++ b/extensions.toml
@@ -238,6 +238,10 @@ version = "0.0.1"
 path = "extensions/wgsl"
 version = "0.0.1"
 
+[xcode-file-icons]
+path = "extensions/xcode-file-icons"
+version = "0.0.1"
+
 [xcode-themes]
 path = "extensions/xcode-themes"
 version = "1.1.1"


### PR DESCRIPTION
This PR is for reserving a Xcode File Icons extension for Zed when https://github.com/zed-industries/zed/issues/8843 is stabilized.