### PR TITLE
ruby: Bump version to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -945,7 +945,7 @@ version = "0.0.1"
 [ruby]
 submodule = "extensions/zed"
 path = "extensions/ruby"
-version = "0.1.0"
+version = "0.2.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Please see https://github.com/zed-industries/zed/pull/17128 for list of changes. Thanks!