### PR TITLE
gleam: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -371,7 +371,7 @@ version = "0.0.2"
 [gleam]
 submodule = "extensions/zed"
 path = "extensions/gleam"
-version = "0.1.3"
+version = "0.2.0"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.2.0.

See https://github.com/zed-industries/zed/pull/16258 for the changes in this version.