### PR TITLE
Update Unison extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -612,7 +612,7 @@ version = "0.0.4"
 
 [unison]
 submodule = "extensions/unison"
-version = "0.0.1"
+version = "0.0.2"
 
 [unoflat]
 submodule = "extensions/unoflat"


### PR DESCRIPTION
Added LSP support, by hardcoding `ncat` and adding it as a requirement for the language server in the README. 