### PR TITLE
Update Modus Themes to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -915,7 +915,7 @@ version = "0.1.4"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.4"
+version = "0.0.5"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this PR updates the Modus Themes to v0.0.5 that includes several bug fixes listed on the release page [here](https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.5) but I am copying them here at your convience:

## Fixed

- [Fix the alpha channel for Drag&Drop operations](https://github.com/vitallium/zed-modus-themes/commit/d7f097d787aa92fdd06052a6dcf9b1faf54caffa)
- [Fix the current tab color in Modus Operandi Tinted](https://github.com/vitallium/zed-modus-themes/commit/316f9749fe4dc9de40d67ec1580f04ca8d614a89)
- Fixed https://github.com/vitallium/zed-modus-themes/issues/1
- [Fix button background](https://github.com/vitallium/zed-modus-themes/commit/cfe4747df384371a6d1a54418b4a76b1fc0d359a)

## Added

- [Add icon colors](https://github.com/vitallium/zed-modus-themes/commit/508f6ac34c1439bca999288fcb60dd743a41fa1e)


Thank you!