### PR TITLE
Update Just to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -846,7 +846,7 @@ version = "0.1.4"
 
 [just]
 submodule = "extensions/just"
-version = "0.1.3"
+version = "0.1.4"
 
 [kamui-dark-theme]
 submodule = "extensions/kamui-dark-theme"


### PR DESCRIPTION
[jackTabsCode](https://github.com/jackTabsCode) had released [zed just extension](https://github.com/jackTabsCode/zed-just/tree/v0.1.4) v0.1.4, which supports the `[group]` part now.

- extension diff: https://github.com/jackTabsCode/zed-just/compare/0a1b7f3fdf27f8c8a089203190774839511af1bc...ea24f1debf8433b0e67f0541e6d40b3c2c6cad6e
- tree-sitter diff:  https://github.com/IndianBoy42/tree-sitter-just/compare/792717c262df6d6fa285c1136a11c23cedadcb0c...3f90d24eb8c8d9e8c74fee7120d79c3ec7229f26