### PR TITLE
Bump catppuccin to v0.2.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -130,7 +130,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.9"
+version = "0.2.10"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"


### PR DESCRIPTION
workaround for https://github.com/zed-industries/zed/issues/15383
