### PR TITLE
php: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -889,7 +889,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.1.3"
+version = "0.2.0"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
This PR updates the PHP extension to v0.2.0.

See https://github.com/zed-industries/zed/pull/17674 for the changes in this version.