### PR TITLE
Update cue to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -306,7 +306,7 @@ version = "0.0.1"
 
 [cue]
 submodule = "extensions/cue"
-version = "0.0.3"
+version = "0.0.4"
 
 [curry]
 submodule = "extensions/curry"


### PR DESCRIPTION
Release notes:

https://github.com/jkasky/zed-cue/releases/tag/v0.0.4