### PR TITLE
Bump scala to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1161,7 +1161,7 @@ version = "0.0.1"
 
 [scala]
 submodule = "extensions/scala"
-version = "0.1.0"
+version = "0.1.1"
 
 [scheme]
 submodule = "extensions/zed"


### PR DESCRIPTION
This version adds support for tagging ScalaTest tests to enable adding a task to run the tests through the run gutter.