### PR TITLE
Add Cypher extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,6 +278,10 @@
 	path = extensions/cylc
 	url = https://github.com/elliotfontaine/zed-cylc.git
 
+[submodule "extensions/cypher"]
+	path = extensions/cypher
+	url = https://github.com/pupli/cypher
+
 [submodule "extensions/d"]
 	path = extensions/d
 	url = https://github.com/staysail/zed-d.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -294,6 +294,10 @@ version = "0.7.0"
 submodule = "extensions/cylc"
 version = "0.2.0"
 
+[cypher]
+submodule = "extensions/cypher"
+version = "0.0.1"
+
 [d]
 submodule = "extensions/d"
 version = "0.0.8"


### PR DESCRIPTION
Adding the Cypher extension

Syntax highlighting for cypher query language
Grammar are based on [OpenCypherLink](https://opencypher.org/resources/ )
To test the highlights use refer the examples in [Test Cypher Queries](https://github.com/opencypher/openCypher/blob/master/tools/grammar/src/test/resources/cypher.txt)