### PR TITLE
vue: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1440,7 +1440,7 @@ version = "0.0.2"
 [vue]
 submodule = "extensions/zed"
 path = "extensions/vue"
-version = "0.1.0"
+version = "0.1.1"
 
 [wakatime]
 submodule = "extensions/wakatime"


### PR DESCRIPTION
This PR updates the Vue extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/19421 for the changes in this version.