### PR TITLE
Add stylelint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1538,6 +1538,10 @@
 	path = extensions/struct-theme
 	url = https://gitlab.com/Fake.User/struct-zed-theme.git
 
+[submodule "extensions/stylelint"]
+	path = extensions/stylelint
+	url = https://github.com/florian-sanders/zed-stylelint.git
+
 [submodule "extensions/sublime-mariana-theme"]
 	path = extensions/sublime-mariana-theme
 	url = https://github.com/hnatiukr/zed-mariana-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1611,6 +1611,10 @@ version = "0.0.2"
 submodule = "extensions/struct-theme"
 version = "0.0.1"
 
+[stylelint]
+submodule = "extensions/stylelint"
+version = "0.0.1"
+
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
 version = "1.1.0"


### PR DESCRIPTION
Fixes #1648

- This PR adds an extension to wrap `stylelint` LSP,
- [Stylelint](https://stylelint.io/) is used to lint CSS content in files that support it (CSS, SCSS, JS, etc.),
- The [VSCode Stylelint Extension](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) is fairly popular with more than 2,595,360 installs,
- The LSP server comes from the [stylelint/vscode-stylelint](https://github.com/stylelint/vscode-stylelint) project but there are few things to note:
  - the GitHub repository contains both the LSP server and the VSCode extension code,
  - the LSP server is not entirely decoupled from VSCode extension code but it does work on it's own,
  - neither the LSP Server or the VSCode are published as npm packages,
  - the source code needs to be built (TypeScript project) & bundled to be used,
- I had to fork the original repository so that I could:
  - build & bundle the source code using the povided `build-bundle` command (see [source package.json](https://github.com/stylelint/vscode-stylelint/blob/main/package.json#L257C12-L257C180) for more info),
  - publish it as an npm package: https://www.npmjs.com/package/@florian-sanders/vscode-stylelint-prebundled.

## About the fork & npm package

I don't mind maintaining the fork & npm package but I'd definitely be okay to make it less about me and more about Zed or the community. 
I chose to publish the LSP package in the `@florian-sanders` scope on npm just because I wanted to make it clear that it was not officially published by the Stylelint team but I'm open to other options.

For what it's worth, I have created an issue on the source repository to ask:
- if it was okay to fork (license allows it but just in case),
- if they are still planning on decoupling the server & extension code,
- if they plan on publishing the server as a standalone package.

You can follow the discussions here: https://github.com/stylelint/vscode-stylelint/issues/623
For now nobody has answered.
