### PR TITLE
Update Modus Theme to v0.0.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1019,7 +1019,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.9"
+version = "0.0.10"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this PR updates Modus Theme to v0.0.10 that fixes two small issues:

- Changed: [Use new color names for VCS](https://github.com/vitallium/zed-modus-themes/commit/d28420841a10160b5dcfb7a84f291c8ef2fb8559)
- Fixed: [Use fg_link for accent colors of text and icons](https://github.com/vitallium/zed-modus-themes/commit/07324a8fd54f7be437b2366b557d279236ddce4c)

Thanks!