### PR TITLE
Update git-firefly to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -185,7 +185,7 @@ version = "0.0.2"
 
 [git-firefly]
 submodule = "extensions/git-firefly"
-version = "0.0.2"
+version = "0.0.3"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"


### PR DESCRIPTION
In #649, The PR update new style with extension format(old use .json) and gitignore path_suffixes contains .dockerignore

/cc @eth0net 