### PR TITLE
Add `/jira` slash command extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -490,7 +490,7 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
-[submodule "extensions/extensions/jira-slash-command"]
+[submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -491,7 +491,7 @@
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
 [submodule "extensions/extensions/jira-slash-command"]
-	path = extensions/extensions/jira-slash-command
+	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
 
 [submodule "extensions/fiberplane-studio"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -490,6 +490,10 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
+[submodule "extensions/extensions/jira-slash-command"]
+	path = extensions/extensions/jira-slash-command
+	url = https://github.com/trbroyles1/jira-slash-command.git
+
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -490,10 +490,6 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
-[submodule "extensions/jira-slash-command"]
-	path = extensions/jira-slash-command
-	url = https://github.com/trbroyles1/jira-slash-command.git
-
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git
@@ -769,6 +765,10 @@
 [submodule "extensions/jinja2"]
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
+
+[submodule "extensions/jira-slash-command"]
+	path = extensions/jira-slash-command
+	url = https://github.com/trbroyles1/jira-slash-command.git
 
 [submodule "extensions/jsonnet"]
 	path = extensions/jsonnet

--- a/extensions.toml
+++ b/extensions.toml
@@ -808,6 +808,10 @@ version = "2.0.2"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
+[jira-slash-command]
+submodule = "extensions/jira-slash-command"
+version = "0.0.1"
+
 [jsonnet]
 submodule = "extensions/jsonnet"
 version = "0.3.1"


### PR DESCRIPTION
This PR adds a `/jira` slash command to pull an issue from JIRA and include it as a JSON object in assistant context.

Repo: https://github.com/trbroyles1/jira-slash-command

* Implementation is pure Rust, so no external MCP required.
* Uses `http_client` from the Zed extension API to talk to JIRA.
* Requires setting 3 environment variables: 
  - `JIRA_URL`
  - `JIRA_USER`
  - `JIRA_API_TOKEN`. 

Example usage is like: `/jira JRA-1234`

The following issue fields will be included:
* Issue Key
* Summary
* Description
* Issue Type
* Created At
* Reporter
* Assignee (or "Unassigned" if not assigned)
* Status

Comments will be included, each will have:
* Author
* Created At
* Comment Body

It will _not_ try to do anything with attachments on the issue or images posted in the issue or comment bodies.

Ref repository README for further details.