### PR TITLE
Update Modus Themes to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -927,7 +927,7 @@ version = "0.1.4"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.5"
+version = "0.0.6"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi! Another small bugfixes only release of Modus Themes - [v0.0.6](https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.6).

## List of fixes

- [Fix Hint color](https://github.com/vitallium/zed-modus-themes/commit/4eebdc843a03c29377a156e29d4507bdd7527d64)
- [Fix Predictive foreground color](https://github.com/vitallium/zed-modus-themes/commit/08ac61d55b5ad4949787cdb595bc1da6a8301cce)
- [Fix color of the scrollbar's thumb](https://github.com/vitallium/zed-modus-themes/commit/858b532b4143fedf05b72494e0690fb582d74149)

Thank you!