### PR TITLE
Update LaTeX extension to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -700,7 +700,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.1.0"
+version = "0.1.1"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
Version 0.0.7 of this extension allowed users to have `texlab` (LaTeX language server) without explicitly installing it themselves. Users taking advantage of this would then not be able to use `texlab` when launching Zed offline, even if this extension downloaded a `texlab` release previously.

This PR addresses this by adding a fallback for network issues which checks if it can find any versions of `texlab` that it previously downloaded.

Minor extra: duplicate code removed.