### PR TITLE
Add `wit` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -538,6 +538,10 @@
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl.git
 
+[submodule "extensions/wit"]
+	path = extensions/wit
+	url = https://github.com/valentinegb/zed-wit.git
+
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes
 	url = https://github.com/skarline/zed-xcode-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -663,6 +663,10 @@ version = "0.1.1"
 submodule = "extensions/wgsl"
 version = "0.0.1"
 
+[wit]
+submodule = "extensions/wit"
+version = "0.1.0"
+
 [xcode-themes]
 submodule = "extensions/xcode-themes"
 version = "1.1.3"


### PR DESCRIPTION
Adds the initial version of the `wit` extension (v0.1.0). This extension currently adds basic language support for WIT (Wasm Interface Type).