### PR TITLE
Update github-dark-default to 1.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -346,7 +346,7 @@ version = "0.0.2"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
-version = "1.0.5"
+version = "1.0.6"
 
 [github-theme]
 submodule = "extensions/github-theme"


### PR DESCRIPTION
Release notes:

https://github.com/MordFustang21/zed-github-dark/releases/tag/v1.0.6