### PR TITLE
Add F# extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -170,6 +170,10 @@
 	path = extensions/fleet-themes
 	url = https://github.com/skarline/zed-fleet-themes.git
 
+[submodule "extensions/fsharp"]
+	path = extensions/fsharp
+	url = https://github.com/nathanjcollins/zed-fsharp.git
+
 [submodule "extensions/gdscript"]
 	path = extensions/gdscript
 	url = https://github.com/grndctrl/zed-gdscript.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -158,6 +158,10 @@
 	path = extensions/fleet-themes
 	url = https://github.com/skarline/zed-fleet-themes.git
 
+[submodule "extensions/fsharp"]
+	path = extensions/fsharp
+	url = https://github.com/nathanjcollins/zed-fsharp.git
+
 [submodule "extensions/gdscript"]
 	path = extensions/gdscript
 	url = https://github.com/grndctrl/zed-gdscript.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -170,10 +170,6 @@
 	path = extensions/fleet-themes
 	url = https://github.com/skarline/zed-fleet-themes.git
 
-[submodule "extensions/fsharp"]
-	path = extensions/fsharp
-	url = https://github.com/nathanjcollins/zed-fsharp.git
-
 [submodule "extensions/gdscript"]
 	path = extensions/gdscript
 	url = https://github.com/grndctrl/zed-gdscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -204,6 +204,10 @@ version = "0.0.7"
 submodule = "extensions/fleet-themes"
 version = "1.1.0"
 
+[fsharp]
+submodule = "extensions/fsharp"
+version = "0.0.1"
+
 [gdscript]
 submodule = "extensions/gdscript"
 version = "0.1.0"


### PR DESCRIPTION
This is a start to F# support in Zed. I have copied the `.scm` files from [here](https://github.com/ionide/tree-sitter-fsharp) and have fsautocomplete working.

Automatic installation doesn't seem to be possible as the extension api does not support installing through dotnet tools, but maybe I can implement this manually? I wasn't sure if this was an accepted way of doing it.

<img width="282" alt="image" src="https://github.com/zed-industries/extensions/assets/53304818/ceb7adc1-73e7-4429-8839-66e561ea4bc8">
I've come across one issue which seems to break fsautocomplete because there is a hidden character (FEFF) - which you can manually delete and fsautocomplete works as usual. Unsure if this is a me issue or a Zed issue.

Happy to take suggestions, as I'm pretty new to all this.

Would close #141 if accepted