### PR TITLE
Bump `ruby` to v0.2.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1267,7 +1267,7 @@ version = "0.0.1"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.2.2"
+version = "0.2.3"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Bump `ruby` to v0.2.3

Please see the corresponding bump in the `ruby` extension repo https://github.com/zed-extensions/ruby/pull/15

## Changelog

- Update `config.toml` to include additional Ruby-related files (https://github.com/zed-extensions/ruby/pull/5)
- Upgrade `zed_extension_api` to `v0.2.0` (https://github.com/zed-extensions/ruby/pull/12)
- Add label details to `ruby-lsp` completions (https://github.com/zed-extensions/ruby/pull/13)