### PR TITLE
zig: Bump to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1171,4 +1171,4 @@ version = "0.0.4"
 [zig]
 submodule = "extensions/zed"
 path = "extensions/zig"
-version = "0.2.0"
+version = "0.3.0"


### PR DESCRIPTION
This PR updates the Zig extension to v0.3.0.

See zed-industries/zed/pull/16669 for a changelog.