### PR TITLE
material-icon-theme: Bump to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -915,7 +915,7 @@ version = "0.0.1"
 
 [material-icon-theme]
 submodule = "extensions/material-icon-theme"
-version = "0.1.1"
+version = "0.1.2"
 
 [material-theme]
 submodule = "extensions/material-theme"


### PR DESCRIPTION
This PR updates the Material Icon Theme extension to v0.1.2.