### PR TITLE
deno: Update to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -198,7 +198,7 @@ version = "0.0.8"
 [deno]
 submodule = "extensions/zed"
 path = "extensions/deno"
-version = "0.0.1"
+version = "0.0.2"
 
 [docker-compose]
 submodule = "extensions/docker-compose"


### PR DESCRIPTION
This PR updates the Deno extension to v0.0.2.

See https://github.com/zed-industries/zed/pull/15173 for the changes in this version.