### PR TITLE
elixir: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -355,7 +355,7 @@ version = "0.0.4"
 [elixir]
 submodule = "extensions/zed"
 path = "extensions/elixir"
-version = "0.1.0"
+version = "0.1.1"
 
 [elm]
 submodule = "extensions/zed"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/19437 for the changes in this version.