### PR TITLE
Update PHP to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -460,7 +460,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.0.2"
+version = "0.0.3"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
This PR updates the PHP extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/11832 for the changes in this version.