### PR TITLE
Update SageMath to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1289,7 +1289,7 @@ version = "1.0.3"
 
 [sagemath]
 submodule = "extensions/sagemath"
-version = "0.0.1"
+version = "0.1.0"
 
 [scala]
 submodule = "extensions/scala"


### PR DESCRIPTION
This updates the SageMath extension to:

- Use the SageMath tree sitter grammar instead of python.
- Fix a few other syntax highlighting bugs
- Fix the Github repo link.