### PR TITLE
Update Typos to version 0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1443,7 +1443,7 @@ version = "0.1.0"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.3"
+version = "0.0.4"
 
 [typst]
 submodule = "extensions/typst"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1443,7 +1443,7 @@ version = "0.1.0"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.4"
+version = "0.0.5"
 
 [typst]
 submodule = "extensions/typst"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1326,7 +1326,7 @@ version = "0.1.0"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.2"
+version = "0.0.3"
 
 [typst]
 submodule = "extensions/typst"


### PR DESCRIPTION
- Change title to "Typos spell checker"
- Change description to ''Low false-positive source code spell checker."