### PR TITLE
Bump Modus themes to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -967,7 +967,7 @@ version = "0.1.5"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.7"
+version = "0.0.8"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this pull request updates Modus Themes to support newly introduced `version.*` color themes settings for the upcoming Git panel.

## Modus Operandi

![CleanShot 2025-02-07 at 21 39 47@2x](https://github.com/user-attachments/assets/b0b1d323-d8e6-4373-b2c3-6de044d0f598)

## Modus Vivendi

![CleanShot 2025-02-07 at 21 39 54@2x](https://github.com/user-attachments/assets/bb9f4794-3808-4536-871a-bc25964f9a85)
