### PR TITLE
ruby: Bump to v0.4.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1446,7 +1446,7 @@ version = "0.0.1"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.4.5"
+version = "0.4.6"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this PR updates the Ruby extension to v0.4.6 that adds support for textobjects in vim mode. 

Here is how it looks in action:

# Classes and modules

https://github.com/user-attachments/assets/73881f12-7d23-4cae-9a43-6534c50cafcd

Used code for testing:

```ruby
# Class and Modules:

# ac - around class
# ic - inside class
class User < ApplicationRecord
  def full_name
    "#{first_name} #{last_name}"
  end
end

# ac - around class
# ic - inside class
class << User
  def find_admin
    where(admin: true).first
  end
end

# ac - around class (module)
# ic - inside class (module)
module Notifiable
  def send_notification
    # Notification logic
  end
end
```


# Functions and blocks

https://github.com/user-attachments/assets/e7ecb4b5-b8fb-4457-8e36-8a8e1dbce9b1

Used code for testing:

```ruby
# Functions and Blocks:

# af - around function
# if - inside function
def self.active_users
  where(active: true)
end

# af - around function
# if - inside function
def calculate_total
  items.sum(&:price)
end
```

Thanks!