### PR TITLE
Add Zig extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -376,3 +376,8 @@ version = "1.0.2"
 [zedspace]
 submodule = "extensions/zedspace"
 version = "0.0.1"
+
+[zig]
+submodule = "extensions/zed"
+path = "extensions/zig"
+version = "0.0.1"


### PR DESCRIPTION
This PR adds the Zig extension.

Zig support was extracted from Zed in https://github.com/zed-industries/zed/pull/9893.