### PR TITLE
Add adaltas-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,10 @@
 	path = extensions/ada
 	url = https://github.com/wisn/zed-ada-language.git
 
+[submodule "extensions/adaltas-theme"]
+  path = extensions/adaltas-theme
+  url = https://github.com/adaltas/zed-adaltas-theme.git
+
 [submodule "extensions/adwaita-pastel"]
 	path = extensions/adwaita-pastel
 	url = https://github.com/Benjamin-Davies/zed-theme-adwaita.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -6,6 +6,10 @@ version = "1.2.0"
 submodule = "extensions/ada"
 version = "0.2.0"
 
+[adaltas-theme]
+submodule = "extensions/adaltas-theme"
+version = "0.0.1"
+
 [adwaita-pastel]
 submodule = "extensions/adwaita-pastel"
 version = "0.0.2"


### PR DESCRIPTION
The Adaltas theme is an elegantly designed dark theme with sharp contrast colors for the Zed editor. The theme is MIT licensed.

<img width="1315" alt="preview" src="https://github.com/user-attachments/assets/c7565619-7a59-425c-b518-33ad8bfd436c">
