### PR TITLE
Update Lua to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -224,7 +224,7 @@ version = "0.0.1"
 [lua]
 submodule = "extensions/zed"
 path = "extensions/lua"
-version = "0.0.1"
+version = "0.0.3"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
This PR updates the Lua extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10646 for the changes in this version (the PR says v0.0.3, but this was later amended, since we don't have a v0.0.2 yet).