### PR TITLE
Add Symbols Icon Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,6 +1590,10 @@
 	path = extensions/symbols
 	url = https://github.com/sebastiandotdev/zed-symbols.git
 
+[submodule "extensions/symbols-icons"]
+	path = extensions/symbols-icons
+	url = https://github.com/HarshNarayanJha/zed-symbols-icons
+
 [submodule "extensions/syntax"]
 	path = extensions/syntax
 	url = https://github.com/syntaxfm/syntax-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1663,6 +1663,10 @@ version = "0.3.2"
 submodule = "extensions/symbols"
 version = "0.1.0"
 
+[symbols-icons]
+submodule = "extensions/symbols-icons"
+version = "0.0.22"
+
 [syntax]
 submodule = "extensions/syntax"
 version = "0.0.1"


### PR DESCRIPTION
After creating the icon extension, I discovered that this icon theme had already been ported to Zed and is available on the extension registry (https://github.com/sebastiandotdev/zed-symbols) by @sebastiandotdev.  I installed their version to compare and found that mine offers more diverse and accurate icons due to my extended `file_suffixes` list, sourced from the original VS Code theme repository.

My port | @sebastiandotdev's port
------- | --------
![Image](https://github.com/user-attachments/assets/7c63effc-6f64-40d7-a3c5-5a427cdb9757) | ![Image](https://github.com/user-attachments/assets/2f3194ca-702a-4239-952e-d339d642b24a)

I also plan to add color variants, as the original icon theme has many.

The decision rests with the maintainers.