### PR TITLE
Update cython to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -320,7 +320,7 @@ version = "0.0.1"
 
 [cython]
 submodule = "extensions/cython"
-version = "0.1.0"
+version = "0.1.1"
 
 [d]
 submodule = "extensions/d"


### PR DESCRIPTION
- Adds support for `.pxi`
- Bump tree-sitter-cython ([diff](https://github.com/b0o/tree-sitter-cython/compare/0fe384913becb968bcaaf02c5d33d3a1ff8bd615...5f5468af68899b1013eef19ffe154e3f9c7a5d4a))