### PR TITLE
Add Kanagawa theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -510,6 +510,10 @@
 	path = extensions/just
 	url = https://github.com/jackTabsCode/zed-just.git
 
+[submodule "extensions/kanagawa-theme"]
+	path = extensions/kanagawa-theme
+	url = https://github.com/IYair/kanagawa-theme.git
+
 [submodule "extensions/kanagawa-themes"]
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -576,6 +576,10 @@ version = "0.1.2"
 submodule = "extensions/just"
 version = "0.1.2"
 
+[kanagawa-theme]
+submodule = "extensions/kanagawa-theme"
+version = "0.0.1"
+
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

This PR introduces the Kanagawa theme for Zed with three unique variants:
- **Wave**: A calm dark theme with cool blue and green tones
- **Dragon**: A vibrant dark theme featuring deep reds and rich greens
- **Lotus**: A light theme with soft, warm pastel colors

## Changes

- Added three theme JSON files for each variant
- Ensured terminal colors match the overall theme aesthetic
- Included README with detailed installation and usage instructions

## How to Test

1. Clone the repository and navigate to the extension directory.
2. Install the extension locally using the Zed CLI: `zed install path/to/extension`.
3. Apply each theme variant in Zed settings and verify the color consistency across different UI elements and syntax highlighting.


## Repository
https://github.com/IYair/kanagawa-theme.git


## Feedback

All feedback is welcome! Please let me know if there are any additional features or improvements you would like to see.

---

Thank you for reviewing this PR!