### PR TITLE
Update github-dark-default theme to v1.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -489,7 +489,7 @@ version = "0.1.0"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
-version = "1.0.6"
+version = "1.0.7"
 
 [github-monochrome-theme]
 submodule = "extensions/github-monochrome-theme"


### PR DESCRIPTION
Release notes:

https://github.com/MordFustang21/zed-github-dark/releases/tag/v1.0.7