### PR TITLE
Add wgsl-analyzer extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1478,6 +1478,10 @@
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl.git
 
+[submodule "extensions/wgsl-analyzer"]
+	path = extensions/wgsl-analyzer
+	url = https://github.com/AngusGMorrison/wgsl-analyzer.git
+
 [submodule "extensions/wit"]
 	path = extensions/wit
 	url = https://github.com/valentinegb/zed-wit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1594,6 +1594,10 @@ version = "0.1.1"
 submodule = "extensions/wgsl"
 version = "0.0.1"
 
+[wgsl-analyzer]
+submodule = "extensions/wgsl-analyzer"
+version = "0.0.1"
+
 [wit]
 submodule = "extensions/wit"
 version = "0.4.0"


### PR DESCRIPTION
Adds WGSL support via the [wgsl-analyzer language server](https://github.com/wgsl-analyzer/wgsl-analyzer).

Offers richer syntax highlighting and indentation than the existing WGSL language extension, and uses a better-established language server (wgsl-analyzer is the defacto WGSL server for VSCode, although admittedly it's _not_ that well maintained).

The set-up process for the language server itself is straightforward and clearly documented.