### PR TITLE
Update Unison extension to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1228,7 +1228,7 @@ version = "0.0.5"
 
 [unison]
 submodule = "extensions/unison"
-version = "0.0.2"
+version = "0.0.4"
 
 [unocss]
 submodule = "extensions/unocss"


### PR DESCRIPTION
- Improves highlighting
- Updates Zed extension API
- Adds some outline queries
- Changes default language server proxy to use `nc` instead of `netcat`