### PR TITLE
ci: Don't cancel in-progress on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   ZED_EXTENSION_CLI_SHA: ccf6f27b8f1bdfb803b9cc0da0b0cf5c9e136dd9


### PR DESCRIPTION
This PR changes the CI workflow behavior to not cancel any in-progress jobs on `main`.

This means that there will only be one concurrent job running for `main` at a given time, and it will run to completion.

This should allow us to merge multiple PRs concurrently without having to worry about them stomping on each other during the packaging/upload process.