### PR TITLE
Bump Fortran to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -250,7 +250,7 @@ version = "1.1.0"
 
 [fortran]
 submodule = "extensions/fortran"
-version = "0.0.1"
+version = "0.0.2"
 
 [frosted-theme]
 submodule = "extensions/frosted-theme"


### PR DESCRIPTION
This PR updates the Fortran extension to 0.0.2
Changes:  https://github.com/Xavier-Maruff/zed-fortran/pull/1