### PR TITLE
Update catppuccin-blur-plus to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -214,7 +214,7 @@ version = "0.0.6"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"
-version = "0.1.0"
+version = "0.1.1"
 
 [cedar]
 submodule = "extensions/cedar"


### PR DESCRIPTION
Release notes:

https://github.com/taciturnaxolotl/catppuccin-blur-zed/releases/tag/v0.1.1