### PR TITLE
Update Rego extension to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -620,7 +620,7 @@ version = "0.0.3"
 
 [rego]
 submodule = "extensions/rego"
-version = "0.0.1"
+version = "0.0.2"
 
 [rescript]
 submodule = "extensions/rescript"


### PR DESCRIPTION
We have pushed a new release of this extension here: https://github.com/StyraInc/zed-rego/releases/tag/v0.0.2