### PR TITLE
Update Bearded Icon Theme to 0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,6 +134,10 @@
 	path = extensions/bearded
 	url = https://github.com/lassejlv/bearded-themes.git
 
+[submodule "extensions/bearded-icon-theme"]
+	path = extensions/bearded-icon-theme
+	url = https://github.com/sethstha/bearded-icons-theme.git
+
 [submodule "extensions/becker-theme"]
 	path = extensions/becker-theme
 	url = https://github.com/Becker-Theme/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -135,6 +135,10 @@ version = "0.0.5"
 submodule = "extensions/bearded"
 version = "1.0.0"
 
+[bearded-icon-theme]
+submodule = "extensions/bearded-icon-theme"
+version = "0.1.0"
+
 [becker-theme]
 submodule = "extensions/becker-theme"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -137,7 +137,7 @@ version = "1.0.0"
 
 [bearded-icon-theme]
 submodule = "extensions/bearded-icon-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [becker-theme]
 submodule = "extensions/becker-theme"


### PR DESCRIPTION
In this PR
* Bumped version to `0.2.0`
* Added icons for `default file` `documents` `heroku` `json` `lock` `metal` `phoenix` `roc` `templates` `v`
* Fixed typo on extension repo 