### PR TITLE
Update Prisma to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -618,7 +618,7 @@ version = "0.0.3"
 [prisma]
 submodule = "extensions/zed"
 path = "extensions/prisma"
-version = "0.0.2"
+version = "0.0.3"
 
 [purescript]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Prisma extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/13739 for the changes in this version.