### PR TITLE
Update Axolosin to v1.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -97,7 +97,7 @@ version = "0.0.1"
 
 [axolosin]
 submodule = "extensions/axolosin"
-version = "1.1.0"
+version = "1.1.1"
 
 [aylin-theme]
 submodule = "extensions/aylin-theme"


### PR DESCRIPTION
Update Axolosin theme to v1.1.1

Changes:
- Updated `scrollbar_thumb.background` style property to `scrollbar.thumb.background` to comply with https://github.com/zed-industries/zed/pull/8004