### PR TITLE
Update Codebook to 0.1.1 to work with older Linux builds

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -277,7 +277,7 @@ version = "0.2.4"
 
 [codebook]
 submodule = "extensions/codebook"
-version = "0.1.0"
+version = "0.1.1"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"


### PR DESCRIPTION
Fixed https://github.com/blopker/codebook/issues/1 by switching to using musl instead of libc for building Rust on Linux.

Thank you!