### PR TITLE
Update GLSL to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -169,7 +169,7 @@ version = "0.1.1"
 [glsl]
 submodule = "extensions/zed"
 path = "extensions/glsl"
-version = "0.0.1"
+version = "0.1.0"
 
 [graphene]
 submodule = "extensions/graphene"


### PR DESCRIPTION
This PR updates the GLSL extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/10734 for the changes in this version.