### PR TITLE
Update Gleam to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -210,7 +210,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.1.1"
+version = "0.1.2"
 
 [glsl]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.1.2.

See https://github.com/zed-industries/zed/pull/11803 for the changes in this version.