### PR TITLE
Add Dart extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -69,6 +69,11 @@ version = "0.0.1"
 submodule = "extensions/d"
 version = "0.0.3"
 
+[dart]
+submodule = "extensions/zed"
+path = "extensions/dart"
+version = "0.0.1"
+
 [dockerfile]
 submodule = "extensions/dockerfile"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds the Dart extension.

Dart support was extracted from Zed in https://github.com/zed-industries/zed/pull/10212.

Note: The Dart extension requires a minimum Zed version of v0.131.x.