### PR TITLE
💾 Add Amber Monochrome Monitor CRT Phosphor theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -717,3 +717,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/amber-monochrome-monitor-crt-phosphor"]
+	path = extensions/amber-monochrome-monitor-crt-phosphor
+	url = https://github.com/takk8is/amber-monochrome-monitor-crt-phosphor-theme-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -849,3 +849,7 @@ version = "0.0.3"
 submodule = "extensions/zed"
 path = "extensions/zig"
 version = "0.1.2"
+
+[amber-monochrome-monitor-crt-phosphor]
+submodule = "extensions/amber-monochrome-monitor-crt-phosphor"
+version = "0.1.3"


### PR DESCRIPTION
📺 This PR adds the Amber Monochrome Monitor CRT Phosphor theme for Zed.

![Amber Monochrome Monitor CRT Phosphor](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/icon.jpg?raw=true)

# Amber Monochrome Monitor CRT Phosphor Theme for Zed

The "Amber Monochrome Monitor CRT Phosphor" theme brings the nostalgic essence of vintage amber phosphor monitors to your Zed editor. This theme is crafted to offer a unique and immersive visual experience, capturing the original charm of early computing displays. Available in both dark and light versions, the Amber Monochrome Monitor CRT Phosphor Theme transforms your coding environment with its distinct amber-on-black and amber-on-light-amber aesthetics.

## Theme Variants

The theme includes eight distinct variants, each designed to emulate specific types of CRT phosphors:

### Amber Monochrome Monitor CRT Phosphor Dark I

![Amber Monochrome Monitor CRT Phosphor Dark I](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-i.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark II

![Amber Monochrome Monitor CRT Phosphor Dark II](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-ii.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark III

![Amber Monochrome Monitor CRT Phosphor Dark III](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-iii.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P3

![Amber Monochrome Monitor CRT Phosphor Dark P3](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p3.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P12

![Amber Monochrome Monitor CRT Phosphor Dark P12](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p12.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P19

![Amber Monochrome Monitor CRT Phosphor Dark P19](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p19.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P25

![Amber Monochrome Monitor CRT Phosphor Dark P25](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p25.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P26

![Amber Monochrome Monitor CRT Phosphor Dark P26](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p26.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P33

![Amber Monochrome Monitor CRT Phosphor Dark P33](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p33.png?raw=true)

### Amber Monochrome Monitor CRT Phosphor Dark P38

![Amber Monochrome Monitor CRT Phosphor Dark P38](https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed/blob/main/assets/screenshot-dark-p38.png?raw=true)

## Theme Overview

The "Amber Monochrome Monitor CRT Phosphor" is designed to evoke the look and feel of classic CRT monitors, emphasizing simplicity and readability. The dark versions feature a predominantly black background with vibrant amber text and accents, while the light versions introduce a softer amber background for a refreshing contrast. Both versions maintain a consistent colour scheme that is easy on the eyes and suitable for long coding sessions.

### Installation Instructions

**1. Manual Install**

-   **Download**: Download the theme files (`amber-monochrome-monitor-crt-phosphor.json`) from the repository.
-   **Add**: Move the downloaded JSON file to the `~/.config/zed/themes/` directory on your macOS.
-   **Activate**: Open the Command Palette in Zed by typing `theme selector: toggle`, then search for "Amber Monochrome Monitor CRT Phosphor" to apply the theme.

**2. Install via Command Palette**

-   **Open**: Open the Command Palette in Zed by navigating to the menu and selecting `Go > Open Command Palette...`.
-   **Type**: Type `extensions` or `zed: extensions` in the Command Palette.
-   **Search**: Search for "Amber Monochrome Monitor CRT Phosphor" and install it directly from the extension marketplace.

**3. Activate**

-   **Open**: Open the Command Palette in Zed by navigating to the menu and selecting `Go > Open Command Palette...`.
-   **Type**: Type `theme selector: toggle`.
-   **Search**: Search for "Amber Monochrome Monitor CRT Phosphor" and select it from the list to activate the theme.

## Theme Details

### Amber Monochrome Monitor Dark Theme

-   **Accent Colours**: Various shades of amber for borders, highlights, and syntax elements.
-   **Syntax Highlighting**: Strong emphasis on readability with bold amber text for keywords, strings, and other elements.

### Amber Monochrome Monitor Light Theme

-   **Accent Colours**: Light amber tones for borders, highlights, and syntax elements.
-   **Syntax Highlighting**: Enhanced visibility with lighter amber text for keywords, strings, and other elements.

Both versions of the theme ensure a cohesive and immersive experience, making your coding environment visually appealing and reminiscent of classic amber phosphor monitors.

## Phosphor Specific Details

### Amber Monochrome Monitor CRT Phosphor P3 (Yellow)

-   **Colour**: #FFD700 (Amber Pure)
-   **Application**: First radars (C. 1939)

### Amber Monochrome Monitor CRT Phosphor P12 (Orange)

-   **Colour**: #FFA500 (Orange)
-   **Application**: Radar indicators

### Amber Monochrome Monitor CRT Phosphor P19 (Orange)

-   **Colour**: #FF8C00 (Dark orange)
-   **Application**: Radar screen

### Amber Monochrome Monitor CRT Phosphor P25 (Orange)

-   **Colour**: #FF4500 (Reddish orange)
-   **Application**: Military Displays with 2-10 seconds refresh interval

### Amber Monochrome Monitor CRT Phosphor P26 (Orange)

-   **Colour**: #FF7F50 (Coral)
-   **Application**: Radar

### Amber Monochrome Monitor CRT Phosphor P33 (LD Orange)

-   **Colour**: #FF8C00 (Dark orange)
-   **Application**: Radar screen

### Amber Monochrome Monitor CRT Phosphor P38 (LK Orange)

-   **Colour**: #FF4500 (Reddish orange)
-   **Application**: Radar screen

## Support

Experience the power of Zed by visiting their [official website](https://zed.dev/).

To contribute to public and social projects focused on research and artificial intelligence, feel free to support with any amount you prefer.

## About the Author

### Takk™ Innovate Studio

-   **Author**: David C Cavalcante
-   **LinkedIn**: [David C Cavalcante](https://www.linkedin.com/in/hellodav/)
-   **Medium**: [David C Cavalcante](https://medium.com/@davcavalcante/)
-   **Positive results, rapid innovation**
-   **Leading the Digital Revolution as the Pioneering 100% Artificial Intelligence Team**
-   **URL**: [Takk](https://takk.ag/)
-   **Twitter**: [Takk](https://twitter.com/takk8is/)
-   **Medium**: [Takk](https://takk8is.medium.com/)

Enjoy coding with the nostalgic and visually soothing aesthetics of the Amber Monochrome Monitor CRT Phosphor Theme. Whether you prefer the dark version's striking amber-on-black contrast or the light version's refreshing amber tones, this theme will enhance your Zed editor experience with a touch of vintage charm.