### PR TITLE
Add PureScript extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -254,6 +254,10 @@ version = "0.0.1"
 path = "extensions/zed/extensions/prisma"
 version = "0.0.1"
 
+[purescript]
+path = "extensions/zed/extensions/purescript"
+version = "0.0.1"
+
 [r]
 path = "extensions/r"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the PureScript extension.

PureScript support was extracted from Zed in https://github.com/zed-industries/zed/pull/9824.