### PR TITLE
Update HAML extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -563,7 +563,7 @@ version = "0.0.5"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.3"
+version = "0.0.4"
 
 [harper]
 submodule = "extensions/harper"


### PR DESCRIPTION
Bumps the HAML extension from v0.0.3 to v0.0.4 (https://github.com/davidcornu/zed-haml/releases/tag/v0.0.4).

cc @vitallium 