### PR TITLE
Bump java to v4.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -709,7 +709,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "3.0.1"
+version = "4.0.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Changelog: https://github.com/zed-extensions/java/releases/tag/v4.0.0