### PR TITLE
Update ezio-theme to v0.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -498,6 +498,10 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
+[submodule "extensions/ezio-theme"]
+	path = extensions/ezio-theme
+	url = https://github.com/dsantolo/ezio-zed.git
+
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -498,10 +498,6 @@
 	path = extensions/ezio
 	url = https://github.com/dsantolo/ezio-zed.git
 
-[submodule "extensions/ezio-zed"]
-	path = extensions/ezio-zed
-	url = https://github.com/dsantolo/ezio-zed.git
-
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1857,3 +1857,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/ezio"]
+	path = extensions/ezio
+	url = https://github.com/dsantolo/ezio-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -498,10 +498,6 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
-[submodule "extensions/ezio"]
-	path = extensions/ezio
-	url = https://github.com/dsantolo/ezio-zed.git
-
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -494,6 +494,10 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
+[submodule "extensions/ezio"]
+	path = extensions/ezio
+	url = https://github.com/dsantolo/ezio-zed.git
+
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git
@@ -1857,6 +1861,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/ezio"]
-	path = extensions/ezio
-	url = https://github.com/dsantolo/ezio-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -498,6 +498,10 @@
 	path = extensions/ezio
 	url = https://github.com/dsantolo/ezio-zed.git
 
+[submodule "extensions/ezio-zed"]
+	path = extensions/ezio-zed
+	url = https://github.com/dsantolo/ezio-zed.git
+
 [submodule "extensions/fiberplane-studio"]
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -527,7 +527,7 @@ version = "0.1.3"
 
 [ezio-theme]
 submodule = "extensions/ezio-theme"
-version = "0.0.1"
+version = "0.0.3"
 
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"

--- a/extensions.toml
+++ b/extensions.toml
@@ -521,6 +521,10 @@ version = "0.0.2"
 submodule = "extensions/exquisite"
 version = "0.1.3"
 
+[ezio-theme]
+submodule = "extensions/ezio-theme"
+version = "0.0.1"
+
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -525,8 +525,8 @@ version = "0.0.2"
 submodule = "extensions/exquisite"
 version = "0.1.3"
 
-[ezio]
-submodule = "extensions/ezio"
+[ezio-theme]
+submodule = "extensions/ezio-theme"
 version = "0.0.1"
 
 [fiberplane-studio]

--- a/extensions.toml
+++ b/extensions.toml
@@ -521,8 +521,8 @@ version = "0.0.2"
 submodule = "extensions/exquisite"
 version = "0.1.3"
 
-[ezio-theme]
-submodule = "extensions/ezio-theme"
+[ezio]
+submodule = "extensions/ezio"
 version = "0.0.1"
 
 [fiberplane-studio]


### PR DESCRIPTION
Update the ezio-theme extension: 

- Adds release.yml to automate future updates 
- Bumps `ezio-theme/extension.toml` and `extensions.toml` to v0.0.3
- Updates colors of errors to be more readable 

**Before**

<img width="642" alt="image" src="https://github.com/user-attachments/assets/4543cdaa-6f6f-4c7b-a509-463fde562b34" />

**After**

<img width="627" alt="image" src="https://github.com/user-attachments/assets/b5393dd4-4380-431d-9ee3-b28432debef0" />
