### PR TITLE
Add C# extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -43,6 +43,11 @@ version = "0.0.3"
 submodule = "extensions/cosmos"
 version = "0.0.1"
 
+[csharp]
+submodule = "extensions/zed"
+path = "extensions/csharp"
+version = "0.0.1"
+
 [cue]
 submodule = "extensions/cue"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the C# extension.

C# support was extracted from Zed in https://github.com/zed-industries/zed/pull/9971.