### PR TITLE
Add viewtree extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1026,6 +1026,10 @@
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git
 
+[submodule "extensions/molViewtree"]
+	path = extensions/molViewtree
+	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
+
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1026,8 +1026,8 @@
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git
 
-[submodule "extensions/molViewtree"]
-	path = extensions/molViewtree
+[submodule "extensions/mol-view-tree"]
+	path = extensions/mol-view-tree
 	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
 
 [submodule "extensions/monokai-reversed"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1026,10 +1026,6 @@
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git
 
-[submodule "extensions/mol-view-tree"]
-	path = extensions/mol-view-tree
-	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
-
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed
@@ -1833,6 +1829,10 @@
 [submodule "extensions/vhs"]
 	path = extensions/vhs
 	url = https://github.com/eth0net/zed-vhs.git
+
+[submodule "extensions/viewtree"]
+	path = extensions/viewtree
+	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
 
 [submodule "extensions/vintergata"]
 	path = extensions/vintergata

--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,8 +1044,8 @@ version = "0.1.7"
 submodule = "extensions/modus-themes"
 version = "0.0.10"
 
-[molViewtree]
-submodule = "extensions/molViewtree"
+[mol-view-tree]
+submodule = "extensions/mol-view-tree"
 version = "0.0.3"
 
 [monokai-reversed]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,6 +1044,10 @@ version = "0.1.7"
 submodule = "extensions/modus-themes"
 version = "0.0.10"
 
+[molViewtree]
+submodule = "extensions/molViewtree"
+version = "0.0.3"
+
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,8 +1044,8 @@ version = "0.1.7"
 submodule = "extensions/modus-themes"
 version = "0.0.10"
 
-[mol-view-tree]
-submodule = "extensions/mol-view-tree"
+[viewtree]
+submodule = "extensions/viewtree"
 version = "0.0.3"
 
 [monokai-reversed]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,10 +1044,6 @@ version = "0.1.7"
 submodule = "extensions/modus-themes"
 version = "0.0.10"
 
-[viewtree]
-submodule = "extensions/viewtree"
-version = "0.0.3"
-
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.2"
@@ -1876,6 +1872,10 @@ version = "0.0.1"
 [vhs]
 submodule = "extensions/vhs"
 version = "0.1.0"
+
+[viewtree]
+submodule = "extensions/viewtree"
+version = "0.0.3"
 
 [vintergata]
 submodule = "extensions/vintergata"


### PR DESCRIPTION
Hi !
I really want to add this extension for zed!
It's extension for fantastic web-framework $mol

which out of the box supports **fully offline work** after the build

**work between windows and browser tabs**
incredible reactivity that renders only the necessary component in which the data is re-rendered

The application does **not crash due to errors**!

and that's not all, and all this was 10 years ago!
and this is all out of the box, you don't need to write anything, you only write business code! (logical code)

Links:
- https://github.com/dev-cmyser/zed-tree-mol-support
- https://github.com/Dev-cmyser/tree-sitter-mol-view-tree