### PR TITLE
Add Psalm extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1126,6 +1126,10 @@
 	path = extensions/prolog
 	url = https://github.com/Piefayth/zed-prolog
 
+[submodule "extensions/psalm"]
+	path = extensions/psalm
+	url = https://github.com/sebcode/psalm-zed.git
+
 [submodule "extensions/pug"]
 	path = extensions/pug
 	url = https://github.com/Baw-Appie/zed-pug

--- a/extensions.toml
+++ b/extensions.toml
@@ -1208,6 +1208,10 @@ submodule = "extensions/zed"
 path = "extensions/proto"
 version = "0.2.1"
 
+[psalm]
+submodule = "extensions/psalm"
+version = "0.0.1"
+
 [pug]
 submodule = "extensions/pug"
 version = "0.0.1"


### PR DESCRIPTION
This adds support for [psalm](https://psalm.dev/) lsp, a static analysis tool for PHP.