### PR TITLE
terraform: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1106,7 +1106,7 @@ version = "0.0.3"
 [terraform]
 submodule = "extensions/zed"
 path = "extensions/terraform"
-version = "0.0.4"
+version = "0.1.0"
 
 [terrible-theme]
 submodule = "extensions/terrible-theme"


### PR DESCRIPTION
This PR updates the Terraform extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/17365 for the changes in this version.