### PR TITLE
Add Luau extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -338,6 +338,10 @@
 	path = extensions/lox
 	url = https://github.com/arian81/zed-lox.git
 
+[submodule "extensions/luau"]
+	path = extensions/luau
+	url = https://github.com/4teapo/zed-luau
+
 [submodule "extensions/macos-classic"]
 	path = extensions/macos-classic
 	url = https://github.com/huacnlee/zed-theme-macos-classic.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -409,6 +409,10 @@ submodule = "extensions/zed"
 path = "extensions/lua"
 version = "0.0.2"
 
+[luau]
+submodule = "extensions/luau"
+version = "0.1.0"
+
 [macos-classic]
 submodule = "extensions/macos-classic"
 version = "0.0.8"

--- a/package.json
+++ b/package.json
@@ -23,5 +23,6 @@
     "prettier": "3.2.5",
     "typescript": "5.3.3",
     "vitest": "1.6.0"
-  }
+  },
+  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,5 @@
     "prettier": "3.2.5",
     "typescript": "5.3.3",
     "vitest": "1.6.0"
-  },
-  "packageManager": "pnpm@9.4.0+sha512.f549b8a52c9d2b8536762f99c0722205efc5af913e77835dbccc3b0b0b2ca9e7dc8022b78062c17291c48e88749c70ce88eb5a74f1fa8c4bf5e18bb46c8bd83a"
+  }
 }


### PR DESCRIPTION
Adds support for the Luau programming language.

Resolves https://github.com/zed-industries/extensions/issues/171.

Note: Diagnostics won't work in release builds until https://github.com/zed-industries/zed/pull/13102 is there. It will work if you temporarily build from main instead, as the PR is merged.