### PR TITLE
Add Vapor theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -557,3 +557,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/zed-vapor"]
+	path = extensions/zed-vapor
+	url = https://github.com/felipetesc/zed-vapor.git


### PR DESCRIPTION
Added zed-vapor theme.

![zed_vapor](https://github.com/zed-industries/extensions/assets/2336812/c6b1a961-bcbe-481e-9b7c-d276686f7074)


Previous pr had submodule sh instead of https://github.com/felipetesc/zed-extensions.git . 
Sorry for the mistake