### PR TITLE
Add VSCode icons theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1678,6 +1678,10 @@
 	path = extensions/vscode-dark-plus
 	url = https://github.com/d1y/vscode_dark_plus.zed.git
 
+[submodule "extensions/vscode-icons"]
+	path = extensions/vscode-icons
+	url = https://github.com/pranavmangal/zed-vscode-icons
+
 [submodule "extensions/vscode-monokai-charcoal"]
 	path = extensions/vscode-monokai-charcoal
 	url = https://github.com/d1y/vscode-monokaicharcoal.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1770,6 +1770,10 @@ version = "0.0.5"
 submodule = "extensions/vscode-dark-plus"
 version = "0.0.1"
 
+[vscode-icons]
+submodule = "extensions/vscode-icons"
+version = "0.1.0"
+
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"


### PR DESCRIPTION
Thank you for implementing support for custom icons in Zed!

This PR adds the [zed-vscode-icons](https://github.com/pranavmangal/zed-vscode-icons) theme, which uses icons from the popular [vscode-icons](https://github.com/vscode-icons/vscode-icons) project.
