### PR TITLE
html: Bump to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -624,7 +624,7 @@ version = "0.0.1"
 [html]
 submodule = "extensions/zed"
 path = "extensions/html"
-version = "0.1.3"
+version = "0.1.4"
 
 [http]
 submodule = "extensions/http"


### PR DESCRIPTION
This PR updates the HTML extension to v0.1.4.

See https://github.com/zed-industries/zed/pull/20692 for the changes in this version.