### PR TITLE
ruby: Bump to version v0.3.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1300,7 +1300,7 @@ version = "0.0.1"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.2.3"
+version = "0.3.3"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Bump the Ruby extension to v0.3.3.

See the changelog here https://github.com/zed-extensions/ruby/pull/23

Thanks!