### PR TITLE
zig: Bump to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1017,4 +1017,4 @@ version = "0.0.3"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.3"
+version = "0.1.4"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.4.

See https://github.com/zed-industries/zed/pull/14651 for the changes in this version.