### PR TITLE
astro: Update to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -37,7 +37,7 @@ version = "0.0.1"
 [astro]
 submodule = "extensions/zed"
 path = "extensions/astro"
-version = "0.0.3"
+version = "0.1.0"
 
 [aura-theme]
 submodule = "extensions/aura"


### PR DESCRIPTION
This PR updates the Astro extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/15172 for the changes in this version.