### PR TITLE
Update Gleam to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -102,7 +102,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.0.1"
+version = "0.0.2"
 
 [graphene]
 submodule = "extensions/graphene"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.0.2.

This version of the extension will now respect any `gleam` binary on the PATH.