### PR TITLE
Update Monokai Vibrant Amped to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -947,7 +947,7 @@ version = "0.0.1"
 
 [monokai-vibrant-amped]
 submodule = "extensions/monokai-vibrant-amped"
-version = "0.0.1"
+version = "0.0.2"
 
 [monolith]
 submodule = "extensions/monolith"


### PR DESCRIPTION
Whoops! I might have put the name in wrong in the previous PR :sweat:.