### PR TITLE
Add Prisma extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -250,6 +250,10 @@ version = "0.0.1"
 path = "extensions/poimandres"
 version = "0.0.1"
 
+[prisma]
+path = "extensions/zed/extensions/prisma"
+version = "0.0.1"
+
 [r]
 path = "extensions/r"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Prisma extension.

Prisma support was extracted from Zed in https://github.com/zed-industries/zed/pull/9820.