### PR TITLE
Update Zig to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -921,4 +921,4 @@ version = "0.0.3"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.2"
+version = "0.1.3"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.3.
