### PR TITLE
💾 Add Amber Monochrome Monitor CRT Phosphor theme

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -837,3 +837,6 @@ version = "0.0.3"
 submodule = "extensions/zed"
 path = "extensions/zig"
 version = "0.1.2"
+[amber-monochrome-monitor-crt-phosphor]
+submodule = "extensions/amber-monochrome-monitor-crt-phosphor"
+version = "0.1.3"


### PR DESCRIPTION
📺 This PR adds the Amber Monochrome Monitor CRT Phosphor theme for Zed.