### PR TITLE
swift: Bump to v0.3.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1013,7 +1013,7 @@ version = "0.0.3"
 
 [swift]
 submodule = "extensions/swift"
-version = "0.3.0"
+version = "0.3.1"
 
 [syntax]
 submodule = "extensions/syntax"


### PR DESCRIPTION
This PR updates the Swift extension to v0.3.1.

See https://github.com/zed-extensions/swift/pull/16 for the changes in this version.