### PR TITLE
Add Clojure extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -35,6 +35,11 @@ version = "0.0.1"
 submodule = "extensions/catppuccin"
 version = "0.2.4"
 
+[clojure]
+submodule = "extensions/zed"
+path = "extensions/clojure"
+version = "0.0.1"
+
 [colorizer]
 submodule = "extensions/colorizer"
 version = "0.0.3"


### PR DESCRIPTION
This PR adds the Clojure extension.

Clojure support was extracted from Zed in https://github.com/zed-industries/zed/pull/10088.