### PR TITLE
Bump java to v5.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -750,7 +750,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "5.0.1"
+version = "5.0.2"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v5.0.2