### PR TITLE
Add D2 extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -266,6 +266,10 @@
 	path = extensions/d
 	url = https://github.com/staysail/zed-d.git
 
+[submodule "extensions/d2"]
+	path = extensions/d2
+	url = https://github.com/gabeidx/zed-d2.git
+
 [submodule "extensions/dafny"]
 	path = extensions/dafny
 	url = https://github.com/WeetHet/dafny-zed.git


### PR DESCRIPTION
This PR adds an extension that provides support for the D2 diagram scripting language. 

It introduces a basic syntax highligthing feature for `.d2` files, as well as `d2` block in markdown files.