### PR TITLE
Add ZedHacker theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -718,6 +718,10 @@
 	path = extensions/hacker-night-vision
 	url = https://github.com/Takk8IS/hacker-night-vision-theme-for-zed.git
 
+[submodule "extensions/hacker-theme"]
+	path = extensions/hacker-theme
+	url = https://github.com/N0TZ3R0/zedhacker.git
+
 [submodule "extensions/halcyon"]
 	path = extensions/halcyon
 	url = https://github.com/hichemfantar/halcyon-zed.git
@@ -2001,10 +2005,6 @@
 [submodule "extensions/zed"]
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
-
-[submodule "extensions/zed-hacker"]
-	path = extensions/hacker-theme
-	url = https://github.com/N0TZ3R0/zedhacker.git
 
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes

--- a/.gitmodules
+++ b/.gitmodules
@@ -718,7 +718,6 @@
 	path = extensions/hacker-night-vision
 	url = https://github.com/Takk8IS/hacker-night-vision-theme-for-zed.git
 
-
 [submodule "extensions/hacker-theme"]
 	path = extensions/hacker-theme
 	url = https://github.com/N0TZ3R0/zedhacker.git
@@ -726,7 +725,6 @@
 [submodule "extensions/haku-dark-theme"]
 	path = extensions/haku-dark-theme
 	url = https://github.com/ArthurBrussee/haku_dark.git
-
 
 [submodule "extensions/halcyon"]
 	path = extensions/halcyon

--- a/.gitmodules
+++ b/.gitmodules
@@ -2037,3 +2037,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/zed-hacker"]
+	path = extensions/zed-hacker
+	url = https://github.com/N0TZ3R0/zedhacker.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2002,6 +2002,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-hacker"]
+	path = extensions/hacker-theme
+	url = https://github.com/N0TZ3R0/zedhacker.git
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
@@ -2037,6 +2041,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/zed-hacker"]
-	path = extensions/zed-hacker
-	url = https://github.com/N0TZ3R0/zedhacker.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2042,8 +2042,8 @@ version = "0.1.0"
 submodule = "extensions/yue-theme"
 version = "1.2.1"
 
-[zed-hacker]
-submodule = "extensions/zed-hacker"
+[hacker-theme]
+submodule = "extensions/hacker-theme"
 version = "1.0.0"
 
 [zed-legacy-themes]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2042,6 +2042,10 @@ version = "0.1.0"
 submodule = "extensions/yue-theme"
 version = "1.2.1"
 
+[zed-hacker]
+submodule = "extensions/zed-hacker"
+version = "1.0.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,6 +731,10 @@ version = "1.0.0"
 submodule = "extensions/hacker-night-vision"
 version = "2.0.0"
 
+[hacker-theme]
+submodule = "extensions/hacker-theme"
+version = "1.0.0"
+
 [halcyon]
 submodule = "extensions/halcyon"
 version = "0.0.5"
@@ -2041,10 +2045,6 @@ version = "0.1.0"
 [yue-theme]
 submodule = "extensions/yue-theme"
 version = "1.2.1"
-
-[hacker-theme]
-submodule = "extensions/hacker-theme"
-version = "1.0.0"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,6 @@ version = "1.0.0"
 submodule = "extensions/hacker-night-vision"
 version = "2.0.0"
 
-
 [hacker-theme]
 submodule = "extensions/hacker-theme"
 version = "1.0.0"
@@ -739,7 +738,6 @@ version = "1.0.0"
 [haku-dark-theme]
 submodule = "extensions/haku-dark-theme"
 version = "0.0.1"
-
 
 [halcyon]
 submodule = "extensions/halcyon"


### PR DESCRIPTION
# ZedHacker Theme

This PR adds the ZedHacker theme, a cyberpunk-inspired theme collection with three distinct variants optimized for contrast and readability.

## Features

- 🎨 Enhanced contrast for better UI element visibility
- 🖥️ Multiple theme variants (Monochrome, Matrix, Light)
- ⌨️ Improved selection states for keyboard navigation
- 🧩 Refined syntax highlighting for better code comprehension
- 🌓 Support for both light and dark environments

## Theme Variants

### ZedHacker Matrix
![ZedHacker Matrix](https://raw.githubusercontent.com/N0TZ3R0/zedhacker/main/assets/1.png)
Vibrant green-focused cyberpunk theme inspired by classic hacker aesthetics.

### ZedHacker Monochrome
![ZedHacker Monochrome](https://raw.githubusercontent.com/N0TZ3R0/zedhacker/main/assets/2.png)
Classic black and white aesthetic with maximum contrast for readability.

### ZedHacker Light
![ZedHacker Light](https://raw.githubusercontent.com/N0TZ3R0/zedhacker/main/assets/3.png)
Light background variant ideal for daytime coding and high-glare environments.

Note: I had some issues running the `pnpm sort-extensions` script due to dependency errors, but I've manually placed my entry in alphabetical order in the extensions.toml file.