### PR TITLE
Update Modus Themes to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -939,7 +939,7 @@ version = "0.1.4"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.6"
+version = "0.0.7"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi! This pull request updates `Modus Themes` extension to v0.0.7. This version has only bugfixes. You can find the release [here](https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.7) but I also copying its notes here at your convenience. Thanks!

## What's changed in Modus Themes v0.0.7

- [Adjust the dimmed foreground color for "Modus Operandi Tinted"](https://github.com/vitallium/zed-modus-themes/commit/165e057561be9a622c3a30d39597c344c2f713e7)
- [Change text.literal fg color to match Modus Themes](https://github.com/vitallium/zed-modus-themes/commit/2b8c96844dae1b454be283d794ecf941949a95d6)
- [Make keyword oblique](https://github.com/vitallium/zed-modus-themes/commit/70c793875f059aad231433c87dcb867cefea9117)
- [Maketype oblique](https://github.com/vitallium/zed-modus-themes/commit/5f8e10230ff62eebf4280193bd8c1685831a75d6)
- [Make variable.special oblique](https://github.com/vitallium/zed-modus-themes/commit/1203bbfdede803807f18da0eff745bc631e9126e)
- [Change color for attribute to preprocessor to match Modus Themes](https://github.com/vitallium/zed-modus-themes/commit/ffff3dd7ec311389585423869bc5c39b1297e43f)
- [Make comment italic](https://github.com/vitallium/zed-modus-themes/commit/76691ee61eed49d4ffc323be33382d3389e759d9)
- [Fix players backgrounds and selections](https://github.com/vitallium/zed-modus-themes/commit/cae8e215ae9d3039a51b7d81667e3d479d4894d6)
- [Fix main player background and selection](https://github.com/vitallium/zed-modus-themes/commit/b4df2ef8c387d46a7da15a69cdd06a38be2b56b5)
- [Update search.match_background color](https://github.com/vitallium/zed-modus-themes/commit/70189cd217a1e216a54989780472ad5108288553)
- [Fix keyword color](https://github.com/vitallium/zed-modus-themes/commit/b493c6cf5658b7066f02c273b077a41192724f13)
- [Fix function color](https://github.com/vitallium/zed-modus-themes/commit/76a61f84feb83d042e9de95755831b878f368d7a)