### PR TITLE
neosolarized: Bump to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -759,7 +759,7 @@ version = "0.0.5"
 
 [neosolarized]
 submodule = "extensions/neosolarized"
-version = "0.0.1"
+version = "0.0.2"
 
 [new-darcula]
 submodule = "extensions/new-darcula"


### PR DESCRIPTION
Use `extension.toml` instead of `extension.json`.