### PR TITLE
Update Just to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -846,7 +846,7 @@ version = "0.1.4"
 
 [just]
 submodule = "extensions/just"
-version = "0.1.3"
+version = "0.1.4"
 
 [kamui-dark-theme]
 submodule = "extensions/kamui-dark-theme"


### PR DESCRIPTION
[jackTabsCode](https://github.com/jackTabsCode) had released zed just extension v0.1.4, which supports the `[group]` part now.