### PR TITLE
dart: Bump to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -301,7 +301,7 @@ version = "0.0.1"
 [dart]
 submodule = "extensions/zed"
 path = "extensions/dart"
-version = "0.1.1"
+version = "0.1.2"
 
 [dbml]
 submodule = "extensions/dbml"


### PR DESCRIPTION
This PR updates the Dart extension to v0.1.2.

See https://github.com/zed-industries/zed/pull/19835 for the changes in this version.