### PR TITLE
Update GraphQL extension to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -304,7 +304,7 @@ version = "0.2.0"
 
 [graphql]
 submodule = "extensions/graphql"
-version = "0.0.2"
+version = "0.0.3"
 
 [green-monochrome-monitor-crt-phosphor]
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"


### PR DESCRIPTION
Update graphql extension to v0.0.3

- Add `graphqls` file extension for schema files