### PR TITLE
Bump Ruby to v0.4.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1407,7 +1407,7 @@ version = "0.0.1"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.3.3"
+version = "0.4.4"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this PR bumps the Ruby extension to v0.4.4. 

Here is the full list of changes:

All screenshots were made by using the following settings:

- Default theme `One Dark`
- Font `Berkeley Mono v2`, size 15.
- Zed Preview 0.172.8

## Remove .rdoc from the list of Ruby files

- [Remove .rdoc from the list of Ruby files](https://github.com/zed-extensions/ruby/commit/1109c8bf3898d501aaacd465e2747f3f70cd874a)

| Before  | After  |
|---------|--------|
| ![rdoc_before](https://github.com/user-attachments/assets/63c529d1-7e83-475a-b244-4ffbfdcfcc61) | ![rdoc_after](https://github.com/user-attachments/assets/5f7a9fbd-d1b4-4afa-8064-f87ca607864f) |


## Change `identifier` and `global_variable` highlighting

- [Change `identifier` and `global_variable` highlighting](https://github.com/zed-extensions/ruby/commit/a5a818d0a2460973425ffee7d2834063dae7409e)

| Before  | After  |
|---------|--------|
| ![global_vars_before](https://github.com/user-attachments/assets/905e2d29-1f0a-477a-b3b1-6994880d5c4a)| ![global_after](https://github.com/user-attachments/assets/5ba82fcf-714a-4a44-ba39-a7a30db81283)|

## Separate `nil` from boolean literals

[Separate `nil` from boolean literals](https://github.com/zed-extensions/ruby/commit/5a666ca6cbf127b686641df2fe72996d10cb9c1f)


| Before  | After  |
|---------|--------|
| ![boolean_before](https://github.com/user-attachments/assets/88785d1c-34cf-489a-9c6d-6446c41e2c55) |![boolean_after](https://github.com/user-attachments/assets/3af84d73-b355-422f-bc96-1b922e61f4ab)|


## Improve import keyword highlighting

- [Improve import keyword highlighting](https://github.com/zed-extensions/ruby/commit/1c44a89893145747034dbf13bac501962995e1c0)

| Before  | After  |
|---------|--------|
| ![import_keywords_before](https://github.com/user-attachments/assets/3c9d3917-5add-414a-b62e-902300923b9a)| ![import_keywords_after](https://github.com/user-attachments/assets/121ede82-0a05-4cf1-a358-f2560b6510f6)|


## Add highlighting for module and exception keywords

- [Add highlighting for module and exception keywords](https://github.com/zed-extensions/ruby/commit/cf08167d2b651dadb0656b2dd6ec772cdb4c674d)

### Built-in module functions and exception keywords

| Before  | After  |
|---------|--------|
| ![builtin_and_exceptions_before](https://github.com/user-attachments/assets/65f0157c-9dff-468b-890f-e59ed24e1653)| ![built_it_after_v2](https://github.com/user-attachments/assets/c8c56cc2-683e-4e75-941d-ac5f0da00d80)|

### Refinements and the `fail`

| Before  | After  |
|---------|--------|
| ![refinements_and_raise_before](https://github.com/user-attachments/assets/5f097253-f4ee-45fb-9ab9-13d9b95ea71f) | ![refinements_after](https://github.com/user-attachments/assets/518864a4-4615-41c8-b9e4-d4aa2d1bcd3a)|

### `catch` and `throw`

| Before  | After  |
|---------|--------|
| ![catch_and_throw_before](https://github.com/user-attachments/assets/8786262d-fd7e-4d1b-8657-4023ccf58923)| ![catch_and_throw_after](https://github.com/user-attachments/assets/5c32ff99-d944-4ff1-8adb-8b34b8d6de98)|

## Remove redundant overrides.scm

- [Remove redundant overrides.scm](https://github.com/zed-extensions/ruby/commit/2bc986648b1675a4fb65d7c52bfb1b9b83ceb266)

## Updates tree-sitter grammars

- [Update tree-sitter-ruby to v0.23.1](https://github.com/zed-extensions/ruby/commit/fd2eaaed6aef97985cd6bd5243ff37490b89c955)
- [Update tree-sitter-embedded-template to v0.23.2](https://github.com/zed-extensions/ruby/commit/7ef8f53d7be6ecaddac262249ddbe078cb868e7d)
- [Update tree-sitter-rbs](https://github.com/zed-extensions/ruby/commit/528e4ddb65a0f24be2e5b557ed76a5f000e9070d)

Thanks!