### PR TITLE
Update Beancount to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -54,7 +54,7 @@ version = "0.0.1"
 
 [beancount]
 submodule = "extensions/beancount"
-version = "0.0.2"
+version = "0.0.3"
 
 [bend]
 submodule = "extensions/bend"


### PR DESCRIPTION
This PR updates the Beancount extension to v0.0.3.

Changes:

- https://github.com/zed-extensions/beancount/pull/1