### PR TITLE
Add VHDL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1442,6 +1442,10 @@
 	path = extensions/vesper
 	url = https://github.com/bdsqqq/vesper-zed.git
 
+[submodule "extensions/vhdl"]
+	path = extensions/vhdl
+	url = https://github.com/rapgenic/zed-vhdl
+
 [submodule "extensions/vhs"]
 	path = extensions/vhs
 	url = https://github.com/eth0net/zed-vhs.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1563,6 +1563,10 @@ version = "0.0.6"
 submodule = "extensions/vesper"
 version = "0.0.2"
 
+[vhdl]
+submodule = "extensions/vhdl"
+version = "0.0.1"
+
 [vhs]
 submodule = "extensions/vhs"
 version = "0.1.0"


### PR DESCRIPTION
This PR implements an extension for the VHDL language using

* https://github.com/alemuller/tree-sitter-vhdl for the tree-sitter grammar
* https://github.com/VHDL-LS/rust_hdl as the language server
* the zed csharp extension as a reference

This is a reopening of my previous PR #729. The extension should now be fully functioning after the merge of https://github.com/zed-industries/zed/pull/13958