### PR TITLE
Add Cython extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -298,6 +298,10 @@
 	path = extensions/cypher
 	url = https://github.com/pupli/cypher
 
+[submodule "extensions/cython"]
+	path = extensions/cython
+	url = https://github.com/lgeiger/zed-cython.git
+
 [submodule "extensions/d"]
 	path = extensions/d
 	url = https://github.com/staysail/zed-d.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -314,6 +314,10 @@ version = "0.2.0"
 submodule = "extensions/cypher"
 version = "0.0.1"
 
+[cython]
+submodule = "extensions/cython"
+version = "0.1.0"
+
 [d]
 submodule = "extensions/d"
 version = "0.0.8"


### PR DESCRIPTION
This adds support for [Cython](https://cython.org/) syntax highlighting via https://github.com/lgeiger/zed-cython

Closes https://github.com/zed-industries/zed/discussions/14407