### PR TITLE
Update typos extension to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1231,7 +1231,7 @@ version = "0.1.1"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.1"
+version = "0.0.2"
 
 [typst]
 submodule = "extensions/typst"


### PR DESCRIPTION
The version 0.0.2 of the typos extension adds support for the following languages:

    - AsciiDoc
    - Astro
    - Bash
    - Biome
    - C#
    - C++
    - Deno
    - Docker
    - Emmet
    - GLSL
    - Groovy
    - Luau
    - Makefile
    - PHP
    - Prisma
    - Proto
    - Python
    - R
    - Rego
    - ReStructuredText
    - Scala
    - Svelte
    - TailwindCSS
    - Terraform
    - Uiua
    - Vue
    - Yarn

If there is a way to have a wildcard to enable the extension on all non-binary files instead of having to list them all please tell me.