### PR TITLE
Add Sublime Mariana theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -962,6 +962,10 @@
 	path = extensions/struct-theme
 	url = https://gitlab.com/Fake.User/struct-zed-theme
 
+[submodule "extensions/sublime-mariana-theme"]
+	path = extensions/sublime-mariana-theme
+	url = https://github.com/hnatiukr/zed-mariana-theme.git
+
 [submodule "extensions/swift"]
 	path = extensions/swift
 	url = https://github.com/samuser107/zed-swift-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1078,6 +1078,10 @@ version = "0.0.2"
 submodule = "extensions/struct-theme"
 version = "0.0.1"
 
+[sublime-mariana-theme]
+submodule = "extensions/sublime-mariana-theme"
+version = "1.1.0"
+
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"


### PR DESCRIPTION
Theme, that imitates Sublime Text 4's Mariana theme.

The Mariana color scheme is known for its cool, muted tones that provide a soothing yet vibrant coding environment, making it easy on the eyes during long coding sessions. This theme avoids the use of _cursive or italic_ styles, ensuring a consistent and clean look across all text elements for enhanced readability and focus.

There are two distinct variations: `Sublime Mariana` and Sublime Breakers. Theme variation closely mirrors the original, offering a cool, muted color scheme that’s easy on the eyes.

![mariana-zed](https://github.com/user-attachments/assets/7f6c7f6b-eeb8-4e17-930b-74d65ec6c2e1)

> [!NOTE]  
> I’m aware that a [similar theme](https://github.com/biaqat/mariana-theme-zed/tree/f5a79b6a20628a155c339d19e43a31719e0c7636) already exists, but this version offers some key differences. Notably, it contains only two color schemas and uses only the normal text style, with no italic or bold elements, to provide a clean and uniform appearance throughout. If you decide to decline this PR due to the similar existing theme, no problem—just wanted to share an alternative version!