### PR TITLE
Update macos-classic to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -781,7 +781,7 @@ version = "0.6.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"
-version = "0.2.1"
+version = "0.2.2"
 
 [make]
 submodule = "extensions/make"


### PR DESCRIPTION
Release notes:

https://github.com/huacnlee/zed-theme-macos-classic/releases/tag/v0.2.2