### PR TITLE
ruby: Bump to 0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -529,7 +529,7 @@ version = "1.0.4"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.3"
+version = "0.0.4"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
Hi, this PR bumps the Ruby extension version to 0.0.4. Thanks.

See https://github.com/zed-industries/zed/pull/12101