### PR TITLE
Update Gleam to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -143,7 +143,7 @@ version = "0.0.1"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.0.2"
+version = "0.1.0"
 
 [graphene]
 submodule = "extensions/graphene"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.1.0.

This version of the extension contains improved completion labels:

<img width="572" alt="Screenshot 2024-04-10 at 3 30 25 PM" src="https://github.com/zed-industries/extensions/assets/1486634/950a5b2b-2c47-4ebc-be35-fd44d05d0d89">

This version of the Gleam extension requires Zed v0.131.x or higher.