### PR TITLE
Update AUTHORING_EXTENSIONS.md to use the command in package.json

### DIFF
--- a/AUTHORING_EXTENSIONS.md
+++ b/AUTHORING_EXTENSIONS.md
@@ -134,7 +134,7 @@ In your PR do the following:
    submodule = "extensions/my-extension"
    version = "0.0.1"
    ```
-3. Run `pnpm sort-extensions` to ensure `extensions.toml` and `.gitmodules` are sorted
+3. Run `pnpm fmt` to ensure `extensions.toml` and `.gitmodules` are sorted
 
 Once your PR is merged, the extension will be packaged and published to the Zed extension registry.
 


### PR DESCRIPTION
While authoring an extension i noticed this says to use "pnpm sort-extensions" but from the package.json it appears to be "pnpm fmt" 