### PR TITLE
Bump `ltex` to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -764,7 +764,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.0.3"
+version = "0.0.4"
 
 [lua]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi!

This release brings version 0.0.4 of the `ltex` extension. The most notable change is the switch from the original [`ltex`](https://github.com/valentjn/ltex-ls) repository, which seems to be unmaintained, to a maintained fork named [`ltex-plus`](https://github.com/ltex-plus/ltex-ls-plus). See [the release page](https://github.com/vitallium/zed-ltex/releases/tag/v0.0.4) for more information (which contains everything I've written here. :-)).

**Full Changelog:** [https://github.com/vitallium/zed-ltex/compare/v0.0.3...v0.0.4](https://github.com/vitallium/zed-ltex/compare/v0.0.3...v0.0.4)