### PR TITLE
Add CodeSandbox Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -78,6 +78,10 @@
 	path = extensions/cfengine
 	url = https://github.com/olehermanse/zed-cfengine.git
 
+[submodule "extensions/codesandbox-theme"]
+	path = extensions/codesandbox-theme
+	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git
+
 [submodule "extensions/colorizer"]
 	path = extensions/colorizer
 	url = https://github.com/tamimhasandev/colorizer.git
@@ -633,7 +637,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-
-[submodule "extensions/codesandbox-theme"]
-	path = extensions/codesandbox-theme
-	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -633,3 +633,7 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+
+[submodule "extensions/codesandbox-theme"]
+	path = extensions/codesandbox-theme
+	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -101,13 +101,13 @@ submodule = "extensions/zed"
 path = "extensions/clojure"
 version = "0.0.2"
 
-[colorizer]
-submodule = "extensions/colorizer"
-version = "0.0.3"
-
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
 version = "0.0.1"
+
+[colorizer]
+submodule = "extensions/colorizer"
+version = "0.0.3"
 
 [cosmos]
 submodule = "extensions/cosmos"

--- a/extensions.toml
+++ b/extensions.toml
@@ -101,6 +101,10 @@ version = "0.0.2"
 submodule = "extensions/colorizer"
 version = "0.0.3"
 
+[codesandbox-theme]
+submodule = "extensions/codesandbox-theme"
+version = "0.0.1"
+
 [cosmos]
 submodule = "extensions/cosmos"
 version = "0.0.1"


### PR DESCRIPTION
This PR brings the [CodeSandbox theme from VSCode](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects-theme) over to Zed, done using Zed's tool to convert VSCode themes. Works great from my testing. It has been requested [here](https://github.com/zed-industries/extensions/issues/544).

I have no affiliation with CodeSandbox in any way, hence the mentions of this theme being unofficial. 

I request this theme to be merged into the extensions repo and made available through the extensions store by the maintainers. Any feedback highly appreciated! 

![screen 2024-05-22 at 21 37 50](https://github.com/zed-industries/extensions/assets/32536904/9e707abc-f7f8-40e3-9788-843e38243cd6)

