### PR TITLE
Add protobuf-ls 0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -874,6 +874,10 @@
 	path = extensions/powershell
 	url = https://github.com/wingyplus/zed-powershell.git
 
+[submodule "extensions/protobuf-ls"]
+	path = extensions/protobuf-ls
+	url = https://github.com/prskr/zed-protobuf.git
+
 [submodule "extensions/pug"]
 	path = extensions/pug
 	url = https://github.com/Baw-Appie/zed-pug

--- a/extensions.toml
+++ b/extensions.toml
@@ -960,6 +960,10 @@ submodule = "extensions/zed"
 path = "extensions/prisma"
 version = "0.0.3"
 
+[protobuf-ls]
+submodule = "extensions/protobuf-ls"
+version = "0.1.0"
+
 [pug]
 submodule = "extensions/pug"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds protobuf-ls in its first version.
The extension is still WIP.