### PR TITLE
svelte: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1081,7 +1081,7 @@ version = "0.0.1"
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"
-version = "0.0.3"
+version = "0.1.0"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/17364 for the changes in this version.