### PR TITLE
Update Emmet to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -93,7 +93,7 @@ version = "0.0.1"
 [emmet]
 submodule = "extensions/zed"
 path = "extensions/emmet"
-version = "0.0.1"
+version = "0.0.2"
 
 [erlang]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Emmet extension to v0.0.2.

This version of the extension adds support for PHP and ERB files with Emmet (when using Zed v1.131.0 and above).