### PR TITLE
Update `zed-extension` cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: |
             zed-extension
-          key: ${{ env.ZED_EXTENSION_CLI_SHA }}
+          key: zed-extension-${{ env.ZED_EXTENSION_CLI_SHA }}
 
       - name: Download zed-extension CLI if not cached
         if: steps.cache-zed-extension.outputs.cache-hit != 'true'


### PR DESCRIPTION
This PR updates the cache key we use for the `zed-extension` binary to have some additional context than just the Git SHA.