### PR TITLE
Update LaTeX extension to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -716,7 +716,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.1.1"
+version = "0.1.2"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
This release adds a new setting to add extra directories to TEXINPUTS when invoking `texlab` affecting some LSP functionality and LaTeX compilation. The user may want to consider [alternatives](https://github.com/rzukic/zed-latex/wiki/FAQ#can-i-add-extra-directories-to-be-picked-up-by-the-project) before using this setting.

Example:
```jsonc
{
  "lsp": {
    "texlab": {
      "initialization_options": {
        // experimental: visit zed-latex wiki on github to check if setting location has moved
        "extra_tex_inputs": [
          "/extra/path/1/",
          "/extra/path/2/",
        ]
      }
    }
  }
}
```