### PR TITLE
Bump Luau to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -761,7 +761,7 @@ version = "0.1.0"
 
 [luau]
 submodule = "extensions/luau"
-version = "0.2.0"
+version = "0.2.1"
 
 [lusch-theme]
 submodule = "extensions/lusch-theme"


### PR DESCRIPTION
Notably changes Tree-sitter repo to [4teapo/tree-sitter-luau](https://github.com/4teapo/tree-sitter-luau) for a bunch of syntax highlighting fixes and additions.