### PR TITLE
deno: Bump to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -419,7 +419,7 @@ version = "0.0.9"
 [deno]
 submodule = "extensions/zed"
 path = "extensions/deno"
-version = "0.0.2"
+version = "0.1.0"
 
 [devicetree]
 submodule = "extensions/devicetree"


### PR DESCRIPTION
This PR updates the Deno extension to v0.1.0.

See https://github.com/zed-industries/zed/pull/25255 for the changes in this version.