### PR TITLE
Add Stimulus LSP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -462,6 +462,10 @@
 	path = extensions/starlark
 	url = https://github.com/zaucy/zed-starlark.git
 
+[submodule "extensions/stimulus"]
+	path = extensions/stimulus
+	url = https://github.com/vitallium/zed-stimulus
+
 [submodule "extensions/strace"]
 	path = extensions/strace
 	url = https://github.com/sigmaSd/zed-strace

--- a/extensions.toml
+++ b/extensions.toml
@@ -575,6 +575,10 @@ version = "0.0.2"
 submodule = "extensions/starlark"
 version = "0.1.1"
 
+[stimulus]
+submodule = "extensions/stimulus"
+version = "0.0.1"
+
 [strace]
 submodule = "extensions/strace"
 version = "0.0.2"


### PR DESCRIPTION
This pull request adds a new extension for [Stimulus LSP](https://github.com/marcoroth/stimulus-lsp). Zed support was requested in https://github.com/marcoroth/stimulus-lsp/issues/268 and this PR closes [this issue](https://github.com/zed-industries/extensions/issues/709).

## Screenshots

### Stimulus controllers completion

![CleanShot 2024-05-12 at 14 20 17@2x](https://github.com/zed-industries/extensions/assets/1894248/79cfef66-2fd9-4e09-8abf-e2328ba2ac25)


### Diagnostics 

![CleanShot 2024-05-12 at 14 20 00@2x](https://github.com/zed-industries/extensions/assets/1894248/d0d4ca36-4fa4-41b0-abc1-eb87d6eb3938)
