### PR TITLE
Add chai-theme v0.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -222,6 +222,10 @@
 	path = extensions/cfml
 	url = https://github.com/cfmleditor/zed-cfml.git
 
+[submodule "extensions/chai-theme"]
+	path = extensions/chai-theme
+	url = https://github.com/rushabhcodes/zed-chai-theme
+
 [submodule "extensions/chanterelle"]
 	path = extensions/chanterelle
 	url = https://github.com/steffenhaug/chanterelle-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -228,6 +228,10 @@ version = "1.0.1"
 submodule = "extensions/cfml"
 version = "0.1.5"
 
+[chai-theme]
+submodule = "extensions/chai-theme"
+version = "0.0.1"
+
 [chanterelle]
 submodule = "extensions/chanterelle"
 version = "0.0.1"


### PR DESCRIPTION
### Description
This PR adds the **chai-theme** to the Zed extensions repository. The chai-theme offers a warm, aesthetically pleasing color palette optimized for coding comfort and focus.

### Changes
- Added chai-theme as a Git submodule in `extensions/chai-theme`
- Updated `extensions.toml` with version `0.0.1`

### Notes
- Theme ID: `chai-theme`
- Initial release version: `0.0.1`
