### PR TITLE
Add GLSL extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -145,6 +145,11 @@ submodule = "extensions/zed"
 path = "extensions/gleam"
 version = "0.1.0"
 
+[glsl]
+submodule = "extensions/zed"
+path = "extensions/glsl"
+version = "0.0.1"
+
 [graphene]
 submodule = "extensions/graphene"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the GLSL extension.

GLSL support was extracted from Zed in https://github.com/zed-industries/zed/pull/10433.