### PR TITLE
stimulus: Bump version to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1060,7 +1060,7 @@ version = "0.2.0"
 
 [stimulus]
 submodule = "extensions/stimulus"
-version = "0.0.1"
+version = "0.0.2"
 
 [strace]
 submodule = "extensions/strace"


### PR DESCRIPTION
Just [a maintenance release](https://github.com/vitallium/zed-stimulus/releases/tag/v0.0.2) to upgrade the `zed-extensions-api` crate to v0.1.0. Thanks!