### PR TITLE
terraform: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1247,7 +1247,7 @@ version = "0.0.3"
 [terraform]
 submodule = "extensions/zed"
 path = "extensions/terraform"
-version = "0.1.0"
+version = "0.1.1"
 
 [terrible-theme]
 submodule = "extensions/terrible-theme"


### PR DESCRIPTION
This PR updates the Terraform extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/18382 for the changes in this version.