### PR TITLE
Update Clojure to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -42,7 +42,7 @@ version = "0.2.5"
 [clojure]
 submodule = "extensions/zed"
 path = "extensions/clojure"
-version = "0.0.1"
+version = "0.0.2"
 
 [colorizer]
 submodule = "extensions/colorizer"


### PR DESCRIPTION
This PR updates the Clojure extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10650 for the changes in this version.