### PR TITLE
Add tree-sitter-query extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1538,6 +1538,10 @@
 	path = extensions/tomorrow-theme
 	url = https://github.com/biaqat/tomorrow-theme-zed.git
 
+[submodule "extensions/tree-sitter-query"]
+	path = extensions/tree-sitter-query
+	url = https://github.com/vitallium/zed-tree-sitter-query.git
+
 [submodule "extensions/tsar"]
 	path = extensions/tsar
 	url = https://github.com/x032205/tsar-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1630,6 +1630,10 @@ version = "0.1.2"
 submodule = "extensions/tomorrow-theme"
 version = "0.9.0"
 
+[tree-sitter-query]
+submodule = "extensions/tree-sitter-query"
+version = "0.0.1"
+
 [tsar]
 submodule = "extensions/tsar"
 version = "0.0.2"


### PR DESCRIPTION
Hi, this pull request adds a new extension for proper highlighting and editing of tree-sitter query files (*.scm). The repo is here - https://github.com/vitallium/zed-tree-sitter-query

Here are before&after screenshots:

![CleanShot 2025-02-01 at 11 19 24@2x](https://github.com/user-attachments/assets/4d3d5dc5-6ae4-4312-8675-2a3a7b40ec35)

![CleanShot 2025-02-01 at 11 20 15@2x](https://github.com/user-attachments/assets/660b3baa-77d8-45fc-8e94-f3a2fbd5a73e)


The only thing is: Scheme language also uses the `scm` extension so there might be a conflict when you open a Scheme file or a Tree-sitter query file. Thanks!