### PR TITLE
Add vscode-dark-modern theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -562,6 +562,10 @@
 	path = extensions/vitesse
 	url = https://github.com/d1y/vitesse.zed.git
 
+[submodule "extensions/vscode-dark-modern"]
+	path = extensions/vscode-dark-modern
+	url = https://github.com/kcamcam/vscode_dark_modern.zed.git
+
 [submodule "extensions/vscode-dark-plus"]
 	path = extensions/vscode-dark-plus
 	url = https://github.com/d1y/vscode_dark_plus.zed.git
@@ -609,6 +613,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/vscode-dark-modern"]
-	path = extensions/vscode-dark-modern
-	url = https://github.com/kcamcam/vscode_dark_modern.zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -609,3 +609,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/vscode-dark-modern"]
+	path = extensions/vscode-dark-modern
+	url = https://github.com/kcamcam/vscode_dark_modern.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -687,6 +687,10 @@ version = "0.0.2"
 submodule = "extensions/vitesse"
 version = "0.0.1"
 
+[vscode-dark-modern]
+submodule = "extensions/vscode-dark-modern"
+version = "0.0.1"
+
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"
 version = "0.0.1"


### PR DESCRIPTION
This pull request adds a port of Visual Studio Code's [Dark Modern](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/dark_modern.json) theme to Zed.
- https://github.com/kcamcam/vscode_dark_modern.zed

<img width="2560" alt="preview" src="https://github.com/zed-industries/extensions/assets/16027312/a497f014-abd3-4d8b-b8bd-9b92597ea567">
