### PR TITLE
Bump extension CLI version to `b5ce8e7`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: ccf6f27b8f1bdfb803b9cc0da0b0cf5c9e136dd9
+  ZED_EXTENSION_CLI_SHA: b5ce8e7aa500d530389fef4cdd26f4790d013682
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/b5ce8e7aa500d530389fef4cdd26f4790d013682.