### PR TITLE
Update Scala extension to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -520,7 +520,7 @@ version = "0.0.3"
 
 [scala]
 submodule = "extensions/scala"
-version = "0.0.1"
+version = "0.0.2"
 
 [scheme]
 submodule = "extensions/zed"


### PR DESCRIPTION
This updates the Scala extension to 0.0.2: https://github.com/scalameta/metals-zed

