### PR TITLE
Add Blueprint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,6 +90,10 @@
 	path = extensions/blanche
 	url = https://github.com/kwonoj/zed-blanche.git
 
+[submodule "extensions/blueprint"]
+	path = extensions/blueprint
+	url = https://github.com/tfuxu/zed-blueprint.git
+
 [submodule "extensions/bqn"]
 	path = extensions/bqn
 	url = https://github.com/DavidZwitser/zed-bqn.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -96,6 +96,10 @@ version = "0.0.2"
 submodule = "extensions/blanche"
 version = "0.0.1"
 
+[blueprint]
+submodule = "extensions/blueprint"
+version = "0.1.0"
+
 [bqn]
 submodule = "extensions/bqn"
 version = "0.0.1"


### PR DESCRIPTION
Adds LSP and syntax highlighting support for [Blueprint](https://jwestman.pages.gitlab.gnome.org/blueprint-compiler/) (.blp) files.