### PR TITLE
Bump Yara to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1666,7 +1666,7 @@ version = "0.1.1"
 
 [yara]
 submodule = "extensions/yara"
-version = "0.0.1"
+version = "0.0.2"
 
 [yellowed]
 submodule = "extensions/yellowed"


### PR DESCRIPTION
Quick PR to bump the Yara extension to `0.0.2` which has better highlighting. The next update won't be such a fast-follow. 😅