### PR TITLE
Bump Dart to 0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -285,7 +285,7 @@ version = "0.0.1"
 [dart]
 submodule = "extensions/zed"
 path = "extensions/dart"
-version = "0.1.0"
+version = "0.1.1"
 
 [dbml]
 submodule = "extensions/dbml"


### PR DESCRIPTION
- Includes: https://github.com/zed-industries/zed/pull/18845