### PR TITLE
Add OMNeT++ extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -774,6 +774,10 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
+[submodule "extensions/omnetpp-zed"]
+	path = extensions/omnetpp-zed
+	url = https://github.com/omnetpp/omnetpp-zed
+
 [submodule "extensions/one-dark-darkened"]
 	path = extensions/one-dark-darkened
 	url = https://github.com/pavles6/one-dark-darkened

--- a/.gitmodules
+++ b/.gitmodules
@@ -774,9 +774,10 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
-[submodule "extensions/omnetpp-zed"]
+
+[submodule "extensions/omnetpp"]
 	path = extensions/omnetpp
-	url = https://github.com/omnetpp/omnetpp-zed
+	url = https://github.com/omnetpp/omnetpp-zed.git
 
 [submodule "extensions/one-dark-darkened"]
 	path = extensions/one-dark-darkened

--- a/.gitmodules
+++ b/.gitmodules
@@ -774,7 +774,6 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
-
 [submodule "extensions/omnetpp"]
 	path = extensions/omnetpp
 	url = https://github.com/omnetpp/omnetpp-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -775,7 +775,7 @@
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
 [submodule "extensions/omnetpp-zed"]
-	path = extensions/omnetpp-zed
+	path = extensions/omnetpp
 	url = https://github.com/omnetpp/omnetpp-zed
 
 [submodule "extensions/one-dark-darkened"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -850,6 +850,11 @@ version = "0.1.0"
 submodule = "extensions/oh-lucy"
 version = "0.0.1"
 
+[omnetpp]
+submodule = "extensions/omnetpp-zed"
+path = "extensions/omnetpp"
+version = "0.0.1"
+
 [one-dark-darkened]
 submodule = "extensions/one-dark-darkened"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -852,7 +852,6 @@ version = "0.0.1"
 
 [omnetpp]
 submodule = "extensions/omnetpp-zed"
-path = "extensions/omnetpp"
 version = "0.0.1"
 
 [one-dark-darkened]

--- a/extensions.toml
+++ b/extensions.toml
@@ -851,7 +851,7 @@ submodule = "extensions/oh-lucy"
 version = "0.0.1"
 
 [omnetpp]
-submodule = "extensions/omnetpp-zed"
+submodule = "extensions/omnetpp"
 version = "0.0.1"
 
 [one-dark-darkened]


### PR DESCRIPTION
NED and MSG (extensions .ned and .msg) are DSLs for the OMNeT++ network simulator. They are used by model frameworks for OMNeT++, such as the INET framework, Simu5G, Veins, etc. We are the team that develops [OMNeT++](https://github.com/omnetpp/omnetpp) and the [INET Framework](https://github.com/inet-framework/) and we have created tree-sitter grammars for these languages, as well as an extension for the Zed editor.