### PR TITLE
Add Code::Stats extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -186,6 +186,10 @@
 	path = extensions/cobalt2
 	url = https://github.com/wesbos/cobalt2-zed.git
 
+[submodule "extensions/code-stats"]
+	path = extensions/code-stats
+	url = https://github.com/maxdeviant/zed-code-stats.git
+
 [submodule "extensions/codesandbox-theme"]
 	path = extensions/codesandbox-theme
 	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -197,6 +197,10 @@ version = "0.0.3"
 submodule = "extensions/cobalt2"
 version = "0.1.0"
 
+[code-stats]
+submodule = "extensions/code-stats"
+version = "0.1.0"
+
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
 version = "0.0.5"


### PR DESCRIPTION
This PR adds an extension for using Zed with [Code::Stats](https://codestats.net/).