### PR TITLE
Disallow "Zed" at the end of extension names and IDs

### DIFF
--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -12,6 +12,13 @@ const languageConfigValidator = ajv.compile(
 );
 
 /**
+ * Exceptions to the rule of extension IDs ending in `-zed`.
+ *
+ * Only to be edited by Zed staff.
+ */
+const EXTENSION_ID_ENDS_WITH_EXCEPTIONS = ["xy-zed"];
+
+/**
  * @param {Record<string, any>} extensionsToml
  */
 export function validateExtensionsToml(extensionsToml) {
@@ -22,7 +29,10 @@ export function validateExtensionsToml(extensionsToml) {
       );
     }
 
-    if (extensionId.endsWith("-zed")) {
+    if (
+      extensionId.endsWith("-zed") &&
+      !EXTENSION_ID_ENDS_WITH_EXCEPTIONS.includes(extensionId)
+    ) {
       throw new Error(
         `Extension IDs should not end with "-zed", as they are all Zed extensions: "${extensionId}".`,
       );

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -21,6 +21,12 @@ export function validateExtensionsToml(extensionsToml) {
         `Extension IDs should not start with "zed-", as they are all Zed extensions: "${extensionId}".`,
       );
     }
+
+    if (extensionId.endsWith("-zed")) {
+      throw new Error(
+        `Extension IDs should not end with "-zed", as they are all Zed extensions: "${extensionId}".`,
+      );
+    }
   }
 }
 
@@ -31,6 +37,12 @@ export function validateManifest(manifest) {
   if (manifest["name"].startsWith("Zed ")) {
     throw new Error(
       `Extension names should not start with "Zed ", as they are all Zed extensions: "${manifest["name"]}".`,
+    );
+  }
+
+  if (manifest["name"].endsWith(" Zed")) {
+    throw new Error(
+      `Extension names should not end with " Zed", as they are all Zed extensions: "${manifest["name"]}".`,
     );
   }
 }


### PR DESCRIPTION
This PR updates the validation rules to disallow "Zed" at the end of extension names and IDs, just like at the start.