### PR TITLE
vue: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1766,7 +1766,7 @@ version = "0.0.2"
 
 [vue]
 submodule = "extensions/vue"
-version = "0.1.3"
+version = "0.2.0"
 
 [wakatime]
 submodule = "extensions/wakatime"


### PR DESCRIPTION
This PR updates the Vue extension to v0.2.0.

See https://github.com/zed-extensions/vue/pull/14 for the changes in this version.