### PR TITLE
lua: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -655,7 +655,7 @@ version = "0.0.1"
 [lua]
 submodule = "extensions/zed"
 path = "extensions/lua"
-version = "0.0.3"
+version = "0.1.0"
 
 [luau]
 submodule = "extensions/luau"


### PR DESCRIPTION
This PR updates the Lua extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/18246 for the changes in this version.