### PR TITLE
Add Material Icon Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -866,6 +866,10 @@
 	path = extensions/material-dark
 	url = https://github.com/xerodark/zed-material-theme.git
 
+[submodule "extensions/material-icon-theme"]
+	path = extensions/material-icon-theme
+	url = https://github.com/zed-extensions/material-icon-theme.git
+
 [submodule "extensions/material-theme"]
 	path = extensions/material-theme
 	url = https://github.com/Codextor/zed-material-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -913,6 +913,10 @@ version = "1.0.0"
 submodule = "extensions/material-dark"
 version = "0.0.1"
 
+[material-icon-theme]
+submodule = "extensions/material-icon-theme"
+version = "0.1.0"
+
 [material-theme]
 submodule = "extensions/material-theme"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the [Material Icon Theme](https://github.com/zed-extensions/material-icon-theme).

Note that this requires Zed v0.173.0 or higher in order to use.

