### PR TITLE
Add Java LSP Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -170,6 +170,10 @@
 	path = extensions/java
 	url = https://github.com/samuser107/zed-java-extension.git
 
+[submodule "extensions/java-eclipse-jdtls"]
+	path = extensions/java-eclipse-jdtls
+	url = https://github.com/ABckh/zed-java-language-support-jdtls
+
 [submodule "extensions/jsonnet"]
 	path = extensions/jsonnet
 	url = https://github.com/narqo/zed-jsonnet.git
@@ -521,6 +525,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/java-eclipse-jdtls"]
-	path = extensions/java-eclipse-jdtls
-	url = https://github.com/ABckh/zed-java-language-support-jdtls

--- a/.gitmodules
+++ b/.gitmodules
@@ -501,3 +501,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/java-eclipse-jdtls"]
+	path = extensions/java-eclipse-jdtls
+	url = https://github.com/ABckh/zed-java-language-support-jdtls

--- a/extensions.toml
+++ b/extensions.toml
@@ -237,7 +237,7 @@ version = "0.0.4"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"
-version = "0.0.1"
+version = "0.1.0"
 
 [jsonnet]
 submodule = "extensions/jsonnet"

--- a/extensions.toml
+++ b/extensions.toml
@@ -235,6 +235,10 @@ version = "0.1.2"
 submodule = "extensions/java"
 version = "0.0.4"
 
+[java-eclipse-jdtls]
+submodule = "extensions/java-eclipse-jdtls"
+version = "0.0.1"
+
 [jsonnet]
 submodule = "extensions/jsonnet"
 version = "0.1.0"


### PR DESCRIPTION
Moved the changes made in this [PR](https://github.com/zed-industries/zed/pull/8813) to a Java extension. As mentioned in this discussion, @louisnicolas-longheval-vinci doesn't have time to support it. @valentinegb and I have already put a lot of effort not only into LSP support but also into proper syntax highlighting. Because of that, I have decided to create a separate extension for it.

In [extension repository](https://github.com/ABckh/zed-java-language-support-jdtls) I have added list of future improvements, which will be added to the extension

It would close #500