### PR TITLE
Add playdate extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -662,6 +662,10 @@
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git
 
+[submodule "extensions/playdate-zed-extension"]
+	path = extensions/playdate
+	url = https://github.com/notpeter/playdate-zed-extension.git
+
 [submodule "extensions/poimandres"]
 	path = extensions/poimandres
 	url = https://github.com/mshaugh/poimandres.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -743,6 +743,10 @@ version = "0.0.1"
 submodule = "extensions/pkl"
 version = "0.1.0"
 
+[playdate]
+submodule = "extensions/playdate"
+version = "0.1.0"
+
 [poimandres]
 submodule = "extensions/poimandres"
 version = "0.0.4"


### PR DESCRIPTION
Add [notpeter/playdate-zed-extension](https://github.com/notpeter/playdate-zed-extension).
Includes syntax highlighting for Panic PlaydateSDK custom formats:

- [tree-sitter-pdxinfo](https://github.com/notpeter/tree-sitter-pdxinfo)
- [tree-sitter-animationtxt](https://github.com/notpeter/tree-sitter-animationtxt)
