### PR TITLE
Update Unison to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1566,7 +1566,7 @@ version = "0.1.5"
 
 [unison]
 submodule = "extensions/unison"
-version = "0.0.4"
+version = "0.0.5"
 
 [unocss]
 submodule = "extensions/unocss"


### PR DESCRIPTION
Updates Unison to latest tree-sitter grammar and includes some minor highlighting fixes a long the way as well.