### PR TITLE
Add Ayu Darker Theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -94,6 +94,10 @@
 	path = extensions/aylin-theme
 	url = https://github.com/biaqat/aylin-theme-zed.git
 
+[submodule "extensions/ayu-darker"]
+	path = extensions/ayu-darker
+	url = https://github.com/k4yt3x/zed-theme-ayu-darker.git
+
 [submodule "extensions/barbenheimer"]
 	path = extensions/barbenheimer
 	url = https://github.com/jayvicsanantonio/barbenheimer-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -95,6 +95,10 @@ version = "0.0.1"
 submodule = "extensions/aylin-theme"
 version = "0.6.0"
 
+[ayu-darker]
+submodule = "extensions/ayu-darker"
+version = "1.0.0"
+
 [barbenheimer]
 submodule = "extensions/barbenheimer"
 version = "1.0.1"


### PR DESCRIPTION
Add a darker variant of the Ayu Dark theme. Ported over from [k4yt3x/ayu-vim-darker](https://github.com/k4yt3x/ayu-vim-darker).

![screenshot](https://github.com/user-attachments/assets/a30d8e4c-af14-465c-be79-ec0ee5230a46)

The original Ayu Dark, for contrast:

![image](https://github.com/user-attachments/assets/f743bdeb-197d-4da2-a8ee-60f127a845d4)

It's my first time working with the Zed ecosystem. I hope I didn't miss anything. If so, please kindly let me know.
