### PR TITLE
ltex: Bump to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -717,7 +717,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.0.1"
+version = "0.0.3"
 
 [lua]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this PR updates the `LTeX` extension to [v0.0.3](https://github.com/vitallium/zed-ltex/releases/tag/v0.0.3). Changes are minimal:

1. Updated the Rust toolchain and the Zed cargo to v0.1.0.
2. Enabled LTeX in `Typst` files.

Thanks!