### PR TITLE
Add Modus Themes v0.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -834,6 +834,10 @@
 	path = extensions/modest-dark
 	url = https://github.com/timcole/modest-dark.git
 
+[submodule "extensions/modus-themes"]
+	path = extensions/modus-themes
+	url = https://github.com/vitallium/zed-modus-themes.git
+
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed

--- a/extensions.toml
+++ b/extensions.toml
@@ -896,6 +896,10 @@ version = "0.0.1"
 submodule = "extensions/modest-dark"
 version = "0.1.4"
 
+[modus-themes]
+submodule = "extensions/modus-themes"
+version = "0.0.1"
+
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.1"


### PR DESCRIPTION
Hello.

This PR adds a new extension with Modus Themes. Highly accessible themes for [Zed](https://zed.dev), conforming with the highest standard for color contrast between background and foreground values ([WCAG AAA](https://www.w3.org/WAI/WCAG21/Understanding/contrast-enhanced.html)). This is a Zed port of the original [Modus Themes](https://protesilaos.com/emacs/modus-themes) built for [GNU Emacs](https://www.gnu.org/software/emacs/).

You can find all screenshots in the repo [here](https://github.com/vitallium/zed-modus-themes?tab=readme-ov-file#screenshots).

Thanks!