### PR TITLE
Update vscode-dark-modern from `v0.0.4` to `v0.0.5`

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1580,7 +1580,7 @@ version = "1.0.0"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.0.4"
+version = "0.0.5"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"


### PR DESCRIPTION
This pull request updates the **vscode-dark-modern** theme from `v0.0.4` to `v0.0.5`.
- Adds git deleted and info background by @zasdaym in https://github.com/kcamcam/vscode_dark_modern.zed/pull/16