### PR TITLE
Update Elixir to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -138,7 +138,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.3"
+version = "0.0.4"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.4.

See https://github.com/zed-industries/zed/pull/11446 for the changes in this version.