### PR TITLE
Add Elixir extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -119,6 +119,11 @@ version = "0.9.1"
 submodule = "extensions/elisp"
 version = "0.0.4"
 
+[elixir]
+submodule = "extensions/zed"
+path = "extensions/elixir"
+version = "0.0.1"
+
 [elm]
 submodule = "extensions/zed"
 path = "extensions/elm"


### PR DESCRIPTION
This PR adds the Elixir extension.

Elixir support was extracted from Zed in https://github.com/zed-industries/zed/pull/10948.

Since the Elixir extension provides three different language servers,
you'll need to use the `language_servers` setting to select the one you
want to use:

#### Elixir LS

```json
{
  "languages": {
    "Elixir": {
      "language_servers": [ "elixir-ls", "!next-ls", "!lexical", "..."]
    }
  }
}
```

#### Next LS

```json
{
  "languages": {
    "Elixir": {
      "language_servers": [ "next-ls", "!elixir-ls", "!lexical", "..."]
    }
  }
}
```

#### Lexical

```json
{
  "languages": {
    "Elixir": {
      "language_servers": [ "lexical", "!elixir-ls", "!next-ls", "..."]
    }
  }
}
```