### PR TITLE
kotlin: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -438,7 +438,7 @@ version = "0.0.1"
 
 [kotlin]
 submodule = "extensions/kotlin"
-version = "0.0.4"
+version = "0.1.0"
 
 [ktrz-monokai]
 submodule = "extensions/ktrz-monokai"


### PR DESCRIPTION
This PR updates the Kotlin extension to v0.1.0.

See https://github.com/zed-extensions/kotlin/pull/18 for the changes in this version.