### PR TITLE
Update vala to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1060,7 +1060,7 @@ version = "0.2.0"
 
 [vala]
 submodule = "extensions/vala"
-version = "0.1.0"
+version = "0.2.0"
 
 [vale]
 submodule = "extensions/vale"


### PR DESCRIPTION
Release notes:

https://github.com/FyraLabs/zed-vala/releases/tag/v0.2.0