### PR TITLE
ruby: Bump to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -737,7 +737,7 @@ version = "1.0.7"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.7"
+version = "0.0.8"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"


### PR DESCRIPTION
This pull request updates the Ruby extension to v0.0.8.

Please see https://github.com/zed-industries/zed/pull/14707 for the changes in this version.