### PR TITLE
Add Vale extension for style and spellchecking

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -506,6 +506,10 @@
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
 
+[submodule "extensions/vale"]
+	path = extensions/vale
+	url = https://github.com/koozz/zed-vale.git
+
 [submodule "extensions/vesper"]
 	path = extensions/vesper
 	url = https://github.com/bdsqqq/vesper-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -626,6 +626,10 @@ version = "0.0.2"
 submodule = "extensions/unoflat"
 version = "0.0.3"
 
+[vale]
+submodule = "extensions/vale"
+version = "0.0.1"
+
 [vesper]
 submodule = "extensions/vesper"
 version = "0.0.1"


### PR DESCRIPTION
Still need some help with troubleshooting, it seems to work at first.
Dev extension works. Vale errors and warnings are shown.

![image](https://github.com/zed-industries/extensions/assets/264372/1a18f28f-2f5f-476a-b679-e650411da88e)

Quickly after, the language server shuts down.

Any pointers on how to troubleshoot it further?

```bash
> tail -f ~/Library/Logs/Zed/Zed.log
2024-05-06T14:44:50+02:00 [INFO] compiling rust extension /Users/jan/git/github.com/koozz/zed-vale
2024-05-06T14:44:51+02:00 [INFO] finished compiling extension /Users/jan/git/github.com/koozz/zed-vale
2024-05-06T14:44:52+02:00 [INFO] rebuilt extension index in 20.117417ms
2024-05-06T14:44:52+02:00 [INFO] extensions updated. loading 1, reloading 0, unloading 0
2024-05-06T14:44:52+02:00 [INFO] Initializing default prettier with plugins {}
2024-05-06T14:44:52+02:00 [INFO] starting language servers for Markdown:
2024-05-06T14:44:52+02:00 [INFO] Initializing default prettier with plugins {}
2024-05-06T14:44:52+02:00 [INFO] starting language servers for Markdown: vale
2024-05-06T14:44:52+02:00 [INFO] starting language server "vale", path: "/Users/jan/git/github.com/myproject", id: 1
2024-05-06T14:44:52+02:00 [INFO] rebuilt extension index in 15.916958ms
2024-05-06T14:44:52+02:00 [INFO] extensions updated. loading 0, reloading 1, unloading 0
2024-05-06T14:44:52+02:00 [INFO] Initializing default prettier with plugins {}
2024-05-06T14:44:52+02:00 [INFO] starting language servers for Markdown:
2024-05-06T14:44:52+02:00 [INFO] Initializing default prettier with plugins {}
2024-05-06T14:44:52+02:00 [INFO] starting language servers for Markdown: vale
2024-05-06T14:44:54+02:00 [INFO] starting language server. binary path: "/Users/jan/Library/Application Support/Zed/extensions/work/vale/vale-ls-v0.3.7/vale-ls", working directory: "/Users/jan/git/github.com/myproject", args: []
2024-05-06T14:45:41+02:00 [INFO] Waiting for default prettier to install
2024-05-06T14:45:41+02:00 [INFO] Starting prettier at path "/Users/jan/Library/Application Support/Zed/prettier"
2024-05-06T14:45:41+02:00 [INFO] Node runtime install_if_needed
2024-05-06T14:45:42+02:00 [INFO] starting language server. binary path: "/Users/jan/Library/Application Support/Zed/node/node-v18.15.0-darwin-arm64/bin/node", working directory: "/Users/jan/Library/Application Support/Zed/prettier", args: ["/Users/jan/Library/Application Support/Zed/prettier/prettier_server.js", "/Users/jan/Library/Application Support/Zed/prettier"]
2024-05-06T14:45:42+02:00 [INFO] Started default prettier in "/Users/jan/Library/Application Support/Zed/prettier"
2024-05-06T14:45:43+02:00 [ERROR] crates/lsp/src/lsp.rs:352: cannot read LSP message headers
2024-05-06T14:45:43+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:43+02:00 [ERROR] crates/project/src/project.rs:6949: server shut down
2024-05-06T14:45:43+02:00 [ERROR] crates/lsp/src/lsp.rs:374: Broken pipe (os error 32)
2024-05-06T14:45:45+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:45+02:00 [ERROR] crates/project/src/project.rs:6949: server shut down
2024-05-06T14:45:52+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:52+02:00 [ERROR] crates/project/src/project.rs:6949: server shut down
2024-05-06T14:45:52+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:52+02:00 [ERROR] crates/project/src/project.rs:6949: server shut down
2024-05-06T14:45:56+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:56+02:00 [ERROR] crates/project/src/project.rs:6949: server shut down
2024-05-06T14:45:57+02:00 [ERROR] crates/project/src/project.rs:2688: sending into a closed channel
2024-05-06T14:45:57+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
2024-05-06T14:45:58+02:00 [WARN] Generic lsp request to vale-ls failed: server shut down
```

Fixes: #548 