### PR TITLE
Update Gentle Dark to v1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -563,7 +563,7 @@ version = "0.0.1"
 
 [gentle-dark]
 submodule = "extensions/gentle-dark"
-version = "1.0.1"
+version = "1.1.0"
 
 [git-firefly]
 submodule = "extensions/git-firefly"


### PR DESCRIPTION
- Set drop_target.background color
- Make the text.accent color easier to see
- Set the tag color under syntax
- Set the color editor.document_highlight.bracket_background
- Add black terminal colors that are easy to see