### PR TITLE
Validate extension IDs

### DIFF
--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -1,3 +1,5 @@
+const EXTENSION_ID_PATTERN = /^[a-z0-9\-]+$/;
+
 /**
  * Exceptions to the rule of extension IDs ending in `-zed`.
  *
@@ -10,6 +12,12 @@ const EXTENSION_ID_ENDS_WITH_EXCEPTIONS = ["xy-zed"];
  */
 export function validateExtensionsToml(extensionsToml) {
   for (const [extensionId, _extensionInfo] of Object.entries(extensionsToml)) {
+    if (!EXTENSION_ID_PATTERN.test(extensionId)) {
+      throw new Error(
+        `Extension IDs must only consist of lowercase letters, numbers, and hyphens ('-'): "${extensionId}".`,
+      );
+    }
+
     if (extensionId.startsWith("zed-")) {
       throw new Error(
         `Extension IDs should not start with "zed-", as they are all Zed extensions: "${extensionId}".`,

--- a/src/lib/validation.test.js
+++ b/src/lib/validation.test.js
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { validateGitmodules, validateManifest } from "./validation.js";
+import {
+  validateExtensionsToml,
+  validateGitmodules,
+  validateManifest,
+} from "./validation.js";
 
 describe("validateManifest", () => {
   describe("given a valid manifest", () => {
@@ -24,6 +28,36 @@ describe("validateManifest", () => {
         `[Error: Extension names should not start with "Zed ", as they are all Zed extensions: "Zed Something".]`,
       );
     });
+  });
+});
+
+describe("validateExtensionsToml", () => {
+  describe("when `extensions.toml` only contains extensions with valid IDs", () => {
+    it.each(["my-cool-extension", "base16"])(
+      'does not throw for "%s"',
+      (extensionId) => {
+        const extensionsToml = {
+          [extensionId]: {},
+        };
+
+        expect(() => validateExtensionsToml(extensionsToml)).not.toThrow();
+      },
+    );
+  });
+
+  describe("when `extensions.toml` contains an extension ID with invalid characters", () => {
+    it.each(["BadExtension", "bad_extension"])(
+      'throws a validation error for "%s"',
+      (extensionId) => {
+        const extensionsToml = {
+          [extensionId]: {},
+        };
+
+        expect(() => validateExtensionsToml(extensionsToml)).toThrowError(
+          `Extension IDs must only consist of lowercase letters, numbers, and hyphens ('-'): "${extensionId}".`,
+        );
+      },
+    );
   });
 });
 


### PR DESCRIPTION
This PR adds additional validation for extension IDs to ensure they only contain valid characters.

Extension IDs must only consist of lowercase letters, numbers, and hyphens (`-`).