### PR TITLE
Add `vscode-light-plus` theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1734,6 +1734,10 @@
 	path = extensions/vscode-icons
 	url = https://github.com/pranavmangal/zed-vscode-icons
 
+[submodule "extensions/vscode-light-plus"]
+	path = extensions/vscode-light-plus
+	url = https://github.com/MadLittleMods/zed-theme-vscode-light-plus.git
+
 [submodule "extensions/vscode-monokai-charcoal"]
 	path = extensions/vscode-monokai-charcoal
 	url = https://github.com/d1y/vscode-monokaicharcoal.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1821,6 +1821,10 @@ version = "0.1.2"
 submodule = "extensions/vscode-icons"
 version = "0.2.0"
 
+[vscode-light-plus]
+submodule = "extensions/vscode-light-plus"
+version = "0.0.1"
+
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"


### PR DESCRIPTION
Add `vscode-light-plus` theme extension

> Port of the VSCode Light+ (Default Light+) theme for the Zed code editor

Project: https://github.com/MadLittleMods/zed-theme-vscode-light-plus