### PR TITLE
Update outrun theme to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1244,7 +1244,7 @@ version = "0.0.1"
 
 [outrun]
 submodule = "extensions/outrun"
-version = "0.0.1"
+version = "0.0.2"
 
 [oxc]
 submodule = "extensions/oxc"


### PR DESCRIPTION
bumps the outrun theme version to resolve https://github.com/Acepie/OutrunZedTheme/issues/1