### PR TITLE
php: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -665,7 +665,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.0.6"
+version = "0.1.0"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
This PR updates the PHP extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/14607 for the changes in this version.

Of note, this version of the PHP extension now supports [Phpactor](https://github.com/phpactor/phpactor) as a language server.