### PR TITLE
Bump GraphQL extension to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -76,7 +76,7 @@ version = "0.1.0"
 
 [graphql]
 path = "extensions/graphql"
-version = "0.0.1"
+version = "0.0.2"
 
 [horizon]
 path = "extensions/horizon"


### PR DESCRIPTION
Bump GraphQL extension to v0.0.2

[Release notes](https://github.com/11bit/zed-extension-graphql/blob/main/CHANGELOG.md#002--2024-12-04)