### PR TITLE
Add Haskell extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -106,6 +106,10 @@ version = "0.1.0"
 path = "extensions/graphql"
 version = "0.0.2"
 
+[haskell]
+path = "extensions/zed/extensions/haskell"
+version = "0.0.1"
+
 [horizon]
 path = "extensions/horizon"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Haskell extension.

Haskell support was extracted from Zed in https://github.com/zed-industries/zed/pull/9814.