### PR TITLE
Update LaTeX to 0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -602,7 +602,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.0.6"
+version = "0.0.7"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
Enhancement: download `texlab` if not on PATH or provided in settings.
Fix: auto-closing bracket conflicts.