### PR TITLE
Add hyprlang extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -710,6 +710,10 @@
 	path = extensions/hurl
 	url = https://github.com/tommy/zed-hurl
 
+[submodule "extensions/hyprlang"]
+	path = extensions/hyprlang
+	url = https://github.com/WhySoBad/zed-hyprlang-extension.git
+
 [submodule "extensions/ical"]
 	path = extensions/ical
 	url = https://github.com/TitouanReal/zed-ical.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -753,6 +753,10 @@ version = "0.0.1"
 submodule = "extensions/hurl"
 version = "0.1.0"
 
+[hyprlang]
+submodule = "extensions/hyprlang"
+version = "0.0.1"
+
 [ical]
 submodule = "extensions/ical"
 version = "0.1.0"


### PR DESCRIPTION
This extension adds syntax highlighting for hyprlang and optional language server support for hyprland config files.

It uses [hyprls](https://github.com/hyprland-community/hyprls) as a language server (which needs to be installed manually) and the [tree-sitter-hyprlang](https://github.com/tree-sitter-grammars/tree-sitter-hyprlang) tree sitter grammar.

close #695 