### PR TITLE
Update Obsidian Sunset to 1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1091,7 +1091,7 @@ version = "0.0.1"
 
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"
-version = "1.0.0"
+version = "1.1.0"
 
 [ocaml]
 submodule = "extensions/ocaml"


### PR DESCRIPTION
Update Obsidian Sunset theme extension to v.1.1.0
Repository link: https://github.com/lczerniawski/ObsidianSunset-Zed