### PR TITLE
Move typst extension to GitHub for contributor convenience

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -432,7 +432,7 @@
 
 [submodule "extensions/typst"]
 	path = extensions/typst
-	url = https://codeberg.org/WeetHet/typst.zed.git
+	url = https://github.com/WeetHet/typst.zed.git
 
 [submodule "extensions/ultimate-dark-neo"]
 	path = extensions/ultimate-dark-neo

--- a/extensions.toml
+++ b/extensions.toml
@@ -542,7 +542,7 @@ version = "0.1.0"
 
 [typst]
 submodule = "extensions/typst"
-version = "0.0.2"
+version = "0.0.3"
 
 [uiua]
 submodule = "extensions/zed"


### PR DESCRIPTION
I've moved the typst extension repo to GitHub, so it would be easier for people to report issues. This also adds passing the shell environment to the lsp, which might be unnecessary, but still is a good thing to do