### PR TITLE
Update ltex to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -846,7 +846,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.0.5"
+version = "0.0.6"
 
 [lua]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This pull request updates the `LTeX` extension to v0.0.6. The release page is [here](https://github.com/vitallium/zed-ltex/releases/tag/v0.0.6). This release contains only one bug fix for users who have installed Java and configured `JAVA_HOME` env variable. For some reasone, starting `ltex` LS under such conditions fails with:

```
Language server error: ltex

oneshot canceled
-- stderr--
Error: JAVA_HOME is not defined correctly.
  We cannot execute /Users/vslobodin/.local/share/mise/installs/java/21.0.2
[?2004l/bin/java
```

Thanks!