### PR TITLE
Add ChatGPT theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -98,6 +98,10 @@
 	path = extensions/cfengine
 	url = https://github.com/olehermanse/zed-cfengine.git
 
+[submodule "extensions/chatgpt"]
+	path = extensions/chatgpt
+	url = https://github.com/Takk8IS/chatgpt-theme-for-zed.git
+
 [submodule "extensions/city-lights"]
 	path = extensions/city-lights
 	url = https://github.com/DP19/zed-theme-city-lights.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -104,6 +104,10 @@ version = "0.0.1"
 submodule = "extensions/cfengine"
 version = "1.0.1"
 
+[chatgpt]
+submodule = "extensions/chatgpt"
+version = "0.1.1"
+
 [city-lights]
 submodule = "extensions/city-lights"
 version = "0.0.2"


### PR DESCRIPTION
📺 This PR adds the ChatGPT theme for Zed.

# ChatGPT Theme for Zed

The "ChatGPT" theme brings the clean and modern aesthetic of the ChatGPT interface to your Zed editor. Inspired by the sleek design and intuitive color scheme of ChatGPT, this theme offers a refreshing and visually appealing coding experience. Available in a dark version, the theme transforms your coding environment with its elegant and readable color palette.

## Theme Overview

The "ChatGPT" theme is designed to enhance readability and reduce eye strain during long coding sessions. The dark version features a predominantly black background with subtle highlights and accent colors, maintaining a consistent and professional look.

### Theme Screenshot

![ChatGPT (Playground)](https://github.com/Takk8IS/chatgpt-theme-for-zed/blob/main/assets/screenshot-dark.png?raw=true)

## Theme Details

### ChatGPT Dark Theme

-   **Accent Colours**: Various shades of green and blue for borders, highlights, and syntax elements.
-   **Syntax Highlighting**: Emphasis on readability with distinct colours for keywords, strings, and other elements.

The theme ensures a cohesive and immersive experience, making your coding environment visually appealing and modern.