### PR TITLE
Update Hex themes to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -485,7 +485,7 @@ version = "0.1.1"
 
 [hex-light-theme]
 submodule = "extensions/hex-light-theme"
-version = "0.0.2"
+version = "0.0.3"
 
 [hlsl]
 submodule = "extensions/hlsl"


### PR DESCRIPTION
support players for Itg flat Dark.