### PR TITLE
Update Terraform to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -448,7 +448,7 @@ version = "0.0.2"
 [terraform]
 submodule = "extensions/zed"
 path = "extensions/terraform"
-version = "0.0.1"
+version = "0.0.2"
 
 [the-dark-side]
 submodule = "extensions/the-dark-side"


### PR DESCRIPTION
This PR updates the Terraform extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10653 for the changes in this version.