### PR TITLE
Add Adwaita Pastel Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,10 @@
 	path = extensions/0x96f
 	url = https://github.com/filipjanevski/zed-theme.git
 
+[submodule "extensions/adwaita-pastel"]
+	path = extensions/adwaita-pastel
+	url = https://github.com/Benjamin-Davies/zed-theme-adwaita.git
+
 [submodule "extensions/alabaster"]
 	path = extensions/alabaster
 	url = https://github.com/tsimoshka/zed-theme-alabaster.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2,6 +2,10 @@
 submodule = "extensions/0x96f"
 version = "1.0.2"
 
+[adwaita-pastel]
+submodule = "extensions/adwaita-pastel"
+version = "0.0.1"
+
 [alabaster]
 submodule = "extensions/alabaster"
 version = "0.0.2"


### PR DESCRIPTION
Adds a theme based on the default GNOME apps but with more exciting syntax highlighting.

This theme differs from Zedwaita in that it provides better contrast for some frequently-used UI elements and takes a bolder approach to colors.