### PR TITLE
Bump extension CLI version to `9d6c0e5`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: b5ce8e7aa500d530389fef4cdd26f4790d013682
+  ZED_EXTENSION_CLI_SHA: 9d6c0e57a05209b4a1a46091e9b3450110ee32a1
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/9d6c0e57a05209b4a1a46091e9b3450110ee32a1.