### PR TITLE
Add Scheme extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -356,6 +356,11 @@ version = "0.0.1"
 submodule = "extensions/scala"
 version = "0.0.1"
 
+[scheme]
+submodule = "extensions/zed"
+path = "extensions/scheme"
+version = "0.0.1"
+
 [siri]
 submodule = "extensions/siri"
 version = "0.0.3"


### PR DESCRIPTION
This PR adds the Scheme extension.

Scheme support was extracted from Zed in https://github.com/zed-industries/zed/pull/10442.