### PR TITLE
Update Typos extension to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1743,7 +1743,7 @@ version = "0.1.0"
 
 [typos]
 submodule = "extensions/typos"
-version = "0.0.4"
+version = "0.0.5"
 
 [typst]
 submodule = "extensions/typst"


### PR DESCRIPTION
- Update extension's title and description with 'spell checker' keywords