### PR TITLE
Update Dart to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -96,7 +96,7 @@ version = "0.0.4"
 [dart]
 submodule = "extensions/zed"
 path = "extensions/dart"
-version = "0.0.1"
+version = "0.0.2"
 
 [deno]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Dart extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/10940 for the changes in this version.