### PR TITLE
haskell: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -429,7 +429,7 @@ version = "0.0.2"
 [haskell]
 submodule = "extensions/zed"
 path = "extensions/haskell"
-version = "0.1.0"
+version = "0.1.1"
 
 [hex-light-theme]
 submodule = "extensions/hex-light-theme"


### PR DESCRIPTION
This PR updates the Haskell extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/16228 for the changes in this version.