### PR TITLE
Update LaTeX extension to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -688,7 +688,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.0.8"
+version = "0.1.0"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
**Jump to v0.1.0 to signify a noticeable change in experience.**

This release aims to provide a default out of the box experience building LaTeX documents without user configuration when a suitable previewer is detected. With a fresh Zed project with a LaTeX file, a suitable PDF previewer, and no custom LSP configuration in the Zed settings will now have build-on-save and forward-search after save set up automatically. However any setting explicitly set by the user takes priority. More details in the wiki to come shortly.

## Breaking change
This extension now automatically may make changes to `texlab` settings, to disable this set "lsp.texlab.settings.texlab.forwardSearch" to an empty object `{}`.