### PR TITLE
Add Air extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -34,6 +34,10 @@
 	path = extensions/aiken
 	url = https://github.com/aiken-lang/zed-aiken.git
 
+[submodule "extensions/air"]
+	path = extensions/air
+	url = https://github.com/posit-dev/air.git
+
 [submodule "extensions/alabaster"]
 	path = extensions/alabaster
 	url = https://github.com/tsimoshka/zed-theme-alabaster.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -34,6 +34,11 @@ version = "0.1.0"
 submodule = "extensions/aiken"
 version = "1.0.0"
 
+[air]
+submodule = "extensions/air"
+path = "editors/zed"
+version = "0.1.0"
+
 [alabaster]
 submodule = "extensions/alabaster"
 version = "0.0.2"


### PR DESCRIPTION
[Air](https://github.com/posit-dev/air) is an extremely fast R code formatter, using the same underlying infra as both Ruff and Biome.

We've been working on a Zed extension (mostly mimicking Ruff) which lives here:
https://github.com/posit-dev/air/tree/main/editors/zed

The submodule commit points to https://github.com/posit-dev/air/commit/88c573ba9cdabf084cf7817ab419f87beea37b39 where we've introduced 0.1.0 of the zed extension.

Note that I had a bit of trouble finding the `path =` option to point Zed to our `editors/zed` subdirectory. I've also mentioned this here: https://github.com/zed-industries/zed/discussions/25575. I think I have it set up right, but it's hard for me to test. An extra line or two in the "Developing Extensions" section about this option would be great and would have saved me a good chunk of time!