### PR TITLE
Update HAML extension to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -574,7 +574,7 @@ version = "0.0.5"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.4"
+version = "0.0.5"
 
 [harper]
 submodule = "extensions/harper"


### PR DESCRIPTION
Bumps the HAML extension from v0.0.4 to v0.0.5: https://github.com/davidcornu/zed-haml/releases/tag/v0.0.5

cc @vitallium 