### PR TITLE
Warn when using `extension.json`

### DIFF
--- a/src/lib/fs.js
+++ b/src/lib/fs.js
@@ -14,3 +14,25 @@ export async function readTomlFile(path) {
     throw new Error(`Failed to parse TOML file '${path}': ${err}`);
   }
 }
+
+/**
+ * @param {string} path
+ * @returns {Promise<boolean>}
+ */
+export async function fileExists(path) {
+  try {
+    const stat = await fs.stat(path);
+    return stat.isFile();
+  } catch (err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "code" in err &&
+      err.code === "ENOENT"
+    ) {
+      return false;
+    }
+
+    throw err;
+  }
+}

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -3,7 +3,7 @@ import toml from "@iarna/toml";
 import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readTomlFile } from "./lib/fs.js";
+import { fileExists, readTomlFile } from "./lib/fs.js";
 import {
   checkoutGitSubmodule,
   readGitmodules,
@@ -142,6 +142,12 @@ async function packageExtension(
 
   const SCRATCH_DIR = "./scratch";
   await fs.mkdir(SCRATCH_DIR, { recursive: true });
+
+  if (await fileExists(path.join(extensionPath, "extension.json"))) {
+    console.warn(
+      "The `extension.json` manifest format has been superseded by `extension.toml`",
+    );
+  }
 
   const zedExtensionOutput = await exec(
     "./zed-extension",


### PR DESCRIPTION
This PR adds a warning when an `extension.json` manifest is detected.

`extension.toml` should be preferred instead.