### PR TITLE
Update Glazier to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -138,7 +138,7 @@ version = "0.0.2"
 
 [glazier]
 submodule = "extensions/glazier"
-version = "0.0.1"
+version = "0.0.2"
 
 [gleam]
 submodule = "extensions/zed"


### PR DESCRIPTION
- Remove Redrum theme
- Increase remaining themes' background opacity from #xxxxxx77 to #xxxxxxAA