### PR TITLE
gleam: Revert v0.1.4 bump

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -363,7 +363,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.1.4"
+version = "0.1.3"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"


### PR DESCRIPTION
This PR reverts the v0.1.4 version bump of the Gleam extension from #1215, as it isn't ready to be released.