### PR TITLE
Add Tomorrow Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -893,3 +893,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/tomorrow-theme"]
+	path = extensions/tomorrow-theme
+	url = https://github.com/biaqat/tomorrow-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -770,6 +770,10 @@
 	path = extensions/tokyo-night
 	url = https://github.com/ssaunderss/zed-tokyo-night.git
 
+[submodule "extensions/tomorrow-theme"]
+	path = extensions/tomorrow-theme
+	url = https://github.com/biaqat/tomorrow-theme-zed.git
+
 [submodule "extensions/tsar"]
 	path = extensions/tsar
 	url = https://github.com/x032205/tsar-zed-theme.git
@@ -893,6 +897,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/tomorrow-theme"]
-	path = extensions/tomorrow-theme
-	url = https://github.com/biaqat/tomorrow-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -896,6 +896,10 @@ submodule = "extensions/zed"
 path = "extensions/toml"
 version = "0.1.1"
 
+[tomorrow-theme]
+submodule = "extensions/tomorrow-theme"
+version = "0.5.0"
+
 [tsar]
 submodule = "extensions/tsar"
 version = "0.0.2"


### PR DESCRIPTION
Port of chriskempson's [Tomorrow Theme](<https://github.com/chriskempson/tomorrow-theme?tab=readme-ov-file>)  as well as some specific alternate versions: (VSCode's [_Tomorrow Night Blue_](<https://arc.net/l/quote/nbuipqzx>), [mdBook](<https://rust-lang.github.io/mdBook/for_developers/preprocessors.html>)'s _Coal_, and [_rusty.nvim_](<https://github.com/namrabtw/rusty.nvim?tab=readme-ov-file>)).
 
Comes with the variants specified in the Tomorrow Theme repo as well as 2 minimal variants for less highlights.

### Preview:
<table>
  <tr>
    <td rowspan="2"><img src="https://github.com/bIaqat/tomorrow-theme-zed/raw/main/assets/tomorrow-night.png" width="500"></td>
    <td><img src="https://github.com/bIaqat/tomorrow-theme-zed/raw/main/assets/tomorrow.png" width="250"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/bIaqat/tomorrow-theme-zed/raw/main/assets/tomorrow-night-blue.png" width="250"></td>
  </tr>
</table>

I think this could close #593 as the Blue variant is based off of VSCode's Tomorrow Night Blue.