### PR TITLE
Add external Racket extension to add LSP support for Racket

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1186,6 +1186,10 @@
 	path = extensions/r
 	url = https://github.com/ocsmit/zed-r.git
 
+[submodule "extensions/racket"]
+	path = extensions/racket
+	url = https://github.com/Reilithion/zed-racket.git
+
 [submodule "extensions/rainbow-csv"]
 	path = extensions/rainbow-csv
 	url = https://github.com/weartist/zed-rainbow-csv.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1274,9 +1274,8 @@ submodule = "extensions/r"
 version = "0.0.3"
 
 [racket]
-submodule = "extensions/zed"
-path = "extensions/racket"
-version = "0.0.2"
+submodule = "extensions/racket"
+version = "0.0.3"
 
 [rainbow-csv]
 submodule = "extensions/rainbow-csv"


### PR DESCRIPTION
Addresses #1828. With this, it is now possible to use `racket-langserver` in Zed, providing the benefits of the Racket language server.