### PR TITLE
clojure: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -257,7 +257,7 @@ version = "0.0.2"
 
 [clojure]
 submodule = "extensions/clojure"
-version = "0.1.0"
+version = "0.1.1"
 
 [cobalt2]
 submodule = "extensions/cobalt2"


### PR DESCRIPTION
This PR bumps the Clojure extension to v0.1.1.

Changes:

- https://github.com/zed-extensions/clojure/pull/1