### PR TITLE
xml: Bunmp to v0.0.7 (fix)

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1433,7 +1433,7 @@ version = "1.1.3"
 
 [xml]
 submodule = "extensions/xml"
-version = "0.0.6"
+version = "0.0.7"
 
 [xy-zed]
 submodule = "extensions/xy-zed"


### PR DESCRIPTION
Fix for https://github.com/zed-industries/extensions/pull/1506 not bumping the version number in `extensions.toml` too.

We should probably add a CI test for this.