### PR TITLE
Ignore lock files for other package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 .env
 build
 node_modules
+
+# We only use pnpm.
 bun.lockb
+package-lock.json
+yarn.lock
 
 # Zed extension CLI.
 zed-extension


### PR DESCRIPTION
This PR adds the lock files for other Node package managers to the `.gitignore`, as we only want to use pnpm.