### PR TITLE
Add ziggy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1537,3 +1537,6 @@
 [submodule "extensions/zen-abyssal"]
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
+[submodule "extensions/ziggy"]
+	path = extensions/ziggy
+	url = https://github.com/lvignoli/zed-ziggy

--- a/.gitmodules
+++ b/.gitmodules
@@ -1537,6 +1537,7 @@
 [submodule "extensions/zen-abyssal"]
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
+
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy

--- a/extensions.toml
+++ b/extensions.toml
@@ -1655,3 +1655,7 @@ version = "0.1.0"
 submodule = "extensions/zed"
 path = "extensions/zig"
 version = "0.3.1"
+
+[ziggy]
+submodule = "extensions/ziggy"
+version = "0.0.1"


### PR DESCRIPTION
[Ziggy](https://ziggy-lang.io) support for Zed.

The LSP cannot be installed because of an upstream issue: releases for ziggy are distributed as `tar.xz`, not `tar.gz`.
As I understand, Zed extension SDK does not support this compression format.

Linked issues:
- https://github.com/zed-industries/zed/issues/21407
- https://github.com/kristoff-it/ziggy/issues/48