### PR TITLE
svelte: Bump to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1272,7 +1272,7 @@ version = "0.0.2"
 [svelte]
 submodule = "extensions/zed"
 path = "extensions/svelte"
-version = "0.2.0"
+version = "0.2.1"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.2.1.

See https://github.com/zed-industries/zed/pull/19420 for the changes in this version.