### PR TITLE
Bump extension CLI version to `5ef7591`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZED_EXTENSION_CLI_SHA: b6857ca469293112a89784817fba0685b1553892
+  ZED_EXTENSION_CLI_SHA: 5ef75919f09e31c28b75c09e695946b6c4d9c3ee
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/5ef75919f09e31c28b75c09e695946b6c4d9c3ee.