### PR TITLE
Update catppuccin-icons to v1.17.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -253,7 +253,7 @@ version = "0.1.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
-version = "1.17.3"
+version = "1.17.4"
 
 [cedar]
 submodule = "extensions/cedar"


### PR DESCRIPTION
Release notes:

https://github.com/catppuccin/zed-icons/releases/tag/v1.17.4