### PR TITLE
terraform: Update to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -902,7 +902,7 @@ version = "0.0.2"
 [terraform]
 submodule = "extensions/zed"
 path = "extensions/terraform"
-version = "0.0.3"
+version = "0.0.4"
 
 [terrible-theme]
 submodule = "extensions/terrible-theme"


### PR DESCRIPTION
This PR updates the Terraform extension to v0.0.4.

See https://github.com/zed-industries/zed/pull/15174 for the changes in this version.