### PR TITLE
Add Cooklang language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -242,6 +242,10 @@
 	path = extensions/conl
 	url = https://github.com/ConradIrwin/zed-extension-conl
 
+[submodule "extensions/cooklang"]
+	path = extensions/cooklang
+	url = https://github.com/hugginsio/zed-cooklang.git
+
 [submodule "extensions/cosmos"]
 	path = extensions/cosmos
 	url = https://github.com/nauvalazhar/cosmos.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -253,6 +253,10 @@ version = "0.0.4"
 submodule = "extensions/conl"
 version = "1.0.0"
 
+[cooklang]
+submodule = "extensions/cooklang"
+version = "1.1.0"
+
 [cosmos]
 submodule = "extensions/cosmos"
 version = "0.0.1"


### PR DESCRIPTION
This extension adds support for Cooklang, [a recipe markup language](https://cooklang.org).

Preview:

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/75c7040b-b80f-491c-ad75-c89194fcd730">