### PR TITLE
Update Monospace theme

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -559,7 +559,7 @@ version = "0.1.0"
 
 [monospace-theme]
 submodule = "extensions/monospace-theme"
-version = "0.1.1"
+version = "0.1.2"
 
 [msun-dark]
 submodule = "extensions/msun-dark"


### PR DESCRIPTION
Updated the version number from 0.1.1 to 0.1.2

Changes:
- Fixed the attribute color being the same as JSX tag color