### PR TITLE
Update Elixir to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -134,7 +134,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.1"
+version = "0.0.2"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/11303 for the changes in this version.