### PR TITLE
Update colored-zed-icons-theme to v0.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -306,6 +306,10 @@
 	path = extensions/codesandbox-theme
 	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git
 
+[submodule "extensions/colored-zed-icons-theme"]
+	path = extensions/colored-zed-icons-theme
+	url = https://github.com/TheRedXD/zed-icons-colored-theme.git
+
 [submodule "extensions/colorizer"]
 	path = extensions/colorizer
 	url = https://github.com/tamimhasandev/colorizer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1814,10 +1814,6 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
-[submodule "extensions/zed-icons-colored-theme"]
-	path = extensions/zed-icons-colored-theme
-	url = https://github.com/TheRedXD/zed-icons-colored-theme.git
-
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1841,3 +1841,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/zed-icons-colored-theme"]
+	path = extensions/zed-icons-colored-theme
+	url = https://github.com/TheRedXD/zed-icons-colored-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1814,6 +1814,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-icons-colored-theme"]
+	path = extensions/zed-icons-colored-theme
+	url = https://github.com/TheRedXD/zed-icons-colored-theme.git
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
@@ -1841,6 +1845,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/zed-icons-colored-theme"]
-	path = extensions/zed-icons-colored-theme
-	url = https://github.com/TheRedXD/zed-icons-colored-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -318,7 +318,7 @@ version = "0.0.5"
 
 [colored-zed-icons-theme]
 submodule = "extensions/colored-zed-icons-theme"
-version = "0.3.0"
+version = "0.3.1"
 
 [colorizer]
 submodule = "extensions/colorizer"

--- a/extensions.toml
+++ b/extensions.toml
@@ -308,7 +308,7 @@ submodule = "extensions/codesandbox-theme"
 version = "0.0.5"
 
 [colored-zed-icons-theme]
-submodule = "extensions/zed-icons-colored-theme"
+submodule = "extensions/colored-zed-icons-theme"
 version = "0.2.0"
 
 [colorizer]

--- a/extensions.toml
+++ b/extensions.toml
@@ -309,7 +309,7 @@ version = "0.0.5"
 
 [colored-zed-icons-theme]
 submodule = "extensions/colored-zed-icons-theme"
-version = "0.2.0"
+version = "0.3.0"
 
 [colorizer]
 submodule = "extensions/colorizer"

--- a/extensions.toml
+++ b/extensions.toml
@@ -307,6 +307,10 @@ version = "0.1.1"
 submodule = "extensions/codesandbox-theme"
 version = "0.0.5"
 
+[colored-zed-icons-theme]
+submodule = "extensions/zed-icons-colored-theme"
+version = "0.2.0"
+
 [colorizer]
 submodule = "extensions/colorizer"
 version = "0.0.4"
@@ -1901,10 +1905,6 @@ version = "1.2.0"
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.2"
-
-[zed-icons-colored-theme]
-submodule = "extensions/zed-icons-colored-theme"
-version = "0.2.0"
 
 [zedokai]
 submodule = "extensions/zedokai"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1902,6 +1902,10 @@ version = "1.2.0"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.2"
 
+[zed-icons-colored-theme]
+submodule = "extensions/zed-icons-colored-theme"
+version = "0.2.0"
+
 [zedokai]
 submodule = "extensions/zedokai"
 version = "1.2.1"


### PR DESCRIPTION
The icon theme now has properly scaled Svelte icons, which I have tested and they work perfectly!