### PR TITLE
Update VSCode Dark Modern theme to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -915,7 +915,7 @@ version = "0.0.1"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.0.2"
+version = "0.0.3"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"

--- a/extensions.toml
+++ b/extensions.toml
@@ -826,7 +826,7 @@ version = "0.0.1"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.0.1"
+version = "0.0.2"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"


### PR DESCRIPTION
This pull request updates the VSCode Dark Modern Theme from `v0.0.2` to `v0.0.3`.

Changes: 
- https://github.com/kcamcam/vscode_dark_modern.zed/pull/1 by @nikeee

### Before
Active line background
<img width="2560" alt="Screenshot 2024-07-11 at 10 36 51 PM" src="https://github.com/user-attachments/assets/99180fc6-ea74-437b-ac32-b6bd0945ad63">
Highlighted line background
<img width="2560" alt="Screenshot 2024-07-11 at 10 37 00 PM" src="https://github.com/user-attachments/assets/fc41d69e-c933-4a44-89d3-0d14ecbe533a">

### After
Active line background
<img width="2560" alt="Screenshot 2024-07-11 at 10 38 11 PM" src="https://github.com/user-attachments/assets/c4d526b7-0f5e-4863-ace1-5b29d919b756">
Highlighted line background
<img width="2560" alt="Screenshot 2024-07-11 at 10 38 19 PM" src="https://github.com/user-attachments/assets/9ab94b29-b22c-411f-a982-f1bcabb7b78e">
