### PR TITLE
Update Yara submodule to pick up URL fix

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1686,7 +1686,7 @@ version = "0.1.1"
 
 [yara]
 submodule = "extensions/yara"
-version = "0.0.2"
+version = "0.0.3"
 
 [yellowed]
 submodule = "extensions/yellowed"


### PR DESCRIPTION
This PR fixes a typo I made with the repository URL for the Yara extension. 

Previously, it was `https://github.com/egibs/yara-zed` when it should have been `https://github.com/egibs/yara.zed`.