### PR TITLE
Add PlantUML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -934,6 +934,10 @@
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git
 
+[submodule "extensions/plantuml"]
+	path = extensions/plantuml
+	url = https://github.com/gabeidx/zed-plantuml.git
+
 [submodule "extensions/playdate-zed-extension"]
 	path = extensions/playdate
 	url = https://github.com/notpeter/playdate-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1010,6 +1010,10 @@ version = "0.0.1"
 submodule = "extensions/pkl"
 version = "0.1.0"
 
+[plantuml]
+submodule = "extensions/plantuml"
+version = "0.1.0"
+
 [playdate]
 submodule = "extensions/playdate"
 version = "0.1.1"


### PR DESCRIPTION
This PR adds an extension that provides support for PlantUML: [plantuml.com](https://plantuml.com/)

It introduces a basic syntax highligthing feature for `.wsd`, `.pu`, `.puml`, `.plantuml` and `.iuml` files.

![syntax-highlight](https://github.com/user-attachments/assets/44e382e0-3001-4799-8bd8-893b961816b6)

https://github.com/gabeidx/zed-plantuml