### PR TITLE
Add Deno extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -98,6 +98,11 @@ submodule = "extensions/zed"
 path = "extensions/dart"
 version = "0.0.1"
 
+[deno]
+submodule = "extensions/zed"
+path = "extensions/deno"
+version = "0.0.1"
+
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the Deno extension.

Deno support was extracted from Zed in https://github.com/zed-industries/zed/pull/10912.