### PR TITLE
elixir: Bump to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -215,7 +215,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.5"
+version = "0.0.6"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.6.

See https://github.com/zed-industries/zed/pull/14657 for the changes in this version.