### PR TITLE
Add rst extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -686,6 +686,10 @@
 	path = extensions/rose-pine-theme
 	url = https://github.com/rose-pine/zed
 
+[submodule "extensions/rst"]
+	path = extensions/rst
+	url = https://github.com/elmarco/zed-rst.git
+
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -782,6 +782,10 @@ version = "0.0.1"
 submodule = "extensions/rose-pine-theme"
 version = "1.0.7"
 
+[rst]
+submodule = "extensions/rst"
+version = "0.0.1"
+
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"


### PR DESCRIPTION
This adds [`zed-rst`](https://github.com/elmarco/zed-rst), an extension providing language support for the [reStructuredText markup syntax](https://docutils.sourceforge.io/rst.html).

#1168

![Screenshot from 2024-07-31 12-52-17](https://github.com/user-attachments/assets/8ca4a08c-57cc-4151-b359-116cd9601b2a)