### PR TITLE
Update `base-16` repository version to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -21,7 +21,7 @@ version = "0.0.1"
 
 [base16]
 submodule = "extensions/base16"
-version = "0.0.4"
+version = "0.1.0"
 
 [basher]
 submodule = "extensions/basher"


### PR DESCRIPTION
This PR updates the `base-16` dependency to v0.1.0. It adds a lot of new base-16 variants generated from a template