### PR TITLE
Bump catppuccin to 0.2.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -33,7 +33,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.3"
+version = "0.2.4"
 
 [colorizer]
 submodule = "extensions/colorizer"


### PR DESCRIPTION
- closes https://github.com/zed-industries/zed/issues/10024
- use `extension.toml` instead of `extension.json`