### PR TITLE
Update C# to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -55,7 +55,7 @@ version = "0.0.1"
 [csharp]
 submodule = "extensions/zed"
 path = "extensions/csharp"
-version = "0.0.1"
+version = "0.0.2"
 
 [csv]
 submodule = "extensions/csv"


### PR DESCRIPTION
This PR updates the C# extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10651 for the changes in this version.