### PR TITLE
Update Typos extension to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1326,7 +1326,7 @@ version = "0.1.0"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.2"
+version = "0.0.3"
 
 [typst]
 submodule = "extensions/typst"


### PR DESCRIPTION
- Fix LSP binary path on windows

Requested from https://github.com/BaptisteRoseau/zed-typos/issues/2