### PR TITLE
Update SQL to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -430,7 +430,7 @@ version = "0.0.3"
 
 [sql]
 submodule = "extensions/sql"
-version = "0.0.2"
+version = "1.0.0"
 
 [srcery]
 submodule = "extensions/srcery"


### PR DESCRIPTION
This PR updates the SQL extension to v1.0.0.

This is a continuation of https://github.com/zed-industries/extensions/pull/482.

cc @evrsen