### PR TITLE
Add Ninja Theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1154,6 +1154,10 @@
 	path = extensions/nim
 	url = https://github.com/foxoman/zed-nim.git
 
+[submodule "extensions/ninja.theme"]
+	path = extensions/ninja.theme
+	url = https://github.com/c0mpiler/ninja.theme.zed.git
+
 [submodule "extensions/nix"]
 	path = extensions/nix
 	url = https://github.com/hasit/zed-nix.git
@@ -2037,6 +2041,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/ninja.theme"]
-	path = extensions/ninja.theme
-	url = https://github.com/c0mpiler/ninja.theme.zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1178,10 +1178,9 @@
 	path = extensions/nim
 	url = https://github.com/foxoman/zed-nim.git
 
-[submodule "extensions/ninja.theme"]
-	path = extensions/ninja.theme
+[submodule "extensions/ninja-theme"]
+	path = extensions/ninja-theme
 	url = https://github.com/c0mpiler/ninja.theme.git
-	branch = main
 
 [submodule "extensions/nix"]
 	path = extensions/nix

--- a/.gitmodules
+++ b/.gitmodules
@@ -2037,3 +2037,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/ninja.theme"]
+	path = extensions/ninja.theme
+	url = https://github.com/c0mpiler/ninja.theme.zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1157,6 +1157,7 @@
 [submodule "extensions/ninja.theme"]
 	path = extensions/ninja.theme
 	url = https://github.com/c0mpiler/ninja.theme.zed.git
+	branch = main
 
 [submodule "extensions/nix"]
 	path = extensions/nix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1156,7 +1156,7 @@
 
 [submodule "extensions/ninja.theme"]
 	path = extensions/ninja.theme
-	url = https://github.com/c0mpiler/ninja.theme.zed.git
+	url = https://github.com/c0mpiler/ninja.theme.git
 	branch = main
 
 [submodule "extensions/nix"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1173,7 +1173,7 @@ submodule = "extensions/nim"
 version = "0.2.0"
 
 [ninja-theme]
-submodule = "extensions/ninja-theme"
+submodule = "extensions/ninja.theme"
 path = "ninja"
 version = "1.0.0"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -1172,9 +1172,9 @@ version = "0.1.1"
 submodule = "extensions/nim"
 version = "0.2.0"
 
-[ninja-theme]
+[ninja]
 submodule = "extensions/ninja.theme"
-path = "ninja"
+path = "zed"
 version = "1.0.0"
 
 [nix]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1172,6 +1172,11 @@ version = "0.1.1"
 submodule = "extensions/nim"
 version = "0.2.0"
 
+[ninja-theme]
+submodule = "extensions/ninja-theme"
+path = "ninja"
+version = "1.0.0"
+
 [nix]
 submodule = "extensions/nix"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1197,7 +1197,7 @@ submodule = "extensions/nim"
 version = "0.2.0"
 
 [ninja]
-submodule = "extensions/ninja.theme"
+submodule = "extensions/ninja-theme"
 path = "zed"
 version = "1.0.0"
 


### PR DESCRIPTION
I'd like to submit the `Ninja Theme Collection` for inclusion in the official Zed extensions repository.

`Ninja` is a comprehensive theme suite with enhanced contrast, optimized readability, and robust accessibility features. The collection includes four carefully designed variants to support different preferences and needs:

- **Ninja Dark** - A refined dark theme with improved contrast and carefully weighted syntax elements
- **Ninja Light** - A clean, bright counterpart maintaining the same semantic relationships as the dark theme
- **Ninja Cosmic** - A vibrant, colorful theme with neon-inspired accents for developers who prefer more visual excitement
- **Ninja Colorblind** - An accessibility-focused theme with deuteranopia-friendly colors and enhanced font styling

### Features
- Optimized for 20+ programming languages including Python, JavaScript, Rust, Docker, markdown, etc.
- Enhanced readability with strategic font styling (italics for keywords, bold for functions)
- Consistent syntax highlighting across all variants to minimize context switching
- [WCAG accessibility considerations for color contrast and visual distinctions](https://www.w3.org/TR/WCAG21/)
- Efficient performance with minimal visual noise

### Theme Location
Repo: [https://github.com/c0mpiler/ninja.theme.zed](https://github.com/c0mpiler/ninja.theme.zed)

### Screenshots
Screenshots available in the repository README.

### Testing
The theme has been validated using:
- [Theme schema validation against Zed's official schema (v0.2.0)](https://zed.dev/schema/themes/v0.2.0.json)
- [Color contrast checks for WCAG compliance](https://www.w3.org/TR/WCAG21/)
- Structural consistency validation
- TOML extension file validation

Thank you for considering this submission!