### PR TITLE
Add Cap'n Proto extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,6 +34,10 @@
 	path = extensions/cadence
 	url = https://github.com/janezpodhostnik/cadence.zed.git
 
+[submodule "extensions/capnp"]
+	path = extensions/capnp
+	url = https://github.com/cmackenzie1/zed-capnp.git
+
 [submodule "extensions/catppuccin"]
 	path = extensions/catppuccin
 	url = https://github.com/catppuccin/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -39,6 +39,10 @@ version = "0.0.3"
 submodule = "extensions/cadence"
 version = "0.0.1"
 
+[capnp]
+submodule = "extensions/capnp"
+version = "0.0.1"
+
 [catppuccin]
 submodule = "extensions/catppuccin"
 version = "0.2.5"


### PR DESCRIPTION
This adds a Cap'n Proto extension to the Zed extension registry.

https://github.com/cmackenzie1/zed-capnp
https://capnproto.org