### PR TITLE
Update Modus Themes to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -902,7 +902,7 @@ version = "0.1.4"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.1"
+version = "0.0.3"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi. This PR update the `modus-themes` to v0.0.3.

Here is the list of changes between v0.0.1 (current) and the target version (v0.0.3):

- Changed Muted text colors (v0.0.3)
- Tweak info and hint colors (v0.0.3)
- Fixed diagnostic popover colors (v0.0.2)
- Added colors for predictive completions (v0.0.2)


https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.3

Thanks!