### PR TITLE
Update Melange theme to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -539,7 +539,7 @@ version = "0.0.4"
 
 [melange]
 submodule = "extensions/melange"
-version = "0.0.1"
+version = "0.0.2"
 
 [mellow]
 submodule = "extensions/mellow"


### PR DESCRIPTION
Fix missing `element.background` in Melange Dark.