### PR TITLE
Update cue to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -252,7 +252,7 @@ version = "0.0.1"
 
 [cue]
 submodule = "extensions/cue"
-version = "0.0.2"
+version = "0.0.3"
 
 [curry]
 submodule = "extensions/curry"


### PR DESCRIPTION
Release notes:

* Added support for `cuepls` language server.

https://github.com/jkasky/zed-cue/releases/tag/v0.0.3