### PR TITLE
zig: Bump to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1066,4 +1066,4 @@ version = "0.0.3"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.4"
+version = "0.1.5"


### PR DESCRIPTION
This PR updates the Zig extension to v0.1.5.

See https://github.com/zed-industries/zed/pull/15203 for the changes in this version.