### PR TITLE
Update kanagawa-themes to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -582,7 +582,7 @@ version = "0.1.2"
 
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
-version = "0.0.1"
+version = "0.1.1"
 
 [kdl]
 submodule = "extensions/kdl"


### PR DESCRIPTION
Update kanagawa-themes to v0.1.1

Adds three new themes and a no italics version