### PR TITLE
add Github themes v0.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -394,6 +394,10 @@
 	path = extensions/github-theme
 	url = https://github.com/PyaeSoneAungRgn/github-zed-theme.git
 
+[submodule "extensions/github-themes"]
+	path = extensions/github-themes
+	url = https://github.com/claytercek/github-zed-themes.git
+
 [submodule "extensions/glazier"]
 	path = extensions/glazier
 	url = https://github.com/airgap/glazier.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -440,6 +440,10 @@ version = "0.0.1"
 submodule = "extensions/github-theme"
 version = "0.0.2"
 
+[github-themes]
+submodule = "extenions/github-themes"
+version = "0.0.1"
+
 [glazier]
 submodule = "extensions/glazier"
 version = "0.0.2"


### PR DESCRIPTION
this adds 9 new themes, all generated from the official github design system, [primer](https://primer.style/).

- Github Dark Default
- Github Dark Colorblind
- Github Dark Dimmed
- Github Dark High Contrast
- Github Dark Tritanopia
- Github Light Default
- Github Light Colorblind
- Github Light High Contrast
- Github Light Tritanopia

This is different from the existing `github theme` extension because it includes themes for _all_ primer color schemes (similar to the github VSCode themes), and generates them directly from the primer npm package. 