### PR TITLE
Add Haxe language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -570,6 +570,10 @@
 	path = extensions/harper
 	url = https://github.com/Stef16Robbe/harper_zed.git
 
+[submodule "extensions/haxe"]
+	path = extensions/haxe
+	url = https://github.com/Frixuu/Zed-Haxe
+
 [submodule "extensions/helm"]
 	path = extensions/helm
 	url = https://github.com/cabrinha/helm.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -621,6 +621,10 @@ submodule = "extensions/zed"
 path = "extensions/haskell"
 version = "0.1.2"
 
+[haxe]
+submodule = "extensions/haxe"
+version = "0.1.3"
+
 [helm]
 submodule = "extensions/helm"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -623,7 +623,7 @@ version = "0.1.2"
 
 [haxe]
 submodule = "extensions/haxe"
-version = "0.1.3"
+version = "0.2.0"
 
 [helm]
 submodule = "extensions/helm"


### PR DESCRIPTION
[This extension](https://github.com/Frixuu/Zed-Haxe) provides syntax highlighting [\(MIT-licensed\)](https://github.com/vantreeseba/tree-sitter-haxe/blob/12e814cd9b0656b0eaa3e04b0036b3b6625cc0d7/LICENSE.md) and LSP support [\(MIT-licensed\)](https://github.com/vshaxe/haxe-language-server/blob/900c0570372f8f592724b25ac52ababe1ef5717b/LICENSE.md) for the [Haxe](https://haxe.org/) programming language.

Closes #142.

Preview:
![2024-12-04 21-58-19](https://github.com/user-attachments/assets/b801b544-1a20-4d88-935d-b0e58304f161)