### PR TITLE
Update navi to 0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -253,7 +253,7 @@ version = "0.0.2"
 
 [navi]
 submodule = "extensions/navi"
-version = "0.1.0"
+version = "0.2.0"
 
 [neosolarized]
 submodule = "extensions/neosolarized"


### PR DESCRIPTION
Release notes:

https://github.com/navi-language/zed-navi/releases/tag/v0.2.0