### PR TITLE
Update github-activity-summarizer to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -632,7 +632,7 @@ version = "0.0.3"
 
 [github-activity-summarizer]
 submodule = "extensions/github-activity-summarizer"
-version = "0.2.2"
+version = "0.3.0"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"


### PR DESCRIPTION
https://github.com/rubiojr/gas/releases/tag/v0.3.0

Supersedes https://github.com/zed-industries/extensions/pull/2305 that was closed accidentally.