### PR TITLE
Add Sourcepawn language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -894,6 +894,10 @@
 	path = extensions/solidity
 	url = https://github.com/zarifpour/zed-solidity.git
 
+[submodule "extensions/sourcepawn"]
+	path = extensions/sourcepawn
+	url = https://github.com/tsuza/zed-sourcepawn-ext.git
+
 [submodule "extensions/sql"]
 	path = extensions/sql
 	url = https://github.com/nervenes/zed-sql.git
@@ -1101,6 +1105,3 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
-[submodule "extensions/sourcepawn"]
-	path = extensions/sourcepawn
-	url = https://github.com/tsuza/zed-sourcepawn-ext.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1101,3 +1101,6 @@
 [submodule "extensions/zedwaita"]
 	path = extensions/zedwaita
 	url = https://github.com/someone13574/zed-adwaita-theme.git
+[submodule "extensions/sourcepawn"]
+	path = extensions/sourcepawn
+	url = https://github.com/tsuza/zed-sourcepawn-ext.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1010,6 +1010,10 @@ version = "0.0.1"
 submodule = "extensions/solidity"
 version = "0.1.3"
 
+[sourcepawn]
+submodule = "extensions/sourcepawn"
+version = "0.0.1"
+
 [sql]
 submodule = "extensions/sql"
 version = "1.1.2"


### PR DESCRIPTION
[Sourcepawn](https://github.com/alliedmodders/sourcepawn) is a fork of a language called "Pawn", formerly known as "Small", which is a C-like language generally used for scripting. Sourcepawn was mainly made for [Sourcemod](https://www.sourcemod.net/), which is a modding framework for the Source engine.

Throughout the years, Sourcepawn has completely diverged from Pawn, both syntax-wise and back-end wise, becoming completely different from Pawn, so before anyone says "can't the support be added to Pawn then?", no, it can't.

The extension works fine. It correctly highlights code & the LSP functions correctly. Unfortunately Zed's themes are extremely barebones due to their small number of captures, so some specific highlights do not work. But this is not a big problem.