### PR TITLE
Correct docs "Add Dev Extension" -> "Install Dev Extension"

### DIFF
--- a/AUTHORING_EXTENSIONS.md
+++ b/AUTHORING_EXTENSIONS.md
@@ -115,7 +115,7 @@ See [this blog post](https://zed.dev/blog/user-themes-now-in-preview) for more d
 
 ## Testing your extension locally
 
-To test your extension locally, you can open up the extensions view with the `zed: extensions` command and then click on the `Add Dev Extension` button.
+To test your extension locally, you can open up the extensions view with the `zed: extensions` command and then click on the `Install Dev Extension` button.
 
 This will open a file dialog where you can locate and select the directory in which your extension resides.
 


### PR DESCRIPTION
The extensions section in Zed v0.131.6 has an `Install Dev Extension` button, while the docs still refer to it as `Add Dev Extension`.