### PR TITLE
Add Python requirements extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1322,6 +1322,10 @@
 	path = extensions/python-refactoring
 	url = https://github.com/rowillia/zed-python-refactoring.git
 
+[submodule "extensions/python-requirements"]
+	path = extensions/python-requirements
+	url = https://github.com/dargor/zed-python-requirements.git
+
 [submodule "extensions/qml"]
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1385,6 +1385,10 @@ version = "0.0.1"
 submodule = "extensions/python-refactoring"
 version = "0.0.3"
 
+[python-requirements]
+submodule = "extensions/python-requirements"
+version = "0.0.1"
+
 [qml]
 submodule = "extensions/qml"
 version = "0.0.3"


### PR DESCRIPTION
This extension adds syntax highlighting for python `requirements.txt` and `constraints.txt` files.

Some post-installation steps are documented in the [README](https://github.com/dargor/zed-python-requirements/blob/master/README.md).