### PR TITLE
code-stats: Bump to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -199,7 +199,7 @@ version = "0.1.0"
 
 [code-stats]
 submodule = "extensions/code-stats"
-version = "0.2.1"
+version = "0.2.2"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"


### PR DESCRIPTION
This PR updates the Code::Stats extension to v0.2.2.