### PR TITLE
Bump verilog to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1500,7 +1500,7 @@ version = "0.0.1"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.5"
+version = "0.0.6"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
Changes: https://github.com/someone13574/zed-verilog-extension/releases/tag/v0.0.6