### PR TITLE
Add Lua extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -209,6 +209,11 @@ version = "0.0.3"
 submodule = "extensions/lox"
 version = "0.0.1"
 
+[lua]
+submodule = "extensions/zed"
+path = "extensions/lua"
+version = "0.0.1"
+
 [macos-classic]
 submodule = "extensions/macos-classic"
 version = "0.0.7"


### PR DESCRIPTION
This PR adds the Lua extension.

Lua support was extracted from Zed in https://github.com/zed-industries/zed/pull/10437.