### PR TITLE
code-stats: Bump to v0.2.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -239,7 +239,7 @@ version = "0.1.0"
 
 [code-stats]
 submodule = "extensions/code-stats"
-version = "0.2.2"
+version = "0.2.3"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"


### PR DESCRIPTION
This PR bumps the Code::Stats extension to v0.2.3.