### PR TITLE
Add RCL configuration language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -686,6 +686,10 @@
 	path = extensions/rainbow-csv
 	url = https://github.com/weartist/zed-rainbow-csv.git
 
+[submodule "extensions/rcl"]
+	path = extensions/rcl
+	url = https://github.com/rcl-lang/zed-rcl.git
+
 [submodule "extensions/rego"]
 	path = extensions/rego
 	url = https://github.com/StyraInc/zed-rego.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -782,6 +782,10 @@ version = "0.0.1"
 submodule = "extensions/rainbow-csv"
 version = "0.0.3"
 
+[rcl]
+submodule = "extensions/rcl"
+version = "0.5.0"
+
 [rego]
 submodule = "extensions/rego"
 version = "0.0.2"


### PR DESCRIPTION
This adds the https://github.com/rcl-lang/zed-rcl extension, which contains a grammar for https://rcl-lang.org/.

(I am the author of both.)