### PR TITLE
Add Material Dark Theme Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,6 +98,10 @@
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
 
+[submodule "extensions/material-dark"]
+	path = extensions/material-dark
+	url = https://github.com/xerodark/zed-material-theme.git
+
 [submodule "extensions/mau"]
 	path = extensions/mau
 	url = https://github.com/mauscoelho/zed-mau-themes

--- a/.gitmodules
+++ b/.gitmodules
@@ -253,6 +253,3 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
-[submodule "extensions/material-dark-theme"]
-	path = extensions/material-dark-theme
-	url = https://github.com/xerodark/zed-material-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -253,3 +253,6 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
+[submodule "extensions/material-dark-theme"]
+	path = extensions/material-dark-theme
+	url = https://github.com/xerodark/zed-material-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -255,5 +255,5 @@ path = "extensions/zedspace"
 version = "0.0.1"
 
 [material-dark]
-path = "extensions/material-dark-theme"
+path = "extensions/material-dark"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -253,3 +253,7 @@ version = "1.0.0"
 [zedspace]
 path = "extensions/zedspace"
 version = "0.0.1"
+
+[material-dark]
+path = "extensions/material-dark"
+version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -255,5 +255,5 @@ path = "extensions/zedspace"
 version = "0.0.1"
 
 [material-dark]
-path = "extensions/material-dark"
+path = "extensions/material-dark-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -98,6 +98,10 @@ version = "0.0.4"
 path = "extensions/make"
 version = "0.0.1"
 
+[material-dark]
+path = "extensions/material-dark"
+version = "0.0.1"
+
 [mau]
 path = "extensions/mau"
 version = "0.0.1"
@@ -252,8 +256,4 @@ version = "1.0.0"
 
 [zedspace]
 path = "extensions/zedspace"
-version = "0.0.1"
-
-[material-dark]
-path = "extensions/material-dark"
 version = "0.0.1"


### PR DESCRIPTION
## Add Material Dark Theme Extension

### Description
This pull request introduces the "Material Dark" theme to the Zed IDE, offering a sleek and modern dark theme that aligns with the Material Design guidelines. The theme is designed to provide a visually appealing and comfortable development environment, especially for developers who prefer dark mode for extended coding sessions.

### Changes
- Added the Material Dark theme as a submodule in the `extensions/material-dark-theme` directory.
- Updated the `extensions.toml` file to include the new Material Dark theme with the following entry:
  ```toml
  [material-dark-theme]
      path = "extensions/my-material-dark-theme"
      version = "1.0.0"
  ```
### Testing
The theme has been tested locally within the Zed IDE to ensure compatibility and a consistent user experience across various file types and programming languages. It adheres to the JSON schema specified at [https://zed.dev/schema/themes/v0.1.0.json](https://zed.dev/schema/themes/v0.1.0.json), ensuring that all theme aspects are correctly applied within the IDE.

### Screenshots
<img width="450" alt="image" src="https://github.com/zed-industries/extensions/assets/162190967/b4682c03-9905-46ff-bde1-5b3e2dd5578e">
<img width="450" alt="image" src="https://github.com/zed-industries/extensions/assets/162190967/3d90821d-c759-48e1-be93-f1aca9caf223">


### Additional Notes
The Material Dark theme aims to enhance the Zed IDE's visual environment while maintaining readability and reducing eye strain during nighttime coding sessions. It's inspired by the principles of Material Design, focusing on usability and aesthetics.

I look forward to any feedback or suggestions for improvement. Thank you for considering this addition to the Zed IDE extensions registry and I'm excited to see how this IDE continues to develop.