### PR TITLE
Update Astro to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -21,7 +21,7 @@ version = "0.0.1"
 [astro]
 submodule = "extensions/zed"
 path = "extensions/astro"
-version = "0.0.1"
+version = "0.0.2"
 
 [base16]
 submodule = "extensions/base16"


### PR DESCRIPTION
This PR updates the Astro extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/11834 for the changes in this version.