### PR TITLE
Update Lua to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -427,7 +427,7 @@ version = "0.0.1"
 [lua]
 submodule = "extensions/zed"
 path = "extensions/lua"
-version = "0.0.2"
+version = "0.0.3"
 
 [luau]
 submodule = "extensions/luau"


### PR DESCRIPTION
This PR updates the Lua extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/13882 for the changes in this version.