### PR TITLE
Update Gleam to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -152,7 +152,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.1.0"
+version = "0.1.1"
 
 [glsl]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/10648 for the changes in this version.