### PR TITLE
Update cue to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -63,7 +63,7 @@ version = "0.0.2"
 
 [cue]
 submodule = "extensions/cue"
-version = "0.0.1"
+version = "0.0.2"
 
 [d]
 submodule = "extensions/d"


### PR DESCRIPTION
Release notes:

* Fix an issue where optional fields not showing up in outline
* Fix an issue where imports in list without comma are hidden from outline
* Migrated to `extension.toml`

https://github.com/jkasky/zed-cue/releases/tag/v0.0.2