### PR TITLE
Add Astro extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -6,6 +6,10 @@ version = "0.0.1"
 path = "extensions/assembly"
 version = "0.0.1"
 
+[astro]
+path = "extensions/zed/extensions/astro"
+version = "0.0.1"
+
 [base16]
 path = "extensions/base16"
 version = "0.0.4"


### PR DESCRIPTION
This PR adds the Astro extension.

PureScript support was extracted from Zed in https://github.com/zed-industries/zed/pull/9835.