### PR TITLE
Bump catppuccin to 0.2.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -61,7 +61,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.6"
+version = "0.2.7"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
- fix `inlay_hints` and similar "hint" coloring
- adjust hover and selection coloring on some menus
- more syntax definitions