### PR TITLE
Update jetbrains-icons to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -818,7 +818,7 @@ version = "0.2.4"
 
 [jetbrains-icons]
 submodule = "extensions/jetbrains-icons"
-version = "0.0.2"
+version = "0.0.3"
 
 [jetbrains-new-ui-icons]
 submodule = "extensions/jetbrains-new-ui-icons"


### PR DESCRIPTION
Release notes:

https://github.com/ziishaned/zed-jetbrains-icons/releases/tag/v0.0.3