### PR TITLE
elixir: Bump to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -263,7 +263,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.7"
+version = "0.0.8"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.8.

See https://github.com/zed-industries/zed/pull/16495 for the changes in this version.