### PR TITLE
Update strace to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -569,7 +569,7 @@ version = "0.1.1"
 
 [strace]
 submodule = "extensions/strace"
-version = "0.0.1"
+version = "0.0.2"
 
 [struct-theme]
 submodule = "extensions/struct-theme"


### PR DESCRIPTION
the new version just changes first_line_pattern  to  `"^\\d*\\s?execve\\("` to detect strace files that starts with pid number (when strace is used with -f)