### PR TITLE
Add GitHub Monochrome theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -370,10 +370,6 @@
 	path = extensions/github-dark-default
 	url = https://github.com/MordFustang21/zed-github-dark.git
 
-[submodule "extensions/github-monochrome-zed"]
-	path = extensions/github-monochrome-zed
-	url = https://github.com/Nishantdd/github-monochrome-zed.git
-
 [submodule "extensions/github-theme"]
 	path = extensions/github-theme
 	url = https://github.com/PyaeSoneAungRgn/github-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -370,6 +370,10 @@
 	path = extensions/github-dark-default
 	url = https://github.com/MordFustang21/zed-github-dark.git
 
+[submodule "extensions/github-monochrome-zed"]
+	path = extensions/github-monochrome-zed
+	url = https://github.com/Nishantdd/github-monochrome-zed.git
+
 [submodule "extensions/github-theme"]
 	path = extensions/github-theme
 	url = https://github.com/PyaeSoneAungRgn/github-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -370,6 +370,10 @@
 	path = extensions/github-dark-default
 	url = https://github.com/MordFustang21/zed-github-dark.git
 
+[submodule "extensions/github-monochrome-theme"]
+	path = extensions/github-monochrome-theme
+	url = https://github.com/Nishantdd/github-monochrome-zed.git
+
 [submodule "extensions/github-theme"]
 	path = extensions/github-theme
 	url = https://github.com/PyaeSoneAungRgn/github-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -416,6 +416,10 @@ version = "0.0.2"
 submodule = "extensions/github-dark-default"
 version = "1.0.6"
 
+[github-monochrome-zed]
+submodule = "extensions/github-monochrome-zed"
+version = "0.0.1"
+
 [github-theme]
 submodule = "extensions/github-theme"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -416,8 +416,8 @@ version = "0.0.2"
 submodule = "extensions/github-dark-default"
 version = "1.0.6"
 
-[github-monochrome-zed]
-submodule = "extensions/github-monochrome-zed"
+[github-monochrome-theme]
+submodule = "extensions/github-monochrome-theme"
 version = "0.0.1"
 
 [github-theme]


### PR DESCRIPTION
Monochrome theme based on github's light mode syntax highlighting
![py](https://github.com/user-attachments/assets/3a2673ab-fa89-4b83-8c73-33e80fd6b2f6)
