### PR TITLE
Bump Java extension to v5.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -713,7 +713,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "4.0.0"
+version = "5.0.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v5.0.0