### PR TITLE
svelte: Bump to v0.2.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1162,6 +1162,10 @@
 	path = extensions/surrealql
 	url = https://github.com/siteforge-io/surql-zed
 
+[submodule "extensions/svelte"]
+	path = extensions/svelte
+	url = https://github.com/zed-extensions/svelte.git
+
 [submodule "extensions/swift"]
 	path = extensions/swift
 	url = https://github.com/samuser107/zed-swift-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1274,9 +1274,8 @@ submodule = "extensions/surrealql"
 version = "0.0.2"
 
 [svelte]
-submodule = "extensions/zed"
-path = "extensions/svelte"
-version = "0.2.1"
+submodule = "extensions/svelte"
+version = "0.2.2"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.2.2.

The Svelte extension now resides at [`zed-extensions/svelte`](https://github.com/zed-extensions/svelte).