### PR TITLE
Ansible: Update to v0.1.0 

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -32,7 +32,7 @@ version = "0.1.3"
 
 [ansible]
 submodule = "extensions/ansible"
-version = "0.0.2"
+version = "0.1.0"
 
 [anya]
 submodule = "extensions/anya"


### PR DESCRIPTION
This release enables back code highlighting for Ansible files to fix and close [this](https://github.com/kartikvashistha/zed-ansible/issues/2) issue.

Other misc changes include:
- Bump `zed_extension_api` from `0.0.6` to `0.1.0`
- Update project README

PR: https://github.com/kartikvashistha/zed-ansible/pull/5