### PR TITLE
Update java-eclipse-jdtls to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -249,7 +249,7 @@ version = "0.0.4"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"
-version = "0.1.0"
+version = "0.2.0"
 
 [jsonnet]
 submodule = "extensions/jsonnet"


### PR DESCRIPTION
Update `java-eclipse-jdtls` to version v0.2.0 which introduced completion labels