### PR TITLE
svelte: Bump to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -836,7 +836,7 @@ version = "0.0.1"
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"
-version = "0.0.1"
+version = "0.0.3"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.0.3.

See https://github.com/zed-industries/zed/pull/14650 for the changes in this version.