### PR TITLE
Update LaTeX to v0.1.9

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -822,7 +822,7 @@ version = "1.0.0"
 
 [latex]
 submodule = "extensions/latex"
-version = "0.1.8"
+version = "0.1.9"
 
 [leblackque]
 submodule = "extensions/leblackque"


### PR DESCRIPTION
Add preview and two-way sync for linux+GNOME.

I also add a `textobjects.scm` as per [the docs](https://zed.dev/docs/extensions/languages?highlight=text#text-objects)
defining captures for 'class' but vim-mode movements like `[[` and `]]` seem unaffected. I'm adding here to experiment and see if it's a dev-extension limitation.