### PR TITLE
Add phpactor based lsp for PHP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1097,3 +1097,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/php-phpactor"]
+	path = extensions/php-phpactor
+	url = https://github.com/jelmervdl/phpactor-lsp-zed-extension.git


### PR DESCRIPTION
Adds a LSP for PHP using Phpactor.

The phar is downloaded to the extension's work directory if it isn't already there. It assumes you have PHP installed on your machine.

It's pretty barebones, but functional. I wanted to add an update check, but the only way I know how to get the version from phpactor is by running it with `--version` and parsing the output. But I couldn't find a way to do this from the extension.