### PR TITLE
Update Modus Themes to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -900,7 +900,7 @@ version = "0.1.4"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.3"
+version = "0.0.4"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this PR bumps Modus Themes to v0.0.4. The release page is here https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.4 but here is the list of changes at your convenience:

## Added

- [Add `drop_target` color](https://github.com/vitallium/zed-modus-themes/commit/49eaac36900aadca4d2dc4ee73c8e2ed4677bbec)
- [Add tritanopia variants](https://github.com/vitallium/zed-modus-themes/commit/bcd3df9fe6baea3aa8d202ecda0caae72dd92c9a)
- [Add deuteranopia variants](https://github.com/vitallium/zed-modus-themes/commit/4bb89a77fb7c4806f5fc151b71f5a7a6ff52d770)

## Changed

- Synced all theme colors with the upstream

## Fixed

- [Fix terminal colors for Modus Operandi](https://github.com/vitallium/zed-modus-themes/commit/7a9c6dca47b4145b26faceb2ba96b67a9744ee8c)

Thanks!