### PR TITLE
Add CFEngine extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,6 +34,10 @@
 	path = extensions/catppuccin
 	url = https://github.com/catppuccin/zed.git
 
+[submodule "extensions/cfengine"]
+	path = extensions/cfengine
+	url = https://github.com/olehermanse/zed-cfengine.git
+
 [submodule "extensions/colorizer"]
 	path = extensions/colorizer
 	url = https://github.com/tamimhasandev/colorizer.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -39,6 +39,10 @@ version = "0.0.1"
 submodule = "extensions/catppuccin"
 version = "0.2.5"
 
+[cfengine]
+submodule = "extensions/cfengine"
+version = "1.0.0"
+
 [clojure]
 submodule = "extensions/zed"
 path = "extensions/clojure"


### PR DESCRIPTION
This extension uses a tree-sitter grammar and adds syntax highlighting for CFEngine policy files to Zed.

All major features of the langauge are implemented, I don't know of anything which is broken, so far.

Extension: https://github.com/olehermanse/zed-cfengine

Grammar: https://github.com/olehermanse/tree-sitter-cfengine

Example:

![Screenshot 2024-04-16 at 17 15 42](https://github.com/zed-industries/extensions/assets/4048546/e7bf306e-841e-4cd6-a724-7be1aebaf401)
