### PR TITLE
Update LaTeX to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -598,7 +598,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.0.5"
+version = "0.0.6"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
New feature:
- Read LSP binary setting for `texlab`

Fix:
- Correct error in outlines