### PR TITLE
Add Ruby extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -505,6 +505,11 @@ version = "0.0.3"
 submodule = "extensions/rose-pine-theme"
 version = "1.0.4"
 
+[ruby]
+submodule = "extensions/zed"
+path = "extensions/ruby"
+version = "0.0.1"
+
 [scala]
 submodule = "extensions/scala"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Ruby extension.

Ruby support was extracted from Zed in https://github.com/zed-industries/zed/pull/11360.