### PR TITLE
Paginate results from the blob store

### DIFF
--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -239,9 +239,6 @@ async function getPublishedVersionsByExtensionId() {
       `Retrieved ${bucketList.Contents?.length} object(s) from bucket.`,
     );
     for (const object of bucketList.Contents ?? []) {
-      console.log(object.Key);
-      nextMarker = object.Key;
-
       const [_prefix, extensionId, version, _filename] =
         object.Key?.split("/") ?? [];
       assert.ok(extensionId, "No extension ID in blob store key.");
@@ -253,8 +250,9 @@ async function getPublishedVersionsByExtensionId() {
       publishedVersionsByExtensionId[extensionId] = publishedVersions;
     }
 
-    if (!bucketList.IsTruncated) {
-      nextMarker = undefined;
+    if (bucketList.Contents && bucketList.IsTruncated) {
+      const lastObject = bucketList.Contents[bucketList.Contents.length];
+      nextMarker = lastObject?.Key;
     }
   } while (nextMarker);
 

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -253,6 +253,8 @@ async function getPublishedVersionsByExtensionId() {
     if (bucketList.Contents && bucketList.IsTruncated) {
       const lastObject = bucketList.Contents[bucketList.Contents.length - 1];
       nextMarker = lastObject?.Key;
+    } else {
+      nextMarker = undefined;
     }
   } while (nextMarker);
 

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -225,6 +225,8 @@ async function getPublishedVersionsByExtensionId() {
     Prefix: `${EXTENSIONS_PREFIX}/`,
   });
 
+  console.log(bucketList.IsTruncated);
+
   /** @type {Record<string, string[]>} */
   const publishedVersionsByExtensionId = {};
   bucketList.Contents?.forEach((object) => {

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -251,7 +251,7 @@ async function getPublishedVersionsByExtensionId() {
     }
 
     if (bucketList.Contents && bucketList.IsTruncated) {
-      const lastObject = bucketList.Contents[bucketList.Contents.length];
+      const lastObject = bucketList.Contents[bucketList.Contents.length - 1];
       nextMarker = lastObject?.Key;
     }
   } while (nextMarker);

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -222,25 +222,38 @@ async function packageExtension(
 }
 
 async function getPublishedVersionsByExtensionId() {
-  const bucketList = await s3.listObjects({
-    Bucket: S3_BUCKET,
-    Prefix: `${EXTENSIONS_PREFIX}/`,
-  });
-
-  console.log(bucketList.IsTruncated);
+  let isTruncated = false;
+  /** @type {string | undefined} */
+  let nextMarker;
 
   /** @type {Record<string, string[]>} */
   const publishedVersionsByExtensionId = {};
-  bucketList.Contents?.forEach((object) => {
-    const [_prefix, extensionId, version, _filename] =
-      object.Key?.split("/") ?? [];
-    assert.ok(extensionId, "No extension ID in blob store key.");
-    assert.ok(version, "No version in blob store key.");
 
-    const publishedVersions = publishedVersionsByExtensionId[extensionId] ?? [];
-    publishedVersions.push(version);
-    publishedVersionsByExtensionId[extensionId] = publishedVersions;
-  });
+  do {
+    const bucketList = await s3.listObjects({
+      Bucket: S3_BUCKET,
+      Prefix: `${EXTENSIONS_PREFIX}/`,
+      ...(nextMarker ? { Marker: nextMarker } : {}),
+    });
+
+    console.log(
+      `Retrieved ${bucketList.Contents?.length} object(s) from bucket.`,
+    );
+    for (const object of bucketList.Contents ?? []) {
+      console.log(object.Key);
+      nextMarker = object.Key;
+
+      const [_prefix, extensionId, version, _filename] =
+        object.Key?.split("/") ?? [];
+      assert.ok(extensionId, "No extension ID in blob store key.");
+      assert.ok(version, "No version in blob store key.");
+
+      const publishedVersions =
+        publishedVersionsByExtensionId[extensionId] ?? [];
+      publishedVersions.push(version);
+      publishedVersionsByExtensionId[extensionId] = publishedVersions;
+    }
+  } while (isTruncated);
 
   return publishedVersionsByExtensionId;
 }

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -222,7 +222,6 @@ async function packageExtension(
 }
 
 async function getPublishedVersionsByExtensionId() {
-  let isTruncated = false;
   /** @type {string | undefined} */
   let nextMarker;
 
@@ -253,7 +252,11 @@ async function getPublishedVersionsByExtensionId() {
       publishedVersions.push(version);
       publishedVersionsByExtensionId[extensionId] = publishedVersions;
     }
-  } while (isTruncated);
+
+    if (!bucketList.IsTruncated) {
+      nextMarker = undefined;
+    }
+  } while (nextMarker);
 
   return publishedVersionsByExtensionId;
 }

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -89,6 +89,8 @@ try {
   await sortExtensionsToml("extensions.toml");
   await sortGitmodules(".gitmodules");
 
+  console.log(await getPublishedVersionsByExtensionId());
+
   const extensionIds = shouldPublish
     ? await unpublishedExtensionIds(extensionsToml)
     : await changedExtensionIds(extensionsToml);

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -89,8 +89,6 @@ try {
   await sortExtensionsToml("extensions.toml");
   await sortGitmodules(".gitmodules");
 
-  console.log(await getPublishedVersionsByExtensionId());
-
   const extensionIds = shouldPublish
     ? await unpublishedExtensionIds(extensionsToml)
     : await changedExtensionIds(extensionsToml);


### PR DESCRIPTION
This PR improves the way extensions are retrieved from the blob store to ensure that we're accounting for when they all don't fit in a single page of results.

I had noticed some issues where were starting to drop some extensions towards the end of the list when diffing to determine which extensions need to be published.