### PR TITLE
Add HTML extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -145,6 +145,11 @@ version = "0.0.1"
 submodule = "extensions/horizon"
 version = "0.0.1"
 
+[html]
+submodule = "extensions/zed"
+path = "extensions/html"
+version = "0.0.1"
+
 [indigo]
 submodule = "extensions/indigo"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds the HTML extension.

HTML support was extracted from Zed in https://github.com/zed-industries/zed/pull/10130.