### PR TITLE
Add neocmake extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,6 +306,10 @@
 	path = extensions/navi
 	url = https://github.com/navi-language/zed-navi.git
 
+[submodule "extensions/neocmake"]
+	path = extensions/neocmake
+	url = https://github.com/k0tran/zed_neocmake.git
+
 [submodule "extensions/neosolarized"]
 	path = extensions/neosolarized
 	url = https://github.com/carlocaione/NeoSolarized.zed.git
@@ -613,6 +617,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/neocmake"]
-	path = extensions/neocmake
-	url = git@github.com:k0tran/zed_neocmake.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -605,3 +605,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/neocmake"]
+	path = extensions/neocmake
+	url = git@github.com:k0tran/zed_neocmake.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -372,6 +372,10 @@ version = "0.0.2"
 submodule = "extensions/navi"
 version = "0.3.0"
 
+[neocmake]
+submodule = "extensions/neocmake"
+version = "0.0.1"
+
 [neosolarized]
 submodule = "extensions/neosolarized"
 version = "0.0.1"


### PR DESCRIPTION
Tested under Manjaro Linux x86_64 Zed 0.135.2

For tree sitter used [uyha/tree-sitter-cmake](https://github.com/uyha/tree-sitter-cmake)\
I'm not proficient with tree-sitter grammar so I took it from [helix](https://github.com/helix-editor/helix/tree/master/runtime/queries/cmake). Used a little higher tree-sitter version though (v0.3.0 instead of pre-v0.2.0 commit)

For LSP used [Decodetalkers/neocmakelsp](https://github.com/Decodetalkers/neocmakelsp) (that's why extension called neocmake). Another option would be [regen100/cmake-language-server](https://github.com/regen100/cmake-language-server), but it's written in python and says "Alpha Stage, work in progress." in the README.md