### PR TITLE
Add redscript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1394,6 +1394,10 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
+[submodule "extensions/redscript"]
+	path = extensions/redscript
+	url = https://github.com/jac3km4/redscript-zed.git
+
 [submodule "extensions/rego"]
 	path = extensions/rego
 	url = https://github.com/StyraInc/zed-rego.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1447,6 +1447,10 @@ version = "0.0.3"
 submodule = "extensions/rcl"
 version = "0.8.0"
 
+[redscript]
+submodule = "extensions/redscript"
+version = "0.1.0"
+
 [rego]
 submodule = "extensions/rego"
 version = "0.0.2"


### PR DESCRIPTION
Adds support for the [REDscript](https://github.com/jac3km4/redscript) programming language. It has an LSP and a treesitter grammar, I've tested it manually and both work pretty well in Zed.