### PR TITLE
Add a script for sorting `extensions.toml` and `.gitmodules`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,10 @@
 package-extensions:
     pnpm package-extensions
 
+# Sorts the extensions.
+sort-extensions:
+    pnpm sort-extensions
+
 # Initializes the submodule at the given path.
 init-submodule SUBMODULE_PATH:
     git submodule update --init --recursive {{SUBMODULE_PATH}}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -p .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "package-extensions": "node src/package-extensions.js"
+    "package-extensions": "node src/package-extensions.js",
+    "sort-extensions": "node src/sort-extensions.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.454.0",

--- a/src/lib/extensions-toml.js
+++ b/src/lib/extensions-toml.js
@@ -1,0 +1,25 @@
+import toml from "@iarna/toml";
+import fs from "node:fs/promises";
+import { readTomlFile } from "./fs.js";
+
+/** @param {string} path */
+export async function sortExtensionsToml(path) {
+  const extensionsToml = await readTomlFile(path);
+
+  const extensionNames = Object.keys(extensionsToml);
+  extensionNames.sort();
+
+  /** @type {Record<string, any>} */
+  const sortedExtensionsToml = {};
+
+  for (const name of extensionNames) {
+    const entry = extensionsToml[name];
+    sortedExtensionsToml[name] = entry;
+  }
+
+  await fs.writeFile(
+    path,
+    toml.stringify(sortedExtensionsToml).trimEnd() + "\n",
+    "utf-8",
+  );
+}

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -3,6 +3,7 @@ import toml from "@iarna/toml";
 import assert from "node:assert";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { sortExtensionsToml } from "./lib/extensions-toml.js";
 import { fileExists, readTomlFile } from "./lib/fs.js";
 import {
   checkoutGitSubmodule,
@@ -299,26 +300,4 @@ async function changedExtensionIds(extensionsToml) {
 
   console.log("Extensions changed from main:", result.join(", "));
   return result;
-}
-
-/** @param {string} path */
-async function sortExtensionsToml(path) {
-  const extensionsToml = await readTomlFile(path);
-
-  const extensionNames = Object.keys(extensionsToml);
-  extensionNames.sort();
-
-  /** @type {Record<string, any>} */
-  const sortedExtensionsToml = {};
-
-  for (const name of extensionNames) {
-    const entry = extensionsToml[name];
-    sortedExtensionsToml[name] = entry;
-  }
-
-  await fs.writeFile(
-    path,
-    toml.stringify(sortedExtensionsToml).trimEnd() + "\n",
-    "utf-8",
-  );
 }

--- a/src/sort-extensions.js
+++ b/src/sort-extensions.js
@@ -1,0 +1,5 @@
+import { sortExtensionsToml } from "./lib/extensions-toml.js";
+import { sortGitmodules } from "./lib/git.js";
+
+await sortExtensionsToml("extensions.toml");
+await sortGitmodules(".gitmodules");


### PR DESCRIPTION
This PR adds a script for sorting `extensions.toml` and `.gitmodules`.

This was already done as part of the `package-extensions` script, but this standalone script will make it easier to run when you just care about the sorting.

It can be run with either `pnpm sort-extensions` or `just sort-extensions`.