### PR TITLE
Add gosum extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -330,6 +330,10 @@
 	path = extensions/golangci-lint
 	url = https://github.com/j4ng5y/zed_golangci_lint
 
+[submodule "extensions/gosum"]
+	path = extensions/gosum
+	url = https://github.com/kartikvashistha/zed-gosum.git
+
 [submodule "extensions/graphene"]
 	path = extensions/graphene
 	url = https://github.com/adinack/graphene.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1009,7 +1009,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-
-[submodule "extensions/go-sum"]
-	path = extensions/go-sum
-	url = https://github.com/kartikvashistha/zed-gosum

--- a/.gitmodules
+++ b/.gitmodules
@@ -997,3 +997,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/go-sum"]
+	path = extensions/go-sum
+	url = https://github.com/kartikvashistha/zed-gosum

--- a/.gitmodules
+++ b/.gitmodules
@@ -997,6 +997,7 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+
 [submodule "extensions/go-sum"]
 	path = extensions/go-sum
 	url = https://github.com/kartikvashistha/zed-gosum

--- a/extensions.toml
+++ b/extensions.toml
@@ -382,6 +382,10 @@ version = "0.1.0"
 submodule = "extensions/golangci-lint"
 version = "0.1.0"
 
+[go-sum]
+submodule = "extensions/go-sum"
+version = "0.0.1"
+
 [graphene]
 submodule = "extensions/graphene"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -386,8 +386,8 @@ version = "0.1.0"
 submodule = "extensions/golangci-lint"
 version = "0.1.0"
 
-[go-sum]
-submodule = "extensions/go-sum"
+[gosum]
+submodule = "extensions/gosum"
 version = "0.0.1"
 
 [graphene]


### PR DESCRIPTION
Add highlighting support for Go Checksum files. Addresses [this](https://github.com/zed-industries/zed/pull/7139#issuecomment-1919761603).

<img width="1728" alt="Screenshot 2024-08-11 at 14 57 47" src="https://github.com/user-attachments/assets/88af9c7f-b219-426e-aa9d-42b959f1bfcc">
