### PR TITLE
code-stats: Bump to v0.2.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -293,7 +293,7 @@ version = "0.0.3"
 
 [code-stats]
 submodule = "extensions/code-stats"
-version = "0.2.4"
+version = "0.2.5"
 
 [codebook]
 submodule = "extensions/codebook"


### PR DESCRIPTION
This PR bumps the Code::Stats extension to v0.2.5.