### PR TITLE
material-icon-theme: Bump to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -915,7 +915,7 @@ version = "0.0.1"
 
 [material-icon-theme]
 submodule = "extensions/material-icon-theme"
-version = "0.1.0"
+version = "0.1.1"
 
 [material-theme]
 submodule = "extensions/material-theme"


### PR DESCRIPTION
This PR bumps the Material Icon Theme to v0.1.1.