### PR TITLE
erlang: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -346,7 +346,7 @@ version = "0.0.1"
 [erlang]
 submodule = "extensions/zed"
 path = "extensions/erlang"
-version = "0.0.1"
+version = "0.1.0"
 
 [everforest]
 submodule = "extensions/everforest"


### PR DESCRIPTION
This PR updates the Erlang extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/17679 for the changes in this version.