### PR TITLE
Update Haxe to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -729,7 +729,7 @@ version = "0.1.4"
 
 [haxe]
 submodule = "extensions/haxe"
-version = "0.2.0"
+version = "0.3.0"
 
 [helm]
 submodule = "extensions/helm"


### PR DESCRIPTION
This PR updates the Haxe extension to version 0.3.0.

- Completions are now styled.
- Fixed bracket-related grammar issues.
- Bumped required extension API version.