### PR TITLE
Add Vue extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -484,6 +484,11 @@ version = "0.0.1"
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"
 
+[vue]
+submodule = "extensions/zed"
+path = "extensions/vue"
+version = "0.0.1"
+
 [wgsl]
 submodule = "extensions/wgsl"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Vue extension.

Vue support was extracted from Zed in https://github.com/zed-industries/zed/pull/10486.

Note that the Terraform extension requires Zed v0.132.x (which will be released this coming Wednesday) in order for some problematic code action kinds to be filtered out from the language server.