### PR TITLE
Bump zedrack-theme to 0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1511,7 +1511,7 @@ version = "1.1.1"
 
 [zedrack-theme]
 submodule = "extensions/zedrack-theme"
-version = "0.0.5"
+version = "0.0.6"
 
 [zedspace]
 submodule = "extensions/zedspace"


### PR DESCRIPTION
# Bump of Theme

Theme name: **Zedrack Theme**

Reason: **Minor correction to editor highligh color.**

Repository: https://github.com/foorack/zed-theme

