### PR TITLE
code-stats: Bump to v0.2.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -257,7 +257,7 @@ version = "0.0.3"
 
 [code-stats]
 submodule = "extensions/code-stats"
-version = "0.2.3"
+version = "0.2.4"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"


### PR DESCRIPTION
This PR bumps the Code::Stats extension to v0.2.4.