### PR TITLE
Log errors surfaced by the Zed extension CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZED_EXTENSION_CLI_SHA: 5ef75919f09e31c28b75c09e695946b6c4d9c3ee
+  ZED_EXTENSION_CLI_SHA: 2e87e1d26e86d0ce6f3d94b5d72782636330d24f
 
 jobs:
   package:

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -185,6 +185,13 @@ async function packageExtension(
   );
   console.log(zedExtensionOutput.stdout);
 
+  const warnings = zedExtensionOutput.stderr
+    .split("\n")
+    .filter((line) => line.includes("WARN"));
+  for (const warning of warnings) {
+    console.log(warning);
+  }
+
   const manifestJson = await fs.readFile(
     path.join(outputDir, "manifest.json"),
     "utf-8",


### PR DESCRIPTION
This PR updates CI to show warnings surfaced by the Zed extension CLI.

This PR also bumps the extension CLI version to https://github.com/zed-industries/zed/commit/2e87e1d26e86d0ce6f3d94b5d72782636330d24f.

This version includes the warnings about the deprecated theme key: https://github.com/zed-industries/zed/pull/13081