### PR TITLE
Bump fsharp to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -558,7 +558,7 @@ version = "0.0.1"
 
 [fsharp]
 submodule = "extensions/fsharp"
-version = "0.0.4"
+version = "0.0.5"
 
 [fsm]
 submodule = "extensions/fsm"


### PR DESCRIPTION
Bumps fsharp to [0.0.5](https://github.com/nathanjcollins/zed-fsharp/releases/tag/0.0.5)