### PR TITLE
Update tomorrow-theme to v1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1683,7 +1683,7 @@ version = "0.1.3"
 
 [tomorrow-theme]
 submodule = "extensions/tomorrow-theme"
-version = "0.9.0"
+version = "1.1.0"
 
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"


### PR DESCRIPTION
- Migrated to `scrollbar.thumb.background`
(fixes https://github.com/bIaqat/tomorrow-theme-zed/issues/6)
- Updated text matches and bracket match highlights
- Updated inline AI colors to be more legible
- Updated auto complete highlights
- I believed I had forgotten to push update `1.0` where the Tomorrow Min themes were separated into [their own repo / extension (soon)](https://github.com/bIaqat/tomorrow-min-theme-zed)