### PR TITLE
gleam: Bump to v0.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -430,6 +430,10 @@
 	path = extensions/glazier
 	url = https://github.com/airgap/glazier.git
 
+[submodule "extensions/gleam"]
+	path = extensions/gleam
+	url = https://github.com/gleam-lang/zed-gleam.git
+
 [submodule "extensions/gleam-theme"]
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -477,9 +477,8 @@ submodule = "extensions/glazier"
 version = "0.0.2"
 
 [gleam]
-submodule = "extensions/zed"
-path = "extensions/gleam"
-version = "0.2.0"
+submodule = "extensions/gleam"
+version = "0.2.1"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.2.1.

The Gleam extension now resides at [`gleam-lang/zed-gleam`](https://github.com/gleam-lang/zed-gleam).