### PR TITLE
Bump catppuccin to 0.2.17

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -206,7 +206,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.16"
+version = "0.2.17"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"


### PR DESCRIPTION
- rename from "Catppuccin **Themes**" to just "Catppuccin"
- update maintainer email
- use `v0.2.0` theme schema