### PR TITLE
Update Melange theme to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -583,7 +583,7 @@ version = "0.0.4"
 
 [melange]
 submodule = "extensions/melange"
-version = "0.0.2"
+version = "0.0.3"
 
 [mellow]
 submodule = "extensions/mellow"


### PR DESCRIPTION
Fix Inline Assist background colors

- Add `deleted.background` to dark and light variants
- Modify `info.background` in dark and light variants
- Lighten `surface.background` in light variant