### PR TITLE
Bump java to v6.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -750,7 +750,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "5.0.2"
+version = "6.0.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v6.0.0