### PR TITLE
Add Hurl (hurl.dev) extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -562,6 +562,10 @@
 	path = extensions/http
 	url = https://github.com/tie304/zed-http.git
 
+[submodule "extensions/hurl"]
+	path = extensions/hurl
+	url = https://github.com/tommy/zed-hurl
+
 [submodule "extensions/iceberg"]
 	path = extensions/iceberg
 	url = https://github.com/EFDos/iceberg-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -618,6 +618,10 @@ version = "0.1.3"
 submodule = "extensions/http"
 version = "0.0.1"
 
+[hurl]
+submodule = "extensions/hurl"
+version = "0.1.0"
+
 [iceberg]
 submodule = "extensions/iceberg"
 version = "0.2.10"


### PR DESCRIPTION
This extension adds basic syntax highlighting (and some folding) for hurl.dev files.
