### PR TITLE
Add Dune Theme v1.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -378,6 +378,10 @@
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension
 
+[submodule "extensions/dune-theme"]
+	path = extensions/dune-theme
+	url = https://github.com/Anvell/zed-dune-theme.git
+
 [submodule "extensions/earthfile"]
 	path = extensions/earthfile
 	url = https://github.com/glehmann/earthfile.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -389,6 +389,10 @@ version = "0.9.2"
 submodule = "extensions/duckyscript"
 version = "0.0.1"
 
+[dune-theme]
+submodule = "extensions/dune-theme"
+version = "1.0.0"
+
 [earthfile]
 submodule = "extensions/earthfile"
 version = "0.1.0"


### PR DESCRIPTION
# Description

Adds [Dune theme](https://github.com/Anvell/zed-dune-theme) to Zed extensions repository.

## Notes

Theme ID: `dune-theme`
Initial version: `1.0.0`

### Gallery
#### `01` Arrakis Night

<p align="center">
    <img src="https://raw.githubusercontent.com/Anvell/zed-dune-theme/refs/heads/main/assets/night.png" width=800>
</p>

#### `02` Arrakis Day

<p align="center">
    <img src="https://raw.githubusercontent.com/Anvell/zed-dune-theme/refs/heads/main/assets/day.png" width=800>
</p>