### PR TITLE
Add Twig extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -397,3 +397,7 @@
 [submodule "extensions/zedspace"]
 	path = extensions/zedspace
 	url = https://github.com/Brunowilliang/zedspace.git
+
+[submodule "extensions/twig"]
+	path = extensions/twig
+	url = https://github.com/evernow-io/zed-twig

--- a/extensions.toml
+++ b/extensions.toml
@@ -476,5 +476,4 @@ version = "0.0.1"
 
 [zig]
 submodule = "extensions/zed"
-path = "extensions/zig"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -416,6 +416,11 @@ submodule = "extensions/zed"
 path = "extensions/toml"
 version = "0.0.2"
 
+[twig]
+submodule = "extensions/twig"
+path = "extensions/twig"
+version = "0.0.1"
+
 [typst]
 submodule = "extensions/typst"
 version = "0.0.1"


### PR DESCRIPTION
Extension to enable syntax highlighting for Twig files in Zed (#163).

Unfortunately, the extension does not support formatting. The available Prettier plugins didn't worked well, so I've decided to skip this. If you want to format your Twig files, install [https://www.djlint.com/docs/getting-started/](djLint) and configure Zed/your project like this:

```json
{
  "language_overrides": {
    "Twig": {
      "format_on_save": {
        "external": {
          "command": "bash",
          "arguments": [
            "-c",
            "cat {buffer_path} | djlint - --profile=nunjucks --reformat"
          ]
        }
      }
    }
  }
}
```
