### PR TITLE
Bump beancount to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -17,7 +17,7 @@ version = "0.0.4"
 
 [beancount]
 submodule = "extensions/beancount"
-version = "0.0.1"
+version = "0.0.2"
 
 [biome]
 submodule = "extensions/biome"


### PR DESCRIPTION
This fixes a failure to load the extension, since the previous version relied on Tree-sitter C++ external scanners, which is no longer supported.