### PR TITLE
Add move-aptos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -850,6 +850,10 @@
 	path = extensions/move
 	url = https://github.com/Tzal3x/move-zed-extension.git
 
+[submodule "extensions/move-aptos"]
+	path = extensions/move-aptos
+	url = git@github.com:caoyang2002/zed-move-aptos.git
+
 [submodule "extensions/msun-dark"]
 	path = extensions/msun-dark
 	url = https://github.com/mikesun/msun-dark-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -852,7 +852,7 @@
 
 [submodule "extensions/move-aptos"]
 	path = extensions/move-aptos
-	url = git@github.com:caoyang2002/zed-move-aptos.git
+	url = https://github.com/caoyang2002/zed-move-aptos.git
 
 [submodule "extensions/msun-dark"]
 	path = extensions/msun-dark

--- a/extensions.toml
+++ b/extensions.toml
@@ -913,7 +913,7 @@ submodule = "extensions/move"
 version = "0.0.1"
 
 [move-aptos]
-submodule = "extensions/mov-aptos"
+submodule = "extensions/move-aptos"
 version = "0.0.1"
 
 [msun-dark]

--- a/extensions.toml
+++ b/extensions.toml
@@ -912,6 +912,10 @@ version = "0.0.2"
 submodule = "extensions/move"
 version = "0.0.1"
 
+[move-aptos]
+submodule = "extensions/mov-aptos"
+version = "0.0.1"
+
 [msun-dark]
 submodule = "extensions/msun-dark"
 version = "0.0.6"


### PR DESCRIPTION
In the repository, there is already a Move plugin, but this plugin only works with the Sui blockchain. move-aptos is an extension that works with the Aptos blockchain. Although they share some syntax.

<img width="991" alt="image" src="https://github.com/user-attachments/assets/7c288ceb-f67c-4eed-96cc-7e87e2e4d463" />

<img width="878" alt="image" src="https://github.com/user-attachments/assets/915b51ae-7a28-4d7d-81a9-f556d4a1e6cf" />
