### PR TITLE
Update LaTeX extension to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -685,7 +685,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.0.7"
+version = "0.0.8"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
- Include task to mitigate current issue with build-on-save:
![image](https://github.com/user-attachments/assets/7e4625ff-31d1-4bf3-8980-17ebfd7c1e37)
- Fix minor edge-case [bug](https://github.com/rzukic/zed-latex/pull/28) when attempting to download `texlab` (in a situation for which there is no Zed release anyway)