### PR TITLE
Update Scala to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1099,7 +1099,7 @@ version = "1.0.1"
 
 [scala]
 submodule = "extensions/scala"
-version = "0.0.4"
+version = "0.1.0"
 
 [scheme]
 submodule = "extensions/zed"


### PR DESCRIPTION
- Added highlighting support for auto completions and symbol search
- Added runnable tags for the main three ways scala apps can be run
- Set `tab_size` to 2