### PR TITLE
Add Nix extension with LSP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -394,6 +394,10 @@
 	path = extensions/nix
 	url = https://github.com/hasit/zed-nix.git
 
+[submodule "extensions/nix-language"]
+	path = extensions/nix-language
+	url = https://github.com/msanft/nix-zed
+
 [submodule "extensions/noir"]
 	path = extensions/noir
 	url = https://github.com/shuklaayush/zed-noir.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -465,6 +465,10 @@ version = "0.0.1"
 submodule = "extensions/nix"
 version = "0.0.4"
 
+[nix-language]
+submodule = "extensions/nix-language"
+version = "0.0.1"
+
 [noir]
 submodule = "extensions/noir"
 version = "0.0.1"


### PR DESCRIPTION
There is basic support for the Nix language through the [`nix`](https://github.com/hasit/zed-nix) extension, but it is unmaintained and doesn't have LSP support. 

This adds a more feature-rich extension with better completion and LSP support. I thought about replacing the previous Nix extension, but didn't want to cause any breakage for existing installations. Please let me know what'd be the preferred way to go about this.

See the LSP features, such as recognizing unused arguments:
![image](https://github.com/zed-industries/extensions/assets/58110325/36ce1b95-1830-45a9-b3f3-5ba033ff60e8)
