### PR TITLE
Update move to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1082,7 +1082,7 @@ version = "0.0.2"
 
 [move]
 submodule = "extensions/move"
-version = "0.0.1"
+version = "0.0.2"
 
 [move-aptos]
 submodule = "extensions/move-aptos"


### PR DESCRIPTION
Release notes:

https://github.com/Tzal3x/move-zed-extension/releases/tag/v0.0.2