### PR TITLE
Add SSH-config v0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1410,6 +1410,10 @@
 	path = extensions/srcery
 	url = https://github.com/srcery-colors/srcery-zed.git
 
+[submodule "extensions/ssh-config"]
+	path = extensions/ssh-config
+	url = https://github.com/pranavmangal/zed-ssh-config.git
+
 [submodule "extensions/stan"]
 	path = extensions/stan
 	url = https://github.com/WardBrian/zed-stan-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1497,6 +1497,10 @@ version = "1.1.2"
 submodule = "extensions/srcery"
 version = "0.0.2"
 
+[ssh-config]
+submodule = "extensions/ssh-config"
+version = "0.1.0"
+
 [stan]
 submodule = "extensions/stan"
 version = "0.0.1"


### PR DESCRIPTION
Adds an extension to support syntax highlighting for SSH config files.

Example:
<img width="371" alt="zed-ssh-config" src="https://github.com/user-attachments/assets/308c8a47-6cf0-4cc2-bb0d-5dc15f3c4c42" />
