### PR TITLE
zig: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1171,4 +1171,4 @@ version = "0.0.4"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.1.5"
+version = "0.2.0"


### PR DESCRIPTION
This PR updates the Zig extension to v0.2.0.

See https://github.com/zed-industries/zed/pull/16261 for the changes in this version.