### PR TITLE
clojure: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -265,7 +265,7 @@ version = "0.0.2"
 
 [clojure]
 submodule = "extensions/clojure"
-version = "0.1.1"
+version = "0.2.0"
 
 [cobalt2]
 submodule = "extensions/cobalt2"


### PR DESCRIPTION
This PR updates the Clojure extension to v0.2.0.

See https://github.com/zed-extensions/clojure/pull/8 for the changes in this version.