### PR TITLE
Add EDI X12 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -334,6 +334,10 @@
 	path = extensions/earthfile
 	url = https://github.com/glehmann/earthfile.zed.git
 
+[submodule "extensions/edi"]
+	path = extensions/edi
+	url = https://github.com/hugginsio/zed-edi.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -1465,10 +1469,6 @@
 [submodule "extensions/wit"]
 	path = extensions/wit
 	url = https://github.com/valentinegb/zed-wit.git
-
-[submodule "extensions/x12"]
-	path = extensions/x12
-	url = https://github.com/hugginsio/zed-x12.git
 
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes

--- a/.gitmodules
+++ b/.gitmodules
@@ -1466,6 +1466,10 @@
 	path = extensions/wit
 	url = https://github.com/valentinegb/zed-wit.git
 
+[submodule "extensions/x12"]
+	path = extensions/x12
+	url = https://github.com/hugginsio/zed-x12.git
+
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes
 	url = https://github.com/skarline/zed-xcode-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1582,6 +1582,10 @@ version = "0.0.1"
 submodule = "extensions/wit"
 version = "0.4.0"
 
+[x12]
+submodule = "extensions/x12"
+version = "0.0.1"
+
 [xcode-themes]
 submodule = "extensions/xcode-themes"
 version = "2.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1583,8 +1583,8 @@ submodule = "extensions/wit"
 version = "0.4.0"
 
 [x12]
-submodule = "extensions/x12"
-version = "0.0.1"
+submodule = "extensions/edi"
+version = "0.0.2"
 
 [xcode-themes]
 submodule = "extensions/xcode-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -355,6 +355,10 @@ version = "0.0.1"
 submodule = "extensions/earthfile"
 version = "0.1.0"
 
+[edi]
+submodule = "extensions/edi"
+version = "0.0.2"
+
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.0.1"
@@ -1581,10 +1585,6 @@ version = "0.0.1"
 [wit]
 submodule = "extensions/wit"
 version = "0.4.0"
-
-[x12]
-submodule = "extensions/edi"
-version = "0.0.2"
 
 [xcode-themes]
 submodule = "extensions/xcode-themes"


### PR DESCRIPTION
This extension adds highlighting support for X12 EDI documents.

- [x] Submodule added
- [x] Extensions manifest updated
- [x] `sort-extensions` ran

Please let me know if any changes are required on my end. Thank you all for your hard work building Zed.