### PR TITLE
Add Terraform extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -429,6 +429,11 @@ version = "0.0.1"
 submodule = "extensions/templ"
 version = "0.0.2"
 
+[terraform]
+submodule = "extensions/zed"
+path = "extensions/terraform"
+version = "0.0.1"
+
 [the-dark-side]
 submodule = "extensions/the-dark-side"
 version = "0.2.5"


### PR DESCRIPTION
This PR adds the Terraform extension.

Terraform support was extracted from Zed in https://github.com/zed-industries/zed/pull/10479.

Note that the Terraform extension requires Zed v0.132.x (which will be released this coming Wednesday) in order for some problematic code action kinds to be filtered out from the language server.