### PR TITLE
Add SageMath language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -998,6 +998,10 @@
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git
 
+[submodule "extensions/sagemath"]
+	path = extensions/sagemath
+	url = https://github.com/rot256/zed-sagemath
+
 [submodule "extensions/scala"]
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1104,6 +1104,10 @@ version = "0.1.0"
 submodule = "extensions/s-dark-theme"
 version = "1.0.1"
 
+[sagemath]
+submodule = "extensions/sagemath"
+version = "0.0.1"
+
 [scala]
 submodule = "extensions/scala"
 version = "0.1.0"


### PR DESCRIPTION
This adds basic language support for [SageMath](https://www.sagemath.org/).

SageMath is *very* similar to Python: the language adds some Sage-specific syntactic sugar, changes some operators (e.g. ^ is exponentiation). The language is "compiled" down to python before execution. Nonetheless these changes prevent e.g. Python language servers from working correctly, therefore the need for a separate extension for ".sage" files.

Currently the extension works by using the Python grammar, but changes the highlights.scm to add Sage-specific keywords / builtins / constants.