### PR TITLE
Update one-dark-pro to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -852,7 +852,7 @@ version = "0.0.2"
 
 [one-dark-pro]
 submodule = "extensions/one-dark-pro"
-version = "0.0.5"
+version = "0.0.6"
 
 [one-dark-pro-monokai-darker]
 submodule = "extensions/one-dark-pro-monokai-darker"


### PR DESCRIPTION
Release notes:

https://github.com/MordFustang21/zed-one-dark-pro/releases/tag/v0.0.6