### PR TITLE
Add dockerignore extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,6 +90,10 @@
 	path = extensions/dockerfile
 	url = https://github.com/d1y/dockerfile.zed.git
 
+[submodule "extensions/dockerignore"]
+	path = extensions/dockerignore
+	url = https://github.com/eth0net/zed-dockerignore.git
+
 [submodule "extensions/dracula"]
 	path = extensions/dracula
 	url = https://github.com/dracula/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -115,6 +115,10 @@ version = "0.1.0"
 submodule = "extensions/dockerfile"
 version = "0.0.2"
 
+[dockerignore]
+submodule = "extensions/dockerignore"
+version = "0.1.0"
+
 [dracula]
 submodule = "extensions/dracula"
 version = "0.9.1"


### PR DESCRIPTION
This PR brings a new extension to support syntax highlighting for `.dockerignore` files.
