### PR TITLE
Update neovim-default theme to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1071,7 +1071,7 @@ version = "0.0.2"
 
 [neovim-default]
 submodule = "extensions/neovim-default"
-version = "0.2.0"
+version = "0.3.0"
 
 [new-darcula]
 submodule = "extensions/new-darcula"


### PR DESCRIPTION
This replaces scrollbar_thumb with scrollbar.thumb and fixes #2101 for this theme