### PR TITLE
Add HAML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -498,6 +498,10 @@
 	path = extensions/halcyon
 	url = https://github.com/hichemfantar/halcyon-zed.git
 
+[submodule "extensions/haml"]
+	path = extensions/haml
+	url = https://github.com/davidcornu/zed-haml.git
+
 [submodule "extensions/harper"]
 	path = extensions/harper
 	url = https://github.com/Stef16Robbe/harper_zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -549,6 +549,10 @@ version = "2.0.0"
 submodule = "extensions/halcyon"
 version = "0.0.5"
 
+[haml]
+submodule = "extensions/haml"
+version = "0.0.2"
+
 [harper]
 submodule = "extensions/harper"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -551,7 +551,7 @@ version = "0.0.5"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.2"
+version = "0.0.3"
 
 [harper]
 submodule = "extensions/harper"


### PR DESCRIPTION
Adds a new syntax-highlighting extension for the [HAML](https://haml.info/) templating language, as requested in this thread: https://github.com/zed-industries/extensions/issues/179.

I put together a first version during the Zed meetup at RustConf in Montreal based on @vitallium's work in https://github.com/vitallium/tree-sitter-haml, but hadn't published it as I wasn't sure what their plans were for the grammar. However, in https://github.com/zed-industries/zed/pull/18787#issuecomment-2397885773 they agreed that this would be the right way forward.