### PR TITLE
Update liquid to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -802,7 +802,7 @@ version = "0.0.6"
 
 [liquid]
 submodule = "extensions/liquid"
-version = "0.0.1"
+version = "0.0.2"
 
 [live-server]
 submodule = "extensions/live-server"


### PR DESCRIPTION
Release notes:

https://github.com/TheBeyondGroup/zed-shopify-liquid/releases/tag/v0.0.2