### PR TITLE
Bump One Black Theme to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -994,7 +994,7 @@ version = "0.0.1"
 
 [one-black-theme]
 submodule = "extensions/one-black-theme"
-version = "0.0.1"
+version = "0.0.2"
 
 [one-dark-darkened]
 submodule = "extensions/one-dark-darkened"


### PR DESCRIPTION
- The color of Git-ignored files is now more distinct.
- Fixed the placeholder text color to match the theme.
- Cyan in the terminal now matches the cyan in the editor.
- `border.variant` now matches other borders.
- Enhanced the visibility of the disabled icon color.