### PR TITLE
Fix git url of extensions/struct-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1320,7 +1320,7 @@
 
 [submodule "extensions/struct-theme"]
 	path = extensions/struct-theme
-	url = https://gitlab.com/Fake.User/struct-zed-theme
+	url = https://gitlab.com/Fake.User/struct-zed-theme.git
 
 [submodule "extensions/sublime-mariana-theme"]
 	path = extensions/sublime-mariana-theme


### PR DESCRIPTION
Fix for warning on initial submodule setup:
```
Cloning into '/private/tmp/extensions/extensions/struct-theme'...
warning: redirecting to https://gitlab.com/Fake.User/struct-zed-theme.git/
```