### PR TITLE
Add Slim template language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -598,6 +598,10 @@
 	path = extensions/slate
 	url = https://github.com/someone13574/zed-slate-theme.git
 
+[submodule "extensions/slim"]
+	path = extensions/slim
+	url = https://github.com/calmyournerves/zed-slim.git
+
 [submodule "extensions/slint"]
 	path = extensions/slint
 	url = https://gitlab.com/flukejones/zed-slint.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -704,6 +704,10 @@ version = "0.0.5"
 submodule = "extensions/slate"
 version = "0.0.2"
 
+[slim]
+submodule = "extensions/slim"
+version = "1.0.0"
+
 [slint]
 submodule = "extensions/slint"
 version = "0.0.3"


### PR DESCRIPTION
Adds support for [Slim templates](https://github.com/slim-template/slim) (#140).

This is based on https://github.com/kolen/tree-sitter-slim, ~but currently uses my fork as some PRs are still open upstream that will (hopefully) be merged soon~.