### PR TITLE
ruff: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1014,7 +1014,7 @@ version = "0.2.0"
 [ruff]
 submodule = "extensions/zed"
 path = "extensions/ruff"
-version = "0.0.2"
+version = "0.1.0"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"


### PR DESCRIPTION
This PR updates the Ruff extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/17960 for the changes in this version.