### PR TITLE
Bump D extension to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -192,7 +192,7 @@ version = "0.0.1"
 
 [d]
 submodule = "extensions/d"
-version = "0.0.6"
+version = "0.0.7"
 
 [dart]
 submodule = "extensions/zed"

--- a/extensions.toml
+++ b/extensions.toml
@@ -192,7 +192,7 @@ version = "0.0.1"
 
 [d]
 submodule = "extensions/d"
-version = "0.0.4"
+version = "0.0.5"
 
 [dart]
 submodule = "extensions/zed"

--- a/extensions.toml
+++ b/extensions.toml
@@ -192,7 +192,7 @@ version = "0.0.1"
 
 [d]
 submodule = "extensions/d"
-version = "0.0.5"
+version = "0.0.6"
 
 [dart]
 submodule = "extensions/zed"


### PR DESCRIPTION
This adds improvements in syntax handling for newer D editions, and improved highlighting for embedded escape sequences.