### PR TITLE
Update Brainfuck to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -166,7 +166,7 @@ version = "0.0.1"
 
 [brainfuck]
 submodule = "extensions/brainfuck"
-version = "0.0.3"
+version = "0.0.4"
 
 [brook-code-theme]
 submodule = "extensions/brook-code-theme"


### PR DESCRIPTION
- Fix accidental extension id copy pasta (sorry elisp!)

cc: @JosephTLyons 