### PR TITLE
Bump Zed Legacy Themes to v0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1804,7 +1804,7 @@
 
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
-	url = https://github.com/zed-industries/legacy-themes.git
+	url = https://github.com/zed-extensions/legacy-themes.git
 
 [submodule "extensions/zedokai"]
 	path = extensions/zedokai

--- a/extensions.toml
+++ b/extensions.toml
@@ -1888,7 +1888,7 @@ version = "1.2.0"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
-version = "0.0.1"
+version = "0.0.2"
 
 [zedokai]
 submodule = "extensions/zedokai"


### PR DESCRIPTION
Update URL fix to point at new repo: [zed-extensions/legacy-themes](https://github.com/zed-extensions/legacy-themes).