### PR TITLE
Update Gleam to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -210,7 +210,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.1.2"
+version = "0.1.3"
 
 [glsl]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.1.3.

See https://github.com/zed-industries/zed/pull/12000 for the changes in this version.