### PR TITLE
Update Verilog to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -722,7 +722,7 @@ version = "0.0.1"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.2"
+version = "0.0.3"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
Adds support for the [veridian](https://github.com/vivekmalneedi/veridian) language server. Note that since builds published upstream for every platform I want to target, it uses its own builds that are build when I publish a release.