### PR TITLE
Update Cucumber to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -362,7 +362,7 @@ version = "0.0.2"
 
 [cucumber]
 submodule = "extensions/cucumber"
-version = "0.0.1"
+version = "0.0.2"
 
 [cue]
 submodule = "extensions/cue"


### PR DESCRIPTION
Fixing an issue with custom tags, e.g. including `.`.