### PR TITLE
Bump Java to v5.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -717,7 +717,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "5.0.0"
+version = "5.0.1"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v5.0.1