### PR TITLE
Add nstlgy-dark extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -942,6 +942,10 @@
 	path = extensions/norrsken
 	url = https://github.com/webhooked/norrsken-zed.git
 
+[submodule "extensions/nstlgy-dark"]
+	path = extensions/nstlgy-dark
+	url = https://github.com/nstlgy/zed-nstlgy-dark
+
 [submodule "extensions/nu"]
 	path = extensions/nu
 	url = https://github.com/zed-extensions/nu.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1004,6 +1004,10 @@ version = "0.2.1"
 submodule = "extensions/norrsken"
 version = "3.0.1"
 
+[nstlgy-dark]
+submodule = "extensions/nstlgy-dark"
+version = "0.0.1"
+
 [nu]
 submodule = "extensions/nu"
 version = "0.0.3"


### PR DESCRIPTION
This PR adds the `nstlgy-dark` extension to the Zed extensions repository. The submodule has been added under `extensions/nstlgy-dark` and the `extensions.toml` file has been updated accordingly.
