### PR TITLE
Update COBOL to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -255,7 +255,7 @@ version = "0.1.0"
 
 [cobol]
 submodule = "extensions/cobol"
-version = "0.0.2"
+version = "0.0.3"
 
 [code-stats]
 submodule = "extensions/code-stats"


### PR DESCRIPTION
There was a bug in `v0.0.2` where the downloaded LSP server binary was not marked as executable. This update fixes this issue.