### PR TITLE
Add Curry extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -170,6 +170,10 @@
 	path = extensions/cue
 	url = https://github.com/jkasky/zed-cue.git
 
+[submodule "extensions/curry"]
+	path = extensions/curry
+	url = https://github.com/fwcd/zed-curry.git
+
 [submodule "extensions/d"]
 	path = extensions/d
 	url = https://github.com/staysail/zed-d.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -186,6 +186,10 @@ version = "0.0.1"
 submodule = "extensions/cue"
 version = "0.0.2"
 
+[curry]
+submodule = "extensions/curry"
+version = "0.0.1"
+
 [d]
 submodule = "extensions/d"
 version = "0.0.4"


### PR DESCRIPTION
This adds [`zed-curry`](https://github.com/fwcd/zed-curry), an extension providing language support for the [Curry programming language](https://en.wikipedia.org/wiki/Curry_(programming_language)).

![Screenshot 2024-07-28 at 23 13 56](https://github.com/user-attachments/assets/e89312d4-3bfa-4b4f-80aa-9b78116a6c6b)
