### PR TITLE
Update vitesse theme refined to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1738,7 +1738,7 @@ version = "0.0.2"
 
 [vitesse-theme-refined]
 submodule = "extensions/vitesse-theme-refined"
-version = "0.0.1"
+version = "0.0.2"
 
 [vrl]
 submodule = "extensions/vrl"


### PR DESCRIPTION
`schema_version` was incorrectly set to 2 instead of 1 which prevented the extension from being available to use.
Also add a few color fixes.