### PR TITLE
Update QML extension to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1079,7 +1079,7 @@ version = "0.0.3"
 
 [qml]
 submodule = "extensions/qml"
-version = "0.0.2"
+version = "0.0.3"
 
 [quiet-light-theme]
 submodule = "extensions/quiet-light-theme"


### PR DESCRIPTION
This update fixes qmlls path detection mentioned here: https://github.com/zed-industries/extensions/pull/1560#issuecomment-2426830539

It is now using worktree.which to get the full path to either qmlls or qmlls6 if it can be found in $PATH.

The error message when qmlls was not found is now clearer as well, including some docs on how to install it on various distros and MacOS.