### PR TITLE
Update `visual-assist-dark` to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1791,7 +1791,7 @@ version = "0.0.1"
 
 [visual-assist-dark]
 submodule = "extensions/visual-assist-dark"
-version = "0.0.3"
+version = "0.0.4"
 
 [vitesse]
 submodule = "extensions/vitesse"


### PR DESCRIPTION
To stop using deprecated `scrollbar_thumb.background`.