### PR TITLE
Update Scala to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -938,7 +938,7 @@ version = "1.0.1"
 
 [scala]
 submodule = "extensions/scala"
-version = "0.0.3"
+version = "0.0.4"
 
 [scheme]
 submodule = "extensions/zed"


### PR DESCRIPTION
Update Scala extension to the newest available version. Includes:
* https://github.com/scalameta/metals-zed/pull/15
* https://github.com/scalameta/metals-zed/pull/18
* https://github.com/scalameta/metals-zed/pull/19
* https://github.com/scalameta/metals-zed/pull/20