### PR TITLE
Bump PHP to v0.2.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1280,7 +1280,7 @@ version = "0.0.1"
 
 [php]
 submodule = "extensions/php"
-version = "0.2.5"
+version = "0.2.6"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
Just changes the repo URL.
Includes:
- https://github.com/zed-extensions/php/pull/2