### PR TITLE
Bump Darcula Dark to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -418,7 +418,7 @@ version = "0.0.1"
 
 [darcula-dark]
 submodule = "extensions/darcula-dark"
-version = "0.1.0"
+version = "0.1.1"
 
 [dart]
 submodule = "extensions/dart"


### PR DESCRIPTION
<details><summary>Adds <code>variable.special</code></summary>

![zed-editor_LhbsASPACd](https://github.com/user-attachments/assets/688db77d-f14a-403a-a854-a372faf80e2b)

</details>

<details><summary>Fixes version control modified name as pointed out in <a href="https://github.com/zed-industries/zed/pull/26606">#26606</a></summary>

![zed-editor_DgdOLecZVY](https://github.com/user-attachments/assets/b258699d-b2ff-4dcb-a34d-9c0866a9f42c)

</details>

<details><summary>Fixes subheader color</summary>

![zed-editor_Fhu8pz1ljI](https://github.com/user-attachments/assets/c853e099-af07-48d3-8708-a22a388aab5c)

</details>

<details><summary>Fixes git ignored file colors</summary>

![zed-editor_W1Skokci1y](https://github.com/user-attachments/assets/4fa3f674-eda6-4965-ba9a-24138afdf2fe)

</details>
