### PR TITLE
Update Prisma to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -379,7 +379,7 @@ version = "0.0.1"
 [prisma]
 submodule = "extensions/zed"
 path = "extensions/prisma"
-version = "0.0.1"
+version = "0.0.2"
 
 [purescript]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Prisma extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10689 for the changes in this version.