### PR TITLE
Update TOML to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -414,7 +414,7 @@ version = "0.0.2"
 [toml]
 submodule = "extensions/zed"
 path = "extensions/toml"
-version = "0.0.2"
+version = "0.1.0"
 
 [typst]
 submodule = "extensions/typst"


### PR DESCRIPTION
This PR updates the TOML extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/10482 for the changes in this version.
