### PR TITLE
Use the binary release for Markdown Oxide

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -161,7 +161,7 @@ version = "1.0.0"
 
 [markdown-oxide]
 submodule = "extensions/markdown-oxide"
-version = "0.0.2"
+version = "0.0.3"
 
 [material-dark]
 submodule = "extensions/material-dark"


### PR DESCRIPTION
I mostly copied the gleam extension, and I believe this works well, however I would love some feedback on the extension's code. 

And how important is it to support aarch platforms? I only support x86_64 right now