### PR TITLE
Update catppuccin-blur to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -210,7 +210,7 @@ version = "0.2.17"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"
-version = "0.0.4"
+version = "0.0.5"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"


### PR DESCRIPTION
Release notes:

https://github.com/jenslys/zed-catppuccin-blur/releases/tag/v0.0.5