### PR TITLE
Add Fennel extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1057,6 +1057,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/zed-lang-fennel"]
-	path = extensions/zed-lang-fennel
-	url = https://codeberg.org/mattly/zed-lang-fennel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1029,3 +1029,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/zed-lang-fennel"]
+	path = extensions/zed-lang-fennel
+	url = https://codeberg.org/mattly/zed-lang-fennel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -282,6 +282,10 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
+[submodule "extensions/fennel"]
+	path = extensions/fennel
+	url = https://codeberg.org/mattly/zed-lang-fennel.git
+
 [submodule "extensions/fish"]
 	path = extensions/fish
 	url = https://github.com/hasit/zed-fish.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -329,7 +329,7 @@ submodule = "extensions/exquisite"
 version = "0.1.3"
 
 [fennel]
-submmodule = "extensions/fennel"
+submodule = "extensions/fennel"
 version = "0.0.1"
 
 [fish]

--- a/extensions.toml
+++ b/extensions.toml
@@ -308,6 +308,10 @@ version = "0.0.2"
 submodule = "extensions/exquisite"
 version = "0.1.3"
 
+[fennel]
+submmodule = "extensions/fennel"
+version = "0.0.1"
+
 [fish]
 submodule = "extensions/fish"
 version = "0.0.8"


### PR DESCRIPTION
Does not currently support the LSP, because AFAICT Zed only supports LSPs hosted on Github