### PR TITLE
Update github-dark-default to v1.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -322,7 +322,7 @@ version = "0.0.2"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
-version = "0.0.1"
+version = "1.0.5"
 
 [github-theme]
 submodule = "extensions/github-theme"


### PR DESCRIPTION
Release notes:

https://github.com/MordFustang21/zed-github-dark/releases/tag/v1.0.5