### PR TITLE
elixir: Bump to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -255,7 +255,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.6"
+version = "0.0.7"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.7.

See https://github.com/zed-industries/zed/pull/15867 for the changes in this version.