### PR TITLE
Update Vue to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -799,7 +799,7 @@ version = "0.0.2"
 [vue]
 submodule = "extensions/zed"
 path = "extensions/vue"
-version = "0.0.2"
+version = "0.0.3"
 
 [warp-one-dark]
 submodule = "extensions/warp-one-dark"


### PR DESCRIPTION
This PR updates the Vue extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/12656 for the changes in this version.