### PR TITLE
Add Standard ML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1102,6 +1102,10 @@
 	path = extensions/smithy
 	url = https://github.com/joshrutkowski/zed-smithy.git
 
+[submodule "extensions/sml"]
+	path = extensions/sml
+	url = https://github.com/omarjatoi/zed-sml.git
+
 [submodule "extensions/smooth"]
 	path = extensions/smooth
 	url = https://github.com/segersniels/zed-smooth.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1208,6 +1208,10 @@ version = "0.0.3"
 submodule = "extensions/smithy"
 version = "0.0.1"
 
+[sml]
+submodule = "extensions/sml"
+version = "0.1.0"
+
 [smooth]
 submodule = "extensions/smooth"
 version = "1.0.0"


### PR DESCRIPTION
Adds [SML](https://smlfamily.github.io/) support to Zed with [`tree-sitter-sml`](https://github.com/MatthewFluet/tree-sitter-sml) and [`millet`](https://github.com/azdavis/millet) language server. Closes https://github.com/zed-industries/extensions/issues/133.

https://github.com/omarjatoi/zed-sml