### PR TITLE
vue: Bump to v0.1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1318,6 +1318,10 @@
 	path = extensions/vscode-monokai-charcoal
 	url = https://github.com/d1y/vscode-monokaicharcoal.zed.git
 
+[submodule "extensions/vue"]
+	path = extensions/vue
+	url = https://github.com/zed-extensions/vue.git
+
 [submodule "extensions/wakatime"]
 	path = extensions/wakatime
 	url = https://github.com/wakatime/zed-wakatime.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1452,7 +1452,7 @@ version = "0.0.2"
 [vue]
 submodule = "extensions/zed"
 path = "extensions/vue"
-version = "0.1.1"
+version = "0.1.2"
 
 [wakatime]
 submodule = "extensions/wakatime"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1450,8 +1450,7 @@ submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"
 
 [vue]
-submodule = "extensions/zed"
-path = "extensions/vue"
+submodule = "extensions/vue"
 version = "0.1.2"
 
 [wakatime]


### PR DESCRIPTION
Vue moved to a new repository. This is a no-op version bump which switches to that submodule.