### PR TITLE
Update rainbow-csv to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1452,7 +1452,7 @@ version = "0.1.0"
 
 [rainbow-csv]
 submodule = "extensions/rainbow-csv"
-version = "0.0.3"
+version = "1.0.0"
 
 [rcl]
 submodule = "extensions/rcl"


### PR DESCRIPTION
Release Note: 
https://github.com/weartist/zed-rainbow-csv/releases/tag/v1.0.0