### PR TITLE
Run `pnpm build` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm build
+
       - name: Run tests
         run: pnpm test
 


### PR DESCRIPTION
This PR makes it so `pnpm build` gets run in CI, to catch type errors in the scripts.