### PR TITLE
Add Malibu Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -482,6 +482,10 @@
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
 
+[submodule "extensions/malibu-theme"]
+	path = extensions/malibu-theme
+	url = https://github.com/michael-andreuzza/malibu-theme-zed.git
+
 [submodule "extensions/mariana-theme"]
 	path = extensions/mariana-theme
 	url = https://github.com/biaqat/mariana-theme-zed.git
@@ -1029,6 +1033,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/malibu-theme"]
-	path = extensions/malibu-theme
-	url = https://github.com/michael-andreuzza/malibu-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1029,3 +1029,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/malibu-theme"]
+	path = extensions/malibu-theme
+	url = https://github.com/michael-andreuzza/malibu-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -498,8 +498,8 @@
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
 
-[submodule "extensions/malibu-theme"]
-	path = extensions/malibu-theme
+[submodule "extensions/malibu"]
+	path = extensions/malibu
 	url = https://github.com/michael-andreuzza/malibu-theme-zed.git
 
 [submodule "extensions/mariana-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -569,8 +569,8 @@ version = "0.1.0"
 submodule = "extensions/make"
 version = "1.0.1"
 
-[malibu-theme]
-submodule = "extensions/malibu-theme"
+[malibu]
+submodule = "extensions/malibu"
 version = "0.0.1"
 
 [mariana-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1172,3 +1172,7 @@ version = "0.0.4"
 submodule = "extensions/zed"
 path = "extensions/zig"
 version = "0.2.0"
+
+[malibu-theme]
+submodule = "extensions/malibu-theme"
+version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -553,6 +553,10 @@ version = "0.1.0"
 submodule = "extensions/make"
 version = "1.0.1"
 
+[malibu-theme]
+submodule = "extensions/malibu-theme"
+version = "0.0.1"
+
 [mariana-theme]
 submodule = "extensions/mariana-theme"
 version = "0.7.0"
@@ -1172,7 +1176,3 @@ version = "0.0.4"
 submodule = "extensions/zed"
 path = "extensions/zig"
 version = "0.2.0"
-
-[malibu-theme]
-submodule = "extensions/malibu-theme"
-version = "0.0.1"


### PR DESCRIPTION
This pull request adds the Malibu theme as a submodule to the Zed repository. 
The theme is located in the `extensions/malibu-theme` directory and is registered in the `extensions.toml` file with version 0.0.1.
