### PR TITLE
Update blankeos-zen theme to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -190,7 +190,7 @@ version = "0.0.1"
 
 [blankeos-zen]
 submodule = "extensions/blankeos-zen"
-version = "0.0.4"
+version = "0.0.5"
 
 [blueprint]
 submodule = "extensions/blueprint"


### PR DESCRIPTION
### Changelog (recent to oldest)
- feat: Tab bar contrast improvements
- fix: Git hunk colors. (Since `created_background` and `deleted_background` work properly now) - based this on Ayu Dark.
- fix: 'ignored' colors.
- fix: Clearer colors for autocomplete suggestions.
- fix: `constant` and `this` colors.
- docs: Correction on description it said 'VSCode', should be 'Zed'.
- feat: Added select highlight when search.
- feat: Improved colors to look closer to the vscode version.
- fix: Fixed transparency issues (sidebar).