### PR TITLE
Add Cedar extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -593,3 +593,7 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+
+[submodule "extensions/cedar"]
+	path = extensions/cedar
+	url = https://github.com/chrnorm/zed-cedar.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -66,6 +66,10 @@
 	path = extensions/catppuccin
 	url = https://github.com/catppuccin/zed.git
 
+[submodule "extensions/cedar"]
+	path = extensions/cedar
+	url = https://github.com/chrnorm/zed-cedar.git
+
 [submodule "extensions/cfengine"]
 	path = extensions/cfengine
 	url = https://github.com/olehermanse/zed-cfengine.git
@@ -593,7 +597,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-
-[submodule "extensions/cedar"]
-	path = extensions/cedar
-	url = https://github.com/chrnorm/zed-cedar.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -71,6 +71,10 @@ version = "0.0.1"
 submodule = "extensions/catppuccin"
 version = "0.2.7"
 
+[cedar]
+submodule = "extensions/cedar"
+version = "0.0.1"
+
 [cfengine]
 submodule = "extensions/cfengine"
 version = "1.0.1"


### PR DESCRIPTION
Adds language grammar support for [Cedar policy](https://cedarpolicy.com/) source code (`*.cedar`).