### PR TITLE
Update Cairo to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -90,7 +90,7 @@ version = "0.0.1"
 
 [cairo]
 submodule = "extensions/cairo"
-version = "0.0.1"
+version = "0.0.2"
 
 [call-trans-opt-received]
 submodule = "extensions/call-trans-opt-received"


### PR DESCRIPTION
updating cairo extension to version 0.0.2 which includes the official tree-sitter grammar from starkware