### PR TITLE
feat: add original Material Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -734,6 +734,10 @@
 	path = extensions/material-theme
 	url = https://github.com/Codextor/zed-material-theme.git
 
+[submodule "extensions/material.theme"]
+	path = extensions/material.theme
+	url = https://github.com/material-theme/zed-mt-source
+
 [submodule "extensions/matlab"]
 	path = extensions/matlab
 	url = https://github.com/rzukic/zed-matlab.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -787,6 +787,10 @@ version = "0.0.2"
 submodule = "extensions/martianized"
 version = "1.0.0"
 
+[material.theme]
+submodule = "extensions/material.theme"
+version = "1.0.0"
+
 [material-dark]
 submodule = "extensions/material-dark"
 version = "0.0.1"


### PR DESCRIPTION
Add official Material Theme extension. Also related to https://github.com/zed-industries/extensions/issues/1645