### PR TITLE
Add Elm extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -86,6 +86,11 @@ version = "0.7.3"
 submodule = "extensions/elisp"
 version = "0.0.4"
 
+[elm]
+submodule = "extensions/zed"
+path = "extensions/elm"
+version = "0.0.1"
+
 [ember]
 submodule = "extensions/ember"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Elm extension.

Elm support was extracted from Zed in https://github.com/zed-industries/zed/pull/10432.