### PR TITLE
Update min-theme to v0.1.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1016,7 +1016,7 @@ version = "0.3.0"
 
 [min-theme]
 submodule = "extensions/min-theme"
-version = "0.1.9"
+version = "0.1.10"
 
 [modest-dark]
 submodule = "extensions/modest-dark"


### PR DESCRIPTION
Release notes:

https://github.com/phibr0/zed-min-theme/releases/tag/v0.1.10