### PR TITLE
Update Ruby to v0.4.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1419,7 +1419,7 @@ version = "0.0.1"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.4.4"
+version = "0.4.5"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hello! This PR is about updating the Ruby extension to v0.4.5 which has a single improvement for displaying symbols in Ruby test files. Here is a screenshot showing how it appears in action:

![CleanShot 2025-02-13 at 19 10 51@2x](https://github.com/user-attachments/assets/9a2a3325-9ff3-4bd1-8d0d-da6c01f0efff)


Thank you!