### PR TITLE
kotlin: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -522,7 +522,7 @@ version = "0.0.1"
 
 [kotlin]
 submodule = "extensions/kotlin"
-version = "0.1.0"
+version = "0.1.1"
 
 [ktrz-monokai]
 submodule = "extensions/ktrz-monokai"


### PR DESCRIPTION
This PR updates the Kotlin extension to v0.1.1.

See https://github.com/zed-extensions/kotlin/pull/21 for the changes in this version.