### PR TITLE
Update PHP to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -318,7 +318,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.0.1"
+version = "0.0.2"
 
 [pkl]
 submodule = "extensions/pkl"


### PR DESCRIPTION
This PR updates the PHP extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10480 for the changes in this version.