### PR TITLE
Add GitHub Activity Summarizer extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -610,6 +610,10 @@
 	path = extensions/git-firefly
 	url = https://github.com/d1y/git_firefly.git
 
+[submodule "extensions/github-activity-summarizer"]
+	path = extensions/github-activity-summarizer
+	url = https://github.com/rubiojr/gas.git
+
 [submodule "extensions/github-copilot-theme"]
 	path = extensions/github-copilot-theme
 	url = https://github.com/ssaunderss/zed-gh-copilot-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -618,6 +618,10 @@ version = "1.1.0"
 submodule = "extensions/git-firefly"
 version = "0.0.3"
 
+[github-activity-summarizer]
+submodule = "extensions/github-activity-summarizer"
+version = "0.2.0"
+
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"
 version = "0.1.0"


### PR DESCRIPTION
A Zed context server that uses the GitHub's API to fetch your recent activity (comments, issue interactions, and pull request participation), presenting it in a formatted summary.
This allows you to quickly catch up on your GitHub activity, pull statistics, produce executive summaries, etc without leaving your editor.

Source: https://github.com/rubiojr/gas