### PR TITLE
Bump catppuccin to 0.2.18

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -206,7 +206,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.17"
+version = "0.2.18"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"


### PR DESCRIPTION
- tweak active/inactive tab coloring
- use theme key: `accents` properly for `indent_aware` colors