### PR TITLE
vue: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -972,7 +972,7 @@ version = "0.0.2"
 [vue]
 submodule = "extensions/zed"
 path = "extensions/vue"
-version = "0.0.3"
+version = "0.1.0"
 
 [wakfu-theme]
 submodule = "extensions/wakfu-theme"


### PR DESCRIPTION
This PR updates the Vue extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/14748 for the changes in this version.