### PR TITLE
csharp: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -296,7 +296,7 @@ version = "0.0.1"
 [csharp]
 submodule = "extensions/zed"
 path = "extensions/csharp"
-version = "0.0.2"
+version = "0.1.0"
 
 [csv]
 submodule = "extensions/csv"


### PR DESCRIPTION
This PR updates the C# extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/22617 for the changes in this version.