### PR TITLE
libsql-context-server: Fix version

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -756,7 +756,7 @@ version = "0.0.1"
 
 [libsql-context-server]
 submodule = "extensions/libsql-context-server"
-version = "0.1.0"
+version = "0.0.1"
 
 [lilypond]
 submodule = "extensions/lilypond"


### PR DESCRIPTION
This PR fixes the version for the `libsql-context-server` extension, since it wasn't correct in #1738.