### PR TITLE
serendipity: Bump to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -606,7 +606,7 @@ version = "0.0.3"
 
 [serendipity]
 submodule = "extensions/serendipity"
-version = "0.0.4"
+version = "0.0.5"
 
 [siri]
 submodule = "extensions/siri"


### PR DESCRIPTION
- Fixed Rust `type.interface` incorrect coloring
- Add Serendipity-style coloring for Cursor and Selection
-  Some minor syntax highlighting changes to make it similar to the Serendipity VSCode theme