### PR TITLE
update git-firefly

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -56,7 +56,7 @@ version = "0.0.2"
 
 [git-firefly]
 path = "extensions/git-firefly"
-version = "0.0.1"
+version = "0.0.2"
 
 [github-dark-default]
 path = "extensions/github-dark-default"


### PR DESCRIPTION
Fix git_commit inject failed

```log
❯ /Applications/Zed\ Preview.app/Contents/MacOS/zed
[2024-03-08T04:15:14+08:00 ERROR language::language_registry] failed to load language Git Commit:
Error loading injection query

Caused by:
    Query error at 12:3. Invalid node type raw_text
```