### PR TITLE
Add Svelte, Gleam, and Uiua extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           wget --quiet "https://zed-extension-cli.nyc3.digitaloceanspaces.com/$ZED_EXTENSION_CLI_SHA/x86_64-unknown-linux-gnu/zed-extension"
           chmod +x zed-extension
         env:
-          ZED_EXTENSION_CLI_SHA: adcb591629cbcbd5e75fdaf775de267f64eff064
+          ZED_EXTENSION_CLI_SHA: 6ebe599c980508aa8c7e87fad3e59e5a43892368
 
       - name: Install dependencies
         run: pnpm install
@@ -44,6 +44,12 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Cache extension build binaries
+        uses: actions/cache@v3
+        with:
+          path: |
+            ./scratch
 
       - name: Package extensions
         run: pnpm package-extensions

--- a/.gitmodules
+++ b/.gitmodules
@@ -294,6 +294,10 @@
 	path = extensions/xy-zed
 	url = https://github.com/zarifpour/xy-zed.git
 
+[submodule "extensions/zed"]
+	path = extensions/zed
+	url = https://github.com/zed-industries/zed
+
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai
 	url = https://github.com/slymax/zedokai.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -78,6 +78,10 @@ version = "0.0.1"
 path = "extensions/github-theme"
 version = "0.0.2"
 
+[gleam]
+path = "extensions/zed/extensions/gleam"
+version = "0.0.1"
+
 [graphene]
 path = "extensions/graphene"
 version = "0.1.0"
@@ -246,6 +250,10 @@ version = "0.0.2"
 path = "extensions/srcery"
 version = "0.0.2"
 
+[svelte]
+path = "extensions/zed/extensions/svelte"
+version = "0.0.1"
+
 [swift]
 path = "extensions/swift"
 version = "0.1.0"
@@ -265,6 +273,10 @@ version = "0.2.4"
 [tokyo-night]
 path = "extensions/tokyo-night"
 version = "0.0.2"
+
+[uiua]
+path = "extensions/zed/extensions/uiua"
+version = "0.0.1"
 
 [ultimate-dark-neo]
 path = "extensions/ultimate-dark-neo"

--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -7,7 +7,7 @@ import { exec } from "./process.js";
 export async function checkoutGitSubmodule(path) {
   console.log(`Checking out Git submodule at '${path}'`);
 
-  await exec("git", ["submodule", "update", "--init", path]);
+  await exec("git", ["submodule", "update", "--init", "--depth", "1", path]);
 }
 
 /**

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -81,8 +81,10 @@ const extensionsToml = await readTomlFile("extensions.toml");
 // been packaged.
 await fs.mkdir("build", { recursive: true });
 try {
+  const gitModules = await readGitmodules(".gitmodules");
+
   validateExtensionsToml(extensionsToml);
-  validateGitmodules(await readGitmodules(".gitmodules"));
+  validateGitmodules(gitModules);
 
   await sortExtensionsToml("extensions.toml");
   await sortGitmodules(".gitmodules");
@@ -101,7 +103,11 @@ try {
       `Packaging '${extensionId}'. Version: ${extensionInfo.version}`,
     );
 
-    await checkoutGitSubmodule(extensionInfo.path);
+    const submodulePath = Object.keys(gitModules).find((key) =>
+      extensionInfo.path.startsWith(key),
+    );
+    assert(submodulePath, `no submodule for extension ${extensionId}`);
+    await checkoutGitSubmodule(submodulePath);
 
     await packageExtension(
       extensionId,


### PR DESCRIPTION
These extensions are currently included in the Zed repo. Because they use a newer version of the Zed extension schema, they will not be shown in the extension view for Zed versions < 0.129.