### PR TITLE
marksman: Bump version to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -647,7 +647,7 @@ version = "0.0.4"
 
 [marksman]
 submodule = "extensions/marksman"
-version = "0.0.1"
+version = "0.0.2"
 
 [material-dark]
 submodule = "extensions/material-dark"


### PR DESCRIPTION
Just [a maintenance release](https://github.com/vitallium/zed-marksman/releases/tag/v0.0.2) to upgrade the `zed-extensions-api` crate to v0.1.0. Thanks!