### PR TITLE
Update outrun to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1294,7 +1294,7 @@ version = "0.0.1"
 
 [outrun]
 submodule = "extensions/outrun"
-version = "0.0.2"
+version = "0.0.3"
 
 [oxc]
 submodule = "extensions/oxc"


### PR DESCRIPTION
Release notes:

https://github.com/Acepie/OutrunZedTheme/releases/tag/v0.0.3