### PR TITLE
svelte: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1089,7 +1089,7 @@ version = "0.0.1"
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"
-version = "0.1.0"
+version = "0.1.1"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/17414 for the changes in this version.