### PR TITLE
Update biome extension to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -21,7 +21,7 @@ version = "0.0.1"
 
 [biome]
 submodule = "extensions/biome"
-version = "0.0.1"
+version = "0.0.2"
 
 [blanche]
 submodule = "extensions/blanche"


### PR DESCRIPTION
Tested to work in zed 0.130.3 and up, locally. Zed 0.129.2 too, but only JavaScript support.

https://github.com/zed-industries/zed/issues/10256
