### PR TITLE
ocaml: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -816,7 +816,7 @@ version = "0.2.0"
 [ocaml]
 submodule = "extensions/zed"
 path = "extensions/ocaml"
-version = "0.0.2"
+version = "0.1.0"
 
 [ocean-dark-motifs]
 submodule = "extensions/ocean-dark-motifs"


### PR DESCRIPTION
This PR updates the OCaml extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/17945 for the changes in this version.