### PR TITLE
Update OCaml to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -556,7 +556,7 @@ version = "0.2.0"
 [ocaml]
 submodule = "extensions/zed"
 path = "extensions/ocaml"
-version = "0.0.1"
+version = "0.0.2"
 
 [ocean-dark-motifs]
 submodule = "extensions/ocean-dark-motifs"


### PR DESCRIPTION
This PR updates the OCaml extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/13864 for the changes in this version.