### PR TITLE
Add Python Refactoring extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -678,6 +678,10 @@
 	path = extensions/polar-theme
 	url = https://github.com/biaqat/polar-theme-zed.git
 
+[submodule "extensions/python-refactoring"]
+	path = extensions/python-refactoring
+	url = https://github.com/rowillia/zed-python-refactoring.git
+
 [submodule "extensions/qml"]
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -678,6 +678,10 @@
 	path = extensions/polar-theme
 	url = https://github.com/biaqat/polar-theme-zed.git
 
+[submodule "extensions/python-refactoring"]
+	path = extensions/python-refactoring
+	url = https://github.com/rowillia/zed-python-refactoring
+
 [submodule "extensions/qml"]
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git
@@ -969,10 +973,6 @@
 [submodule "extensions/zed"]
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
-
-[submodule "extensions/zed-python-refactoring"]
-	path = extensions/zed-python-refactoring
-	url = git@github.com:rowillia/zed-python-refactoring.git
 
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai

--- a/.gitmodules
+++ b/.gitmodules
@@ -970,6 +970,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-python-refactoring"]
+	path = extensions/zed-python-refactoring
+	url = git@github.com:rowillia/zed-python-refactoring.git
+
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai
 	url = https://github.com/slymax/zedokai.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -989,3 +989,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/zed-python-refactoring"]
+	path = extensions/zed-python-refactoring
+	url = git@github.com:rowillia/zed-python-refactoring.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -970,10 +970,6 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
-[submodule "extensions/zed-python-refactoring"]
-	path = extensions/zed-python-refactoring
-	url = git@github.com:rowillia/zed-python-refactoring.git
-
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai
 	url = https://github.com/slymax/zedokai.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -678,10 +678,6 @@
 	path = extensions/polar-theme
 	url = https://github.com/biaqat/polar-theme-zed.git
 
-[submodule "extensions/python-refactoring"]
-	path = extensions/python-refactoring
-	url = https://github.com/rowillia/zed-python-refactoring
-
 [submodule "extensions/qml"]
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git
@@ -974,6 +970,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-python-refactoring"]
+	path = extensions/zed-python-refactoring
+	url = git@github.com:rowillia/zed-python-refactoring.git
+
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai
 	url = https://github.com/slymax/zedokai.git
@@ -989,6 +989,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/zed-python-refactoring"]
-	path = extensions/zed-python-refactoring
-	url = git@github.com:rowillia/zed-python-refactoring.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -769,6 +769,10 @@ submodule = "extensions/zed"
 path = "extensions/purescript"
 version = "0.0.1"
 
+[python_refactoring]
+submodule = "extensions/zed-python-refactoring"
+version = "0.0.3"
+
 [qml]
 submodule = "extensions/qml"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -769,8 +769,8 @@ submodule = "extensions/zed"
 path = "extensions/purescript"
 version = "0.0.1"
 
-[python_refactoring]
-submodule = "extensions/zed-python-refactoring"
+[python-refactoring]
+submodule = "extensions/python-refactoring"
 version = "0.0.3"
 
 [qml]

--- a/extensions.toml
+++ b/extensions.toml
@@ -770,7 +770,7 @@ path = "extensions/purescript"
 version = "0.0.1"
 
 [python-refactoring]
-submodule = "extensions/zed-python-refactoring"
+submodule = "extensions/python-refactoring"
 version = "0.0.3"
 
 [qml]

--- a/extensions.toml
+++ b/extensions.toml
@@ -770,7 +770,7 @@ path = "extensions/purescript"
 version = "0.0.1"
 
 [python-refactoring]
-submodule = "extensions/python-refactoring"
+submodule = "extensions/zed-python-refactoring"
 version = "0.0.3"
 
 [qml]


### PR DESCRIPTION
I wrote a LSP implementation, powered by `libcst`, to support basic refactoring support - [`cst-lsp`](https://github.com/rowillia/cst-lsp)

Currently it just supports "Extract Method" but adds the framework needed to support more refactoring easily. 

https://github.com/user-attachments/assets/53edc63a-8aa3-425e-bd9e-4e05ba17042e

