### PR TITLE
Update ReScript extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -409,7 +409,7 @@ version = "0.0.1"
 
 [rescript]
 submodule = "extensions/rescript"
-version = "0.0.1"
+version = "0.1.0"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
Updates the path_suffixes to correctly specify ReScript file extensions "res" and "resi"