### PR TITLE
php: Bump to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -945,7 +945,7 @@ version = "0.1.0"
 [php]
 submodule = "extensions/zed"
 path = "extensions/php"
-version = "0.2.0"
+version = "0.2.1"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
This PR updates the PHP extension to v0.2.1.

See https://github.com/zed-industries/zed/pull/18815 for the changes in this version.