### PR TITLE
Add norminette extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -850,6 +850,10 @@
 	path = extensions/nordic-theme
 	url = https://github.com/biaqat/nordic-theme-zed.git
 
+[submodule "extensions/norminette"]
+	path = extensions/norminette
+	url = https://github.com/DavidLee18/zed_norminette.git
+
 [submodule "extensions/norrsken"]
 	path = extensions/norrsken
 	url = https://github.com/webhooked/norrsken-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -911,6 +911,10 @@ version = "0.0.11"
 submodule = "extensions/nordic-theme"
 version = "0.5.0"
 
+[norminette]
+submodule = "extensions/norminette"
+version = "0.2.1"
+
 [norrsken]
 submodule = "extensions/norrsken"
 version = "3.0.1"


### PR DESCRIPTION
Hi, this is an extension which enforces a specific code style(called "Norme") for *.c/*.h files. It's intended to be used by 42 School students, and it uses a LSP server for [Norminette](https://github.com/42School/norminette), called [norminette_lsp](https://github.com/DavidLee18/norminette_lsp). It would be a lot helpful for students of 42 School if this extension gets on the registry. Thanks.