### PR TITLE
Update Zig to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -706,4 +706,4 @@ version = "0.0.3"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.1"
+version = "0.1.2"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.2.

See https://github.com/zed-industries/zed/pull/11447 for the changes in this version.