### PR TITLE
Bump Mariana to v0.9.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -611,7 +611,7 @@ version = "0.0.1"
 
 [mariana-theme]
 submodule = "extensions/mariana-theme"
-version = "0.7.0"
+version = "0.9.0"
 
 [marine-dark]
 submodule = "extensions/marine-dark"


### PR DESCRIPTION
- Changed colors of hint popups to be less bright
  - Also changed Sublime Mariana's hints to match the colors in sublime (thanks @unixtensor)
- Added indent colors for rainbow and normal indent guidelines
- Fixed minor contrast highlights (element.select and a few others)

### Preview Changes
<table>
  <tr>
    <td rowspan="2"><img src="https://github.com/user-attachments/assets/89ecc10b-9a04-48fb-9f94-5588ffac88da" width="500"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/facfa6d0-f033-4754-b714-f5353805bf37" width="500"></td>
  </tr>
</table>
<table>
  <tr>
<td rowspan="2"><img src="https://github.com/user-attachments/assets/dd6acd7b-73f4-4165-bd4e-b5f1efde04db" width="500"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/aa158849-73f2-4d0d-ab11-0931afd80eb2" width="500"></td>
  </tr>
</table>