### PR TITLE
Bump verilog to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1232,7 +1232,7 @@ version = "0.0.1"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.3"
+version = "0.0.4"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
- Adds syntax highlighting to `.svh` files.