### PR TITLE
Update Omnetpp to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1107,7 +1107,7 @@ version = "0.0.1"
 
 [omnetpp]
 submodule = "extensions/omnetpp"
-version = "0.0.1"
+version = "0.0.2"
 
 [one-black-theme]
 submodule = "extensions/one-black-theme"


### PR DESCRIPTION
Updated language names to be more human-friendly and fixed highlighting
Rename languages:
- `omnetpp-msg` -> `OMNeT++ MSG`
- `omnetpp-ned` -> `OMNeT++ NED`