### PR TITLE
Bump extension CLI version to `18aff55`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ZED_EXTENSION_CLI_SHA: 423c7b999a07d5f5ab82c58ac99f6b0684be50d0
+  ZED_EXTENSION_CLI_SHA: 18aff55f342448401a4dd40747f106a639b73e25
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/18aff55f342448401a4dd40747f106a639b73e25.