### PR TITLE
Update vscode-dark-high-contrast to v1.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1512,7 +1512,7 @@
 
 [submodule "extensions/vscode-dark-high-contrast"]
 	path = extensions/vscode-dark-high-contrast
-	url = https://github.com/nick-myrick/vscode-dark-high-contrast.git
+	url = https://github.com/nqmn1ck/vscode-dark-high-contrast.git
 
 [submodule "extensions/vscode-dark-modern"]
 	path = extensions/vscode-dark-modern

--- a/extensions.toml
+++ b/extensions.toml
@@ -1634,7 +1634,7 @@ version = "0.0.1"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"
-version = "1.0.0"
+version = "1.0.1"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.709.0",
     "@iarna/toml": "2.2.5",
-    "git-submodule-js": "1.0.4"
+    "git-submodule-js": "1.0.4",
+    "pnpm": "^9.15.1"
   },
   "devDependencies": {
     "@tsconfig/node20": "20.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       git-submodule-js:
         specifier: 1.0.4
         version: 1.0.4
+      pnpm:
+        specifier: ^9.15.1
+        version: 9.15.1
     devDependencies:
       '@tsconfig/node20':
         specifier: 20.1.4
@@ -1166,6 +1169,11 @@ packages:
 
   pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+
+  pnpm@9.15.1:
+    resolution: {integrity: sha512-GstWXmGT7769p3JwKVBGkVDPErzHZCYudYfnHRncmKQj3/lTblfqRMSb33kP9pToPCe+X6oj1n4MAztYO+S/zw==}
+    engines: {node: '>=18.12'}
+    hasBin: true
 
   postcss@8.4.35:
     resolution: {integrity: sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==}
@@ -2965,6 +2973,8 @@ snapshots:
       jsonc-parser: 3.2.1
       mlly: 1.6.1
       pathe: 1.1.2
+
+  pnpm@9.15.1: {}
 
   postcss@8.4.35:
     dependencies:


### PR DESCRIPTION
See https://github.com/nqmn1ck/vscode-dark-high-contrast/pull/2 and https://github.com/nqmn1ck/vscode-dark-high-contrast/pull/1 for the improvements. Credit to @teohhanhui.