### PR TITLE
Update Fountain to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -382,7 +382,7 @@ version = "0.0.2"
 
 [fountain]
 submodule = "extensions/fountain"
-version = "0.0.6"
+version = "0.0.7"
 
 [frosted-theme]
 submodule = "extensions/frosted-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -382,7 +382,7 @@ version = "0.0.2"
 
 [fountain]
 submodule = "extensions/fountain"
-version = "0.0.5"
+version = "0.0.6"
 
 [frosted-theme]
 submodule = "extensions/frosted-theme"


### PR DESCRIPTION
Tree-sitter grammar had some false matches that I tried to improve before but didn't manage. Now I managed by adding a match for false character names with higher priority and making sure scene descriptions cannot be empty.