### PR TITLE
Update HAML extension to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -574,7 +574,7 @@ version = "0.0.5"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.5"
+version = "0.0.6"
 
 [hare]
 submodule = "extensions/hare"


### PR DESCRIPTION
Bumps the HAML extension from v0.0.5 to v0.0.6: https://github.com/davidcornu/zed-haml/releases/tag/v0.0.6

cc @vitallium