### PR TITLE
Add UUID extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1286,6 +1286,10 @@
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
 
+[submodule "extensions/uuid"]
+	path = extensions/uuid
+	url = https://github.com/mlavrinenko/zed-uuid.git
+
 [submodule "extensions/v"]
 	path = extensions/v
 	url = https://github.com/lv37/zed-v.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1407,6 +1407,10 @@ version = "0.0.1"
 submodule = "extensions/unoflat"
 version = "0.1.2"
 
+[uuid]
+submodule = "extensions/uuid"
+version = "1.0.0"
+
 [v]
 submodule = "extensions/v"
 version = "0.3.0"


### PR DESCRIPTION
It's a common task to generate some UUIDs while you write new fixtures/migrations. This extension adds the `/uuid` slash command that generates a random UUIDv4.

This would be much more helpful if slash command usage were allowed in the editor (https://github.com/zed-industries/zed/issues/20095).