### PR TITLE
Add original Material Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -730,14 +730,6 @@
 	path = extensions/material-dark
 	url = https://github.com/xerodark/zed-material-theme.git
 
-[submodule "extensions/material-theme"]
-	path = extensions/material-theme
-	url = https://github.com/Codextor/zed-material-theme.git
-
-[submodule "extensions/material.theme"]
-	path = extensions/material.theme
-	url = https://github.com/material-theme/zed-material-theme
-
 [submodule "extensions/matlab"]
 	path = extensions/matlab
 	url = https://github.com/rzukic/zed-matlab.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -734,6 +734,10 @@
 	path = extensions/material-theme
 	url = https://github.com/Codextor/zed-material-theme.git
 
+[submodule "extensions/material.theme"]
+	path = extensions/material.theme
+	url = https://github.com/material-theme/zed-mt-source
+
 [submodule "extensions/matlab"]
 	path = extensions/matlab
 	url = https://github.com/rzukic/zed-matlab.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -730,6 +730,10 @@
 	path = extensions/material-dark
 	url = https://github.com/xerodark/zed-material-theme.git
 
+[submodule "extensions/material.theme"]
+	path = extensions/material.theme
+	url = https://github.com/material-theme/zed-material-theme
+
 [submodule "extensions/matlab"]
 	path = extensions/matlab
 	url = https://github.com/rzukic/zed-matlab.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -730,6 +730,10 @@
 	path = extensions/material-dark
 	url = https://github.com/xerodark/zed-material-theme.git
 
+[submodule "extensions/material-theme"]
+	path = extensions/material-theme
+	url = https://github.com/Codextor/zed-material-theme.git
+
 [submodule "extensions/material.theme"]
 	path = extensions/material.theme
 	url = https://github.com/material-theme/zed-material-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -736,7 +736,7 @@
 
 [submodule "extensions/material.theme"]
 	path = extensions/material.theme
-	url = https://github.com/material-theme/zed-mt-source
+	url = https://github.com/material-theme/zed-material-theme
 
 [submodule "extensions/matlab"]
 	path = extensions/matlab

--- a/extensions.toml
+++ b/extensions.toml
@@ -787,6 +787,10 @@ version = "0.0.2"
 submodule = "extensions/martianized"
 version = "1.0.0"
 
+[material.theme]
+submodule = "extensions/material.theme"
+version = "1.0.0"
+
 [material-dark]
 submodule = "extensions/material-dark"
 version = "0.0.1"


### PR DESCRIPTION
Add official Material Theme extension. This is the free version since is not possible to distribute closed-source extensions yet.

Website
https://www.material-theme.dev

Visual Studio Code Marketplace
https://marketplace.visualstudio.com/items?itemName=Equinusocio.vsc-material-theme

GitKraken
https://github.com/material-theme/gitkraken

Others:
https://github.com/material-theme/vsc-material-theme/discussions/1279

