### PR TITLE
Upgrade Make to 1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -147,7 +147,7 @@ version = "0.0.6"
 
 [make]
 submodule = "extensions/make"
-version = "0.0.1"
+version = "1.0.0"
 
 [markdown-oxide]
 submodule = "extensions/markdown-oxide"


### PR DESCRIPTION
Now contains Makefile syntax highlighting!

Also upgraded to the new `extensions.toml` configuration and tidied up some bits in the repository.

Loaded as a Dev Extension in Zed Preview and it functions as expected locally.