### PR TITLE
Add Gruvbox-ish

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -350,6 +350,10 @@
 	path = extensions/gruber-flavors
 	url = https://github.com/biaqat/gruber-theme-zed.git
 
+[submodule "extensions/gruvbox-ish"]
+	path = extensions/gruvbox-ish
+	url = https://github.com/LeoDog896/zed-gruvbox-ish
+
 [submodule "extensions/gruvbox-material"]
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -406,6 +406,10 @@ version = "0.0.4"
 submodule = "extensions/gruber-flavors"
 version = "0.5.0"
 
+[gruvbox-ish]
+submodule = "extensions/gruvbox-ish"
+version = "0.0.1"
+
 [gruvbox-material]
 submodule = "extensions/gruvbox-material"
 version = "1.0.0"


### PR DESCRIPTION
adds the [gruvbox-ish](https://github.com/LeoDog896/zed-gruvbox-ish) theme ([original](https://github.com/graceful-potato/gruvbox-ish)).

**Note**: I have not explicitly licensed the previous repository. I've contacted the author of `gruvbox-ish` by email, where they said "Of course you can port/modify or do whatever you want with it." If there's some extra requirement for licensing, I can ask for explicit licensing 👍 