### PR TITLE
Add missing `d2` and `graphviz` entries to `extensions.toml`

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -282,6 +282,10 @@ version = "0.2.0"
 submodule = "extensions/d"
 version = "0.0.8"
 
+[d2]
+submodule = "extensions/d2"
+version = "0.1.0"
+
 [dafny]
 submodule = "extensions/dafny"
 version = "0.0.1"
@@ -512,6 +516,10 @@ version = "0.2.0"
 [graphql]
 submodule = "extensions/graphql"
 version = "1.0.0"
+
+[graphviz]
+submodule = "extensions/graphviz"
+version = "0.1.0"
 
 [green-monochrome-monitor-crt-phosphor]
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"


### PR DESCRIPTION
This PR adds the missing entries for the `d2` and `graphviz` extensions, since they were missed in these PRs:

- https://github.com/zed-industries/extensions/pull/1534
- https://github.com/zed-industries/extensions/pull/1536