### PR TITLE
Update modest-dark to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -861,7 +861,7 @@ version = "0.0.1"
 
 [modest-dark]
 submodule = "extensions/modest-dark"
-version = "0.1.3"
+version = "0.1.4"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Fixed sidebar items being the wrong colour in newest zed update.