### PR TITLE
Update Clojure to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -131,7 +131,7 @@ version = "0.0.2"
 [clojure]
 submodule = "extensions/zed"
 path = "extensions/clojure"
-version = "0.0.2"
+version = "0.0.3"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"


### PR DESCRIPTION
This PR updates the Clojure extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/13935 for the changes in this version.