### PR TITLE
Bump PHP to v0.2.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1218,6 +1218,10 @@
 	path = extensions/phine-theme
 	url = https://github.com/phisch/phine-zed.git
 
+[submodule "extensions/php"]
+	path = extensions/php
+	url = https://github.com/zed-extensions/php.git
+
 [submodule "extensions/pica200"]
 	path = extensions/pica200
 	url = https://github.com/Squareheron942/zed-pica200.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1271,7 +1271,7 @@ submodule = "extensions/phine-theme"
 version = "0.0.1"
 
 [php]
-submodule = "extensions/zed"
+submodule = "extensions/php"
 version = "0.2.5"
 
 [pica200]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1272,8 +1272,7 @@ version = "0.0.1"
 
 [php]
 submodule = "extensions/zed"
-path = "extensions/php"
-version = "0.2.4"
+version = "0.2.5"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
Includes:
- Extraction of PHP extension from [zed-industries](https://github.com/zed-industries/zed/) to [zed-extensions/php](https://github.com/zed-extensions/php)
- https://github.com/zed-industries/zed/pull/24558 (thanks @MrSubidubi!)

See:
- https://github.com/zed-extensions/php/pull/1