### PR TITLE
Update Twig extension version to 0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1601,7 +1601,7 @@ version = "0.0.9"
 
 [twig]
 submodule = "extensions/twig"
-version = "0.1.1"
+version = "0.2.0"
 
 [twilight]
 submodule = "extensions/twilight"


### PR DESCRIPTION
Fixes the extension by switching language servers and updating highlights.

Thanks @jannisborgers

- language server:
  - old: https://github.com/kaermorchen/twig-language-server
  - new: https://github.com/moetelo/twiggy
  - pinned to v0.17.0 ([v0.18.0 is current](https://www.npmjs.com/package/twiggy-language-server?activeTab=versions))
- old tree-sitter: https://github.com/gbprod/tree-sitter-twig
- new tree-sitter (fork): https://github.com/jannisborgers/tree-sitter-twig
  - [tree-sitter diff](https://github.com/gbprod/tree-sitter-twig/compare/eaf80e6af969e25993576477a9dbdba3e48c1305...jannisborgers:tree-sitter-twig:723926cff978453c40ee11ca8046de0cb248873c)