### PR TITLE
Add git-firefly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,6 +54,10 @@
 	path = extensions/gdscript
 	url = https://github.com/grndctrl/zed-gdscript
 
+[submodule "extensions/git-firefly"]
+	path = extensions/git-firefly
+	url = git@github.com:d1y/git_firefly.git
+
 [submodule "extensions/github-dark-default"]
 	path = extensions/github-dark-default
 	url = git@github.com:MordFustang21/zed-github-dark.git
@@ -265,6 +269,3 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
-[submodule "extensions/git-firefly"]
-	path = extensions/git-firefly
-	url = git@github.com:d1y/git_firefly.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -265,3 +265,6 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = git@github.com:Brunowilliang/zedspace.git
+[submodule "extensions/git-firefly"]
+	path = extensions/git-firefly
+	url = git@github.com:d1y/git_firefly.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -54,6 +54,10 @@ version = "1.0.0"
 path = "extensions/gdscript"
 version = "0.0.2"
 
+[git-firefly]
+path = "extensions/git-firefly"
+version = "0.0.1"
+
 [github-dark-default]
 path = "extensions/github-dark-default"
 version = "0.0.1"


### PR DESCRIPTION
Prev: [#7048](https://github.com/zed-industries/zed/issues/7048), Let's roll git highlighting back into the extension

> Because tree-sitter-gitcommit slows down the compilation of zed 😅 (https://github.com/zed-industries/zed/pull/7147#issuecomment-1937722323 / https://github.com/zed-industries/zed/issues/7048#issuecomment-1979620553)

Support syntax highlighting 

- git_commit
- git_config
- git_rebase
- git_diff(.diff)
- gitignore
- gitattributes

cc @williamdes @SomeoneToIgnore