### PR TITLE
java: Bump to v2.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -601,7 +601,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "1.0.0"
+version = "2.0.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
> [!WARNING]
> This release includes a breaking change for projects that use the `java_home` setting as that setting no longer exists. Please use the `settings.java.home` initialization option instead.

- Fix override method completion label [`4fe9b62`](https://github.com/zed-extensions/java/commit/4fe9b621cea2239071447b26ee2aa90a7dc3f93e)
- https://github.com/zed-extensions/java/pull/11
  - Fix constant identifiers syntax highlighting [`e7b511f`](https://github.com/zed-extensions/java/pull/11/commits/e7b511fd2aa66e3da96865de25b00d4913c9db29)
  - Fix doc comments syntax highlighting [`cfdedee`](https://github.com/zed-extensions/java/pull/11/commits/cfdedeea8a0df4cc656d51ad5efef2e4009cbe5a)
- https://github.com/zed-extensions/java/pull/12
- https://github.com/zed-extensions/java/pull/13

Full changelog: https://github.com/zed-extensions/java/compare/v1.0.0...v2.0.0