### PR TITLE
php/ruby: Bump versions to 0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -501,7 +501,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.0.4"
+version = "0.0.5"
 
 [pica200]
 submodule = "extensions/pica200"
@@ -557,7 +557,7 @@ version = "1.0.4"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.4"
+version = "0.0.5"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
Includes: https://github.com/zed-industries/zed/pull/12237