### PR TITLE
proto: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -979,7 +979,7 @@ version = "0.0.3"
 [proto]
 submodule = "extensions/zed"
 path = "extensions/proto"
-version = "0.1.0"
+version = "0.2.0"
 
 [pug]
 submodule = "extensions/pug"


### PR DESCRIPTION
This PR updates the Protobuf extension to v0.2.0.

See https://github.com/zed-industries/zed/pull/18814 for the changes in this version.