### PR TITLE
Update Luau to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -411,7 +411,7 @@ version = "0.0.2"
 
 [luau]
 submodule = "extensions/luau"
-version = "0.1.1"
+version = "0.1.2"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
Bumps grammar commit to fix a couple syntax highlighting issues.