### PR TITLE
elixir: Bump to v0.0.9

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -287,7 +287,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.0.8"
+version = "0.0.9"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.0.9.

See https://github.com/zed-industries/zed/pull/16879 for the changes in this version.