### PR TITLE
Update Tokyo Night to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -274,7 +274,7 @@ version = "0.0.3"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"
-version = "0.0.1"
+version = "0.0.2"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"

--- a/extensions.toml
+++ b/extensions.toml
@@ -789,7 +789,7 @@ version = "0.0.1"
 
 [tokyo-night]
 submodule = "extensions/tokyo-night"
-version = "0.0.2"
+version = "0.1.0"
 
 [toml]
 submodule = "extensions/zed"

--- a/extensions.toml
+++ b/extensions.toml
@@ -789,7 +789,7 @@ version = "0.0.1"
 
 [tokyo-night]
 submodule = "extensions/tokyo-night"
-version = "0.1.0"
+version = "0.1.1"
 
 [toml]
 submodule = "extensions/zed"

--- a/extensions.toml
+++ b/extensions.toml
@@ -793,7 +793,7 @@ version = "0.0.1"
 
 [tokyo-night]
 submodule = "extensions/tokyo-night"
-version = "0.1.1"
+version = "0.1.2"
 
 [toml]
 submodule = "extensions/zed"


### PR DESCRIPTION
Updates `tokyo-night` to v0.1.2 - fixes contrast issues.