### PR TITLE
Bump zedwaita to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1523,7 +1523,7 @@ version = "0.0.1"
 
 [zedwaita]
 submodule = "extensions/zedwaita"
-version = "0.0.4"
+version = "0.0.5"
 
 [zen-abyssal]
 submodule = "extensions/zen-abyssal"


### PR DESCRIPTION
Updates the name of a deprecated theme option.