### PR TITLE
Update HAML extension to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -586,7 +586,7 @@ version = "0.1.0"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.6"
+version = "0.0.7"
 
 [hare]
 submodule = "extensions/hare"


### PR DESCRIPTION
Bumps the HAML extension from v0.0.6 to v0.0.7: https://github.com/davidcornu/zed-haml/releases/tag/v0.0.7

Upstream diff: https://github.com/vitallium/tree-sitter-haml/compare/f99259f8a2e6600f5cd5f87b42648db2519e6f73...5dedefd955eaaadec309357879a46edf932945cf

cc @vitallium 