### PR TITLE
toml: Bump to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1670,7 +1670,7 @@ version = "0.5.0"
 [toml]
 submodule = "extensions/zed"
 path = "extensions/toml"
-version = "0.1.2"
+version = "0.1.3"
 
 [tomorrow-theme]
 submodule = "extensions/tomorrow-theme"


### PR DESCRIPTION
This PR updates the TOML extension to v0.1.3.

See https://github.com/zed-industries/zed/pull/25278 for the changes in this version.