### PR TITLE
Update Zig to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -472,4 +472,4 @@ version = "0.0.1"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.0.1"
+version = "0.1.0"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/10481 for the changes in this version.