### PR TITLE
Document sorting `extensions.toml` and `.gitmodules`

### DIFF
--- a/AUTHORING_EXTENSIONS.md
+++ b/AUTHORING_EXTENSIONS.md
@@ -134,6 +134,7 @@ In your PR do the following:
    submodule = "extensions/my-extension"
    version = "0.0.1"
    ```
+3. Run `pnpm sort-extensions` to ensure `extensions.toml` and `.gitmodules` are sorted
 
 Once your PR is merged, the extension will be packaged and published to the Zed extension registry.
 


### PR DESCRIPTION
This PR documents how to sort `extensions.toml` and `.gitmodules` to ensure they pass CI.

Resolves #919.