### PR TITLE
Update HAML extension to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -640,7 +640,7 @@ version = "0.1.0"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.0.7"
+version = "0.1.0"
 
 [hare]
 submodule = "extensions/hare"


### PR DESCRIPTION
Bumps the HAML extension from v0.0.7 to v0.1.0: https://github.com/davidcornu/zed-haml/releases/tag/v0.1.0

Upstream diff: https://github.com/vitallium/tree-sitter-haml/compare/5dedefd955eaaadec309357879a46edf932945cf...ca002c14a373534affb32079dad6ca4a493451b2