### PR TITLE
Bump verilog to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1418,7 +1418,7 @@ version = "0.0.1"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.4"
+version = "0.0.5"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
This version makes a few changes.

1. I've synchronized the tree-sitter queries with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter), including switching to [gmlarumbe/tree-sitter-systemverilog](https://github.com/gmlarumbe/tree-sitter-systemverilog) for the grammar as nvim did.
2. I'm now using a hard-coded tag for Verible instead of pulling the latest release.
   - The Veridian language server is still built from upstream at release time in my repo, so static commits are already enforced for that.
3. I've bumped the extension api version to 0.1.0 from 0.0.6.