### PR TITLE
Add PHP extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -253,6 +253,11 @@ version = "0.0.1"
 submodule = "extensions/pest"
 version = "0.1.0"
 
+[php]
+submodule = "extensions/zed"
+path = "extensions/php"
+version = "0.0.1"
+
 [pkl]
 submodule = "extensions/pkl"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the PHP extension.

PHP support was extracted from Zed in https://github.com/zed-industries/zed/pull/9966.