### PR TITLE
Add PowerShell extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -694,13 +694,13 @@
 	path = extensions/poimandres
 	url = https://github.com/mshaugh/poimandres.zed.git
 
-[submodule "extensions/powershell"]
-	path = extensions/powershell
-	url = https://github.com/wingyplus/zed-powershell.git
-
 [submodule "extensions/polar-theme"]
 	path = extensions/polar-theme
 	url = https://github.com/biaqat/polar-theme-zed.git
+
+[submodule "extensions/powershell"]
+	path = extensions/powershell
+	url = https://github.com/wingyplus/zed-powershell.git
 
 [submodule "extensions/python-refactoring"]
 	path = extensions/python-refactoring

--- a/.gitmodules
+++ b/.gitmodules
@@ -614,6 +614,10 @@
 	path = extensions/poimandres
 	url = https://github.com/mshaugh/poimandres.zed.git
 
+[submodule "extensions/powershell"]
+	path = extensions/powershell
+	url = https://github.com/wingyplus/zed-powershell.git
+
 [submodule "extensions/qml"]
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -695,6 +695,10 @@ version = "0.1.0"
 submodule = "extensions/poimandres"
 version = "0.0.3"
 
+[powershell]
+submodule = "extensions/powershell"
+version = "0.1.0"
+
 [prisma]
 submodule = "extensions/zed"
 path = "extensions/prisma"


### PR DESCRIPTION
This commit add a PowerShell extension by support 2 features, the grammar and the language server. But at this moment, the language server still needs to configure the PowerShellEditorServices directory though the `lsp` configuration.

The grammar, I use https://github.com/airbus-cert/tree-sitter-powershell. And the language server uses https://github.com/PowerShell/PowerShellEditorServices.

Closes #496