### PR TITLE
Update Scala to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -520,7 +520,7 @@ version = "0.0.3"
 
 [scala]
 submodule = "extensions/scala"
-version = "0.0.2"
+version = "0.0.3"
 
 [scheme]
 submodule = "extensions/zed"


### PR DESCRIPTION
This updates the Scala extension to include the fix for `tailwindcss-language-server` support: https://github.com/scalameta/metals-zed/pull/8