### PR TITLE
Bump beancount to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -129,7 +129,7 @@ version = "0.0.1"
 
 [beancount]
 submodule = "extensions/beancount"
-version = "0.0.4"
+version = "0.0.5"
 
 [bearded]
 submodule = "extensions/bearded"


### PR DESCRIPTION
- See: https://github.com/zed-extensions/beancount/pull/8
- Includes: https://github.com/zed-extensions/beancount/pull/7