### PR TITLE
Bump LTeX extension to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -809,7 +809,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.0.4"
+version = "0.0.5"
 
 [lua]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this PR bumps the LTeX extension to v0.0.5 to pull the following 2 changes:

- Added option to override the binary path via local settings.
- Prefer using the cached binary in all use cases.

See the release here https://github.com/vitallium/zed-ltex/releases/tag/v0.0.5

Thanks!