### PR TITLE
Add quakec language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1617,3 +1617,7 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+
+[submodule "extensions/quakec"]
+	path = extensions/quakec
+	url = https://github.com/schraf/zed-quakec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1166,6 +1166,10 @@
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git
 
+[submodule "extensions/quakec"]
+	path = extensions/quakec
+	url = https://github.com/schraf/zed-quakec.git
+
 [submodule "extensions/quiet-light-theme"]
 	path = extensions/quiet-light-theme
 	url = https://github.com/biaqat/quiet-light-theme-zed.git
@@ -1625,7 +1629,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-
-[submodule "extensions/quakec"]
-	path = extensions/quakec
-	url = https://github.com/schraf/zed-quakec.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -682,6 +682,10 @@
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git
 
+[submodule "extensions/kconfig"]
+	path = extensions/kconfig
+	url = https://github.com/hubertmis/zed-ext-kconfig.git
+
 [submodule "extensions/kdl"]
 	path = extensions/kdl
 	url = https://github.com/elkowar/zed-kdl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -739,6 +739,10 @@ version = "0.1.3"
 submodule = "extensions/kanagawa-themes"
 version = "0.1.1"
 
+[kconfig]
+submodule = "extensions/kconfig"
+version = "0.0.3"
+
 [kdl]
 submodule = "extensions/kdl"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1243,7 +1243,7 @@ version = "0.0.3"
 
 [quakec]
 submodule = "extensions/quakec"
-version = "0.0.1"
+version = "0.0.2"
 
 [qml]
 submodule = "extensions/qml"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1241,6 +1241,10 @@ version = "0.0.1"
 submodule = "extensions/python-refactoring"
 version = "0.0.3"
 
+[quakec]
+submodule = "extensions/quakec"
+version = "0.0.1"
+
 [qml]
 submodule = "extensions/qml"
 version = "0.0.3"


### PR DESCRIPTION
I created a language extension for Zed to support QuakeC. It is based on the the tree-sitter parser by [vkazanov](https://github.com/vkazanov/tree-sitter-quakec).