### PR TITLE
ocaml: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -974,7 +974,7 @@ version = "0.0.1"
 [ocaml]
 submodule = "extensions/zed"
 path = "extensions/ocaml"
-version = "0.1.0"
+version = "0.1.1"
 
 [ocean-dark-motifs]
 submodule = "extensions/ocean-dark-motifs"


### PR DESCRIPTION
This PR updates the OCaml extension to v0.1.1.

See https://github.com/zed-industries/zed/pull/20823 for the changes in this version.