### PR TITLE
dart: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -434,7 +434,7 @@ version = "0.0.1"
 
 [dart]
 submodule = "extensions/dart"
-version = "0.1.3"
+version = "0.2.0"
 
 [dbml]
 submodule = "extensions/dbml"


### PR DESCRIPTION
This PR updates the Dart extension to v0.2.0.