### PR TITLE
Update Dracula to 0.7.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -67,7 +67,7 @@ version = "0.0.2"
 
 [dracula]
 submodule = "extensions/dracula"
-version = "0.7.1"
+version = "0.7.3"
 
 [elisp]
 submodule = "extensions/elisp"


### PR DESCRIPTION
- Fixes unreadable bright-black in terminal
- Fixes incorrect property colors
- Tunes transparent colors to be more consistent across opaque/blurred/transparent