### PR TITLE
Add Groovy v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -170,6 +170,10 @@
 	path = extensions/graphql
 	url = https://github.com/11bit/zed-extension-graphql.git
 
+[submodule "extensions/groovy"]
+	path = extensions/groovy
+	url = https://github.com/valentinegb/zed-groovy.git
+
 [submodule "extensions/groq"]
 	path = extensions/groq
 	url = https://github.com/juice49/zed-groq

--- a/extensions.toml
+++ b/extensions.toml
@@ -225,6 +225,10 @@ version = "0.2.0"
 submodule = "extensions/graphql"
 version = "0.0.2"
 
+[groovy]
+submodule = "extensions/groovy"
+version = "1.0.0"
+
 [groq]
 submodule = "extensions/groq"
 version = "0.0.1"


### PR DESCRIPTION
Adds the initial version of [zed-groovy](https://github.com/valentinegb/zed-groovy). See [here](https://github.com/valentinegb/zed-groovy/releases/tag/v1.0.0) for release notes.

Closes #489 and closes #195.