### PR TITLE
Update gruber-flavors to v0.8.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -677,7 +677,7 @@ version = "0.0.7"
 
 [gruber-flavors]
 submodule = "extensions/gruber-flavors"
-version = "0.7.0"
+version = "0.8.0"
 
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"


### PR DESCRIPTION
- Migrated to `scrollbar.thumb.background`
(fixes https://github.com/bIaqat/gruber-theme-zed/issues/1)
- Added **_Gruber Orange_** and ***Gruber Orange Lite*** Variants as someone let me know that I forgot one color of the rainbow (my least favorite color in the rainbow) 😄 

![Arc-gruber-theme-zedassetsgruber-orange png at main · bIaqatgruber-theme-zed-Capture-031909](https://github.com/user-attachments/assets/16bd61d8-d585-4127-b708-1ef117a551fa)
![Arc-gruber-theme-zedassetsgruber-orange-lite png at main · bIaqatgruber-theme-zed-Capture-031911](https://github.com/user-attachments/assets/645e03e0-982b-48a2-a4af-f091d5c746c0)
