### PR TITLE
Update catppuccin-icons to v1.17.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -249,7 +249,7 @@ version = "0.1.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
-version = "1.17.1"
+version = "1.17.2"
 
 [cedar]
 submodule = "extensions/cedar"


### PR DESCRIPTION
Release notes:

https://github.com/tecandrew/catppuccin-zed-icons/releases/tag/v1.17.2