### PR TITLE
Update meson extension to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -571,7 +571,7 @@ version = "0.0.1"
 
 [meson]
 submodule = "extensions/meson"
-version = "0.1.0"
+version = "0.1.1"
 
 [min-theme]
 submodule = "extensions/min-theme"


### PR DESCRIPTION
Updating my meson extension from `0.1.0` to `0.1.1`, fixing the LSP not being executable.