### PR TITLE
Revert "Add Monokai Theme"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -502,10 +502,6 @@
 	path = extensions/modest-dark
 	url = https://github.com/timcole/modest-dark.git
 
-[submodule "extensions/monokai"]
-	path = extensions/monokai
-	url = https://github.com/billgo/monokai.git
-
 [submodule "extensions/monolith"]
 	path = extensions/monolith
 	url = https://github.com/someone13574/zed-monolith-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -573,10 +573,6 @@ version = "0.0.1"
 submodule = "extensions/modest-dark"
 version = "0.1.2"
 
-[monokai]
-submodule = "extensions/monokai"
-version = "0.1.0"
-
 [monolith]
 submodule = "extensions/monolith"
 version = "0.0.3"


### PR DESCRIPTION
@billgo simply copied the [zedokai](https://github.com/slymax/zedokai) extension and changed the name without permission or attribution.

Except for name and author, the extension is identical to zedokai.