### PR TITLE
Update Zig to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -532,4 +532,4 @@ version = "0.0.1"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.0"
+version = "0.1.1"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/10645 for the changes in this version.