### PR TITLE
Update min-theme to v0.1.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -992,7 +992,7 @@ version = "0.3.0"
 
 [min-theme]
 submodule = "extensions/min-theme"
-version = "0.0.1"
+version = "0.1.6"
 
 [modest-dark]
 submodule = "extensions/modest-dark"


### PR DESCRIPTION
Release notes:

https://github.com/phibr0/zed-min-theme/releases/tag/v0.1.6