### PR TITLE
gleam: Bump to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -628,7 +628,7 @@ version = "0.0.2"
 
 [gleam]
 submodule = "extensions/gleam"
-version = "0.3.0"
+version = "0.4.0"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"


### PR DESCRIPTION
This PR updates the Gleam extension to v0.4.0.

See https://github.com/gleam-lang/zed-gleam/pull/12 for the changes in this version.