### PR TITLE
Bump biome to 0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -29,7 +29,7 @@ version = "0.0.2"
 
 [biome]
 submodule = "extensions/biome"
-version = "0.0.2"
+version = "0.0.6"
 
 [blackfox]
 submodule = "extensions/blackfox"


### PR DESCRIPTION
**What's new**
- The extension should be able to read the binary from the node_modules