### PR TITLE
svelte: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1137,7 +1137,7 @@ version = "0.0.2"
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"
-version = "0.1.1"
+version = "0.2.0"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.2.0.

See https://github.com/zed-industries/zed/pull/17962 for the changes in this version.