### PR TITLE
Update TOML to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -587,7 +587,7 @@ version = "0.0.2"
 [toml]
 submodule = "extensions/zed"
 path = "extensions/toml"
-version = "0.1.0"
+version = "0.1.1"
 
 [tsar]
 submodule = "extensions/tsar"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/11359 for the changes in this version.