### PR TITLE
Update Paraíso to extension.toml format

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -228,7 +228,7 @@ version = "0.0.1"
 
 [paraiso]
 path = "extensions/paraiso"
-version = "1.0.0"
+version = "1.0.1"
 
 [penumbra]
 path = "extensions/penumbra"


### PR DESCRIPTION
Updates the extension to use the [freshly documented](https://github.com/zed-industries/extensions/commit/6ab7d4253b6de77025a586e6afc808f668098eac) extension.toml format instead of extension.json.