### PR TITLE
Remove fennel extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -482,10 +482,6 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
-[submodule "extensions/fennel"]
-	path = extensions/fennel
-	url = https://codeberg.org/mattly/zed-lang-fennel.git
-
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -508,10 +508,6 @@ version = "0.0.2"
 submodule = "extensions/exquisite"
 version = "0.1.3"
 
-[fennel]
-submodule = "extensions/fennel"
-version = "0.0.1"
-
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
 version = "0.1.1"


### PR DESCRIPTION
The source repository of the fennel extension has been removed:
- https://codeberg.org/mattly/zed-lang-fennel

This prevents people from doing a clean checkout of all submodules.

Contacted author (@mattly) via email to see if this was intentional and whether they wish to pull the extension.

Originally introduced in:
- https://github.com/zed-industries/extensions/pull/1253
