### PR TITLE
Add Racket extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -352,6 +352,11 @@ version = "0.0.1"
 submodule = "extensions/r"
 version = "0.0.1"
 
+[racket]
+submodule = "extensions/zed"
+path = "extensions/racket"
+version = "0.0.1"
+
 [scala]
 submodule = "extensions/scala"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Racket extension.

Racket support was extracted from Zed in https://github.com/zed-industries/zed/pull/10442.