### PR TITLE
Bump D extension to 0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -59,7 +59,7 @@ version = "0.0.1"
 
 [d]
 submodule = "extensions/d"
-version = "0.0.2"
+version = "0.0.3"
 
 [dockerfile]
 submodule = "extensions/dockerfile"


### PR DESCRIPTION
This adds support for LSP via serve-d.  LSP configuration is not yet present, but this already provides useful guidance from DScanner, as well as rudimentary Find References, Rename symbol and similar.