### PR TITLE
Update oceanic-next theme

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1131,7 +1131,7 @@ version = "0.0.2"
 
 [oceanic-next]
 submodule = "extensions/oceanic-next"
-version = "0.1.0"
+version = "0.2.0"
 
 [odin]
 submodule = "extensions/odin"


### PR DESCRIPTION
Seems that a recent version of Zed (around 0.168.2) surfaced a hidden bug in the oceanic-next theme (selected project panel items are now respecting `element.selected` property). 

Thanks for your hard work on Zed. It's my daily driver for both personal and work projects ❤️