### PR TITLE
Bump scheme to v0.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1354,6 +1354,10 @@
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git
 
+[submodule "extensions/scheme"]
+	path = extensions/scheme
+	url = https://github.com/zed-extensions/scheme.git
+
 [submodule "extensions/scls"]
 	path = extensions/scls
 	url = https://github.com/d1y/simple-completion-zed
@@ -1769,6 +1773,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/scheme"]
-	path = extensions/scheme
-	url = https://github.com/zed-extensions/scheme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1769,3 +1769,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/scheme"]
+	path = extensions/scheme
+	url = https://github.com/zed-extensions/scheme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1427,9 +1427,8 @@ submodule = "extensions/scala"
 version = "0.1.1"
 
 [scheme]
-submodule = "extensions/zed"
-path = "extensions/scheme"
-version = "0.0.2"
+submodule = "extensions/scheme"
+version = "0.0.3"
 
 [scls]
 submodule = "extensions/scls"


### PR DESCRIPTION
Move scheme extension from zed tree to dedicated repo:
- https://github.com/zed-extensions/scheme

No-op otherwise.