### PR TITLE
Update Ruby to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -516,7 +516,7 @@ version = "1.0.4"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.1"
+version = "0.0.2"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
This PR updates the Ruby extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/11769 for the changes in this version.