### PR TITLE
Add Confluence Context Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -282,6 +282,10 @@
 	path = extensions/colorizer
 	url = https://github.com/tamimhasandev/colorizer.git
 
+[submodule "extensions/confluence-context-server"]
+	path = extensions/confluence-context-server
+	url = https://github.com/mouhamadalmounayar/confluence-context-server
+
 [submodule "extensions/conl"]
 	path = extensions/conl
 	url = https://github.com/ConradIrwin/zed-extension-conl

--- a/extensions.toml
+++ b/extensions.toml
@@ -283,6 +283,10 @@ version = "0.0.5"
 submodule = "extensions/colorizer"
 version = "0.0.4"
 
+[confluence-context-server]
+submodule = "extensions/confluence-context-server"
+version = "1.0.0"
+
 [conl]
 submodule = "extensions/conl"
 version = "1.0.0"


### PR DESCRIPTION
An extension that integrates Confluence pages into the Assistant Panel, enabling users to add their content as context. I believe this could be useful for teams that rely on Confluence for comprehensive documentation.
