### PR TITLE
ruby: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -833,7 +833,7 @@ version = "0.0.1"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.0.8"
+version = "0.1.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
This pull request updates the Ruby extension to v0.1.0.

Please see https://github.com/zed-industries/zed/pull/15855 for the changes in this version.