### PR TITLE
Update Ruby to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -565,7 +565,7 @@ version = "1.0.4"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.5"
+version = "0.0.6"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
This PR updates the Ruby extension to v0.0.6.

See https://github.com/zed-industries/zed/pull/12395 for the changes in this version.