### PR TITLE
Bump marksman to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -793,7 +793,7 @@ version = "0.0.4"
 
 [marksman]
 submodule = "extensions/marksman"
-version = "0.0.2"
+version = "0.0.3"
 
 [martianized]
 submodule = "extensions/martianized"


### PR DESCRIPTION
Hi, this is just a technical release of the `marksman` extension. See the release changelog here https://github.com/vitallium/zed-marksman/releases/tag/v0.0.3

Thanks!