### PR TITLE
Add perm extension for perm file support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -630,6 +630,10 @@
 	path = extensions/penumbra
 	url = https://github.com/jbisits/penumbra-zed.git
 
+[submodule "extensions/perm"]
+	path = extensions/perm
+	url = git@github.com:theoriginalstove/perm.git
+
 [submodule "extensions/pest"]
 	path = extensions/pest
 	url = https://github.com/pest-parser/zed-pest.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -632,7 +632,7 @@
 
 [submodule "extensions/perm"]
 	path = extensions/perm
-	url = git@github.com:theoriginalstove/perm.git
+	url = https://github.com/theoriginalstove/perm.git
 
 [submodule "extensions/pest"]
 	path = extensions/pest

--- a/extensions.toml
+++ b/extensions.toml
@@ -706,6 +706,10 @@ version = "1.0.1"
 submodule = "extensions/penumbra"
 version = "0.0.1"
 
+[perm]
+submodule = "extensions/perm"
+version = "0.0.1"
+
 [pest]
 submodule = "extensions/pest"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -708,7 +708,7 @@ version = "0.0.1"
 
 [perm]
 submodule = "extensions/perm"
-version = "0.0.1"
+version = "0.0.2"
 
 [pest]
 submodule = "extensions/pest"

--- a/extensions.toml
+++ b/extensions.toml
@@ -708,7 +708,7 @@ version = "0.0.1"
 
 [perm]
 submodule = "extensions/perm"
-version = "0.0.2"
+version = "0.0.3"
 
 [pest]
 submodule = "extensions/pest"

--- a/extensions.toml
+++ b/extensions.toml
@@ -708,7 +708,7 @@ version = "0.0.1"
 
 [perm]
 submodule = "extensions/perm"
-version = "0.0.3"
+version = "0.0.4"
 
 [pest]
 submodule = "extensions/pest"


### PR DESCRIPTION
`perm` files are used by [Permify](https://github.com/Permify/permify) to define authorization schemas within their DSL. This extension provides basic highlighting support for some keywords.