### PR TITLE
Remove Odin Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -902,10 +902,6 @@
 	path = extensions/oceanic-next
 	url = https://github.com/rkunev/oceanic-next.git
 
-[submodule "extensions/odin"]
-	path = extensions/odin
-	url = https://github.com/clseibold/zed-odin
-
 [submodule "extensions/oh-lucy"]
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -968,10 +968,6 @@ version = "0.0.2"
 submodule = "extensions/oceanic-next"
 version = "0.1.0"
 
-[odin]
-submodule = "extensions/odin"
-version = "0.1.1"
-
 [oh-lucy]
 submodule = "extensions/oh-lucy"
 version = "0.0.1"


### PR DESCRIPTION
Upstream repo is no longer available.
https://github.com/clseibold/zed-odin
Maintainer has been contacted.

CC: @clseibold

This can be reverted if the source becomes available again.
I've pushed my local clone here: https://github.com/notpeter/zed-odin
But have no intention of maintaining it.