### PR TITLE
Update Haskell to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -156,7 +156,7 @@ version = "0.0.2"
 [haskell]
 submodule = "extensions/zed"
 path = "extensions/haskell"
-version = "0.0.1"
+version = "0.1.0"
 
 [horizon]
 submodule = "extensions/horizon"


### PR DESCRIPTION
This PR updates the Haskell extension to v0.1.0.

This version of the extension contains improved symbol labels:

![image](https://github.com/zed-industries/extensions/assets/1486634/84c0c74e-254f-4177-ab36-6a1d635bc9ee)

This version of the Haskell extension requires Zed v0.131.x or higher.