### PR TITLE
Add Path of Exile filter file extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1062,6 +1062,10 @@
 	path = extensions/paraiso
 	url = https://github.com/treffynnon/zed-Paraiso.git
 
+[submodule "extensions/path-of-exile"]
+	path = extensions/path-of-exile
+	url = https://github.com/egibs/poe.zed.git
+
 [submodule "extensions/penumbra"]
 	path = extensions/penumbra
 	url = https://github.com/jbisits/penumbra-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1124,6 +1124,10 @@ version = "0.8.0"
 submodule = "extensions/paraiso"
 version = "1.0.1"
 
+[path-of-exile]
+submodule = "extensions/path-of-exile"
+version = "0.0.1"
+
 [penumbra]
 submodule = "extensions/penumbra"
 version = "0.1.1"


### PR DESCRIPTION
This PR adds a new language extension for Path of Exile `.filter` files. 

Most of the time these files are auto-generated by https://www.filterblade.xyz/, but manual tweaking is useful and no such automation currently exists for Path of Exile 2.

Example:
![image](https://github.com/user-attachments/assets/b6e3dc51-84da-4105-af8a-7ce73b9b2d53)