### PR TITLE
Update Jinja2 to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -542,7 +542,7 @@ version = "0.2.2"
 
 [jinja2]
 submodule = "extensions/jinja2"
-version = "0.0.1"
+version = "0.0.2"
 
 [jsonnet]
 submodule = "extensions/jsonnet"


### PR DESCRIPTION
Add support a new `.j2` path suffix and bump version for Jinja2