### PR TITLE
Add Paraíso theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -198,6 +198,10 @@
 	path = extensions/pact
 	url = https://github.com/kadena-community/pact-zed.git
 
+[submodule "extensions/paraiso"]
+	path = extensions/paraiso
+	url = git@github.com:treffynnon/zed-Paraiso.git
+
 [submodule "extensions/penumbra"]
 	path = extensions/penumbra
 	url = https://github.com/jbisits/penumbra-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -216,7 +216,7 @@
 
 [submodule "extensions/paraiso"]
 	path = extensions/paraiso
-	url = git@github.com:treffynnon/zed-Paraiso.git
+	url = https://github.com/treffynnon/zed-Paraiso.git
 
 [submodule "extensions/penumbra"]
 	path = extensions/penumbra

--- a/extensions.toml
+++ b/extensions.toml
@@ -202,6 +202,10 @@ version = "0.0.2"
 path = "extensions/pact"
 version = "0.0.1"
 
+[paraiso]
+path = "extensions/paraiso"
+version = "1.0.0"
+
 [penumbra]
 path = "extensions/penumbra"
 version = "0.0.1"


### PR DESCRIPTION
# Paraíso theme for the Zed editor

This theme is adapted to Zed from the [VS Code theme of the same name][vscode-theme], which in turn is based on the [TextMate theme][tm-theme] of the same name.

[vscode-theme]: https://github.com/treffynnon/paraiso-dark-vscode-theme "Paraíso VS Code theme"
[tm-theme]: https://github.com/idleberg/Paraiso.tmTheme "Paraíso TextMate theme"

## Screenshot

![Paraiso_dark](https://raw.githubusercontent.com/treffynnon/zed-Paraiso/main/assets/Paraiso_dark.webp)

## Licence

Licenced under the [Creative Commons Attribution-ShareAlike 3.0 Unported][licence] licence.

## Attribution

```
    Name:    Paraíso (dark)
    Author:  Jan T. Sott
    License: Creative Commons Attribution-ShareAlike 3.0 Unported License
    URL:     https://github.com/idleberg/Paraiso.tmTheme

    Inspired by the art of Rubens LP (http://www.rubenslp.com.br)
    Base16 template for TextMate by Chris Kempson (https://github.com/chriskempson)
```

[licence]: https://creativecommons.org/licences/by-sa/3.0/legalcode "Creative Commons Attribution-ShareAlike 3.0 Unported Licence"
