### PR TITLE
Add Proto extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -964,6 +964,11 @@ submodule = "extensions/zed"
 path = "extensions/prisma"
 version = "0.0.3"
 
+[proto]
+submodule = "extensions/zed"
+path = "extensions/proto"
+version = "0.1.0"
+
 [pug]
 submodule = "extensions/pug"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the Proto extension.

Haskell support was extracted from Zed in https://github.com/zed-industries/zed/pull/18704.