### PR TITLE
Bump catppuccin to 0.2.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -43,7 +43,7 @@ version = "0.0.1"
 submodule = "extensions/capnp"
 version = "0.0.1"
 
-[catppuccin]
+[catppuccin-themes]
 submodule = "extensions/catppuccin"
 version = "0.2.6"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -43,7 +43,7 @@ version = "0.0.1"
 submodule = "extensions/capnp"
 version = "0.0.1"
 
-[catppuccin-themes]
+[catppuccin]
 submodule = "extensions/catppuccin"
 version = "0.2.6"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -45,7 +45,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.5"
+version = "0.2.6"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
- fix hint coloring
- [catppuccin/alacritty](https://github.com/catppuccin/alacritty/) terminal coloring