### PR TITLE
Update VS Code Dark Modern theme to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -826,7 +826,7 @@ version = "0.0.1"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.0.1"
+version = "0.0.2"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"


### PR DESCRIPTION
This pull request updates the VS Code Dark Modern Them from `v0.0.1` to `v0.0.2`.

The new release simply fixes typo in the `extension.toml` file. Thanks for [pointing that out](https://github.com/kcamcam/vscode_dark_modern.zed/commit/4d2d1bd3a60d7fd2251dda0606022978c673c7c9) Moshyfawn.

The repository link was broken, https://github.com/kcamcma/vscode_dark_modern.zed (kcamcma), when it should have been https://github.com/kcamcam/vscode_dark_modern.zed (kcamcam).