### PR TITLE
Update Vue to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -682,7 +682,7 @@ version = "0.0.2"
 [vue]
 submodule = "extensions/zed"
 path = "extensions/vue"
-version = "0.0.1"
+version = "0.0.2"
 
 [warp-one-dark]
 submodule = "extensions/warp-one-dark"


### PR DESCRIPTION
This PR updates the Vue extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/11747 for the changes in this version.