### PR TITLE
Validate `.gitmodules` to prevent non-HTTPS URLs

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -35,10 +35,15 @@ export async function checkoutGitRepo(name, repositoryUrl, commitSha) {
 }
 
 /** @param {string} path */
-export async function sortGitmodules(path) {
+export async function readGitmodules(path) {
   const gitmodulesContent = await fs.readFile(path, "utf-8");
 
-  const gitmodules = gitSubmodules.deserialize(gitmodulesContent);
+  return gitSubmodules.deserialize(gitmodulesContent);
+}
+
+/** @param {string} path */
+export async function sortGitmodules(path) {
+  const gitmodules = await readGitmodules(path);
 
   const submoduleNames = Object.keys(gitmodules);
   submoduleNames.sort();

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -43,3 +43,19 @@ export function validateManifest(manifest) {
     );
   }
 }
+
+/**
+ * @param {import('git-submodule-js').Submodule} gitmodules
+ */
+export function validateGitmodules(gitmodules) {
+  for (const [name, entry] of Object.entries(gitmodules)) {
+    const url = entry["url"];
+    if (!url) {
+      throw new Error(`Missing URL for "${name}".`);
+    }
+
+    if (!url.startsWith("https://")) {
+      throw new Error(`Submodules must use "https://" scheme.`);
+    }
+  }
+}

--- a/src/lib/validation.test.js
+++ b/src/lib/validation.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { validateManifest } from "./validation.js";
+import { validateGitmodules, validateManifest } from "./validation.js";
 
 describe("validateManifest", () => {
   describe("given a valid manifest", () => {
@@ -22,6 +22,25 @@ describe("validateManifest", () => {
         validateManifest({ name: "Zed Something" }),
       ).toThrowErrorMatchingInlineSnapshot(
         `[Error: Extension names should not start with "Zed ", as they are all Zed extensions: "Zed Something".]`,
+      );
+    });
+  });
+});
+
+describe("validateGitmodules", () => {
+  describe("when an entry contains a non-HTTPS URL", () => {
+    it("throws a validation error", () => {
+      const gitmodules = {
+        "extensions/my-extension": {
+          path: "extensions/my-extension",
+          url: "git@github.com:me/my-extension.git",
+        },
+      };
+
+      expect(() =>
+        validateGitmodules(gitmodules),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Submodules must use "https://" scheme.]`,
       );
     });
   });

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -4,9 +4,17 @@ import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { readTomlFile } from "./lib/fs.js";
-import { checkoutGitSubmodule, sortGitmodules } from "./lib/git.js";
+import {
+  checkoutGitSubmodule,
+  readGitmodules,
+  sortGitmodules,
+} from "./lib/git.js";
 import { exec } from "./lib/process.js";
-import { validateExtensionsToml, validateManifest } from "./lib/validation.js";
+import {
+  validateExtensionsToml,
+  validateGitmodules,
+  validateManifest,
+} from "./lib/validation.js";
 
 const {
   S3_ACCESS_KEY,
@@ -74,6 +82,7 @@ const extensionsToml = await readTomlFile("extensions.toml");
 await fs.mkdir("build", { recursive: true });
 try {
   validateExtensionsToml(extensionsToml);
+  validateGitmodules(await readGitmodules(".gitmodules"));
 
   await sortExtensionsToml("extensions.toml");
   await sortGitmodules(".gitmodules");


### PR DESCRIPTION
This PR adds some validation for `.gitmodules` to prevent non-HTTPS submodule URLs.

Cloning down submodules that don't use HTTPS is a hassle in CI, so we want to enforce this.