### PR TITLE
Bump catppuccin to 0.2.14

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -198,7 +198,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.13"
+version = "0.2.14"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"


### PR DESCRIPTION
- add more coloring exposed by new `debug: open theme preview`
- update numerous syntax coloring