### PR TITLE
Update Ansible to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -32,7 +32,7 @@ version = "0.1.3"
 
 [ansible]
 submodule = "extensions/ansible"
-version = "0.0.1"
+version = "0.0.2"
 
 [anya]
 submodule = "extensions/anya"


### PR DESCRIPTION
Currently, it is observed that the YAML TS parser, when resued within the Ansible extension, is creating a memory leak when working with non-ansible YAML files. 

Since we aren't able to fully narrow down the issue on TS side just yet to rollout the appropriate fix, I'm disabling highlighting temporarily in order for at least the LSP be useful/accessible to the extension users. 

The issue can be tracked here: https://github.com/kartikvashistha/zed-ansible/issues/2