### PR TITLE
golangci-lint: Bump to v0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -600,7 +600,7 @@
 
 [submodule "extensions/golangci-lint"]
 	path = extensions/golangci-lint
-	url = https://github.com/j4ng5y/zed_golangci_lint
+	url = https://github.com/zed-extensions/golangci-lint.git
 
 [submodule "extensions/gosum"]
 	path = extensions/gosum

--- a/extensions.toml
+++ b/extensions.toml
@@ -633,7 +633,7 @@ version = "0.1.0"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
-version = "0.1.0"
+version = "0.2.0"
 
 [gosum]
 submodule = "extensions/gosum"


### PR DESCRIPTION
This PR updates the golangci-lint extension to v0.2.0.

The extension now lives at [zed-extensions/golangci-lint](https://github.com/zed-extensions/golangci-lint).