### PR TITLE
Update Phosphor Icons Theme to v0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1989,3 +1989,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/phosphor-icons-theme"]
+	path = extensions/phosphor-icons-theme
+	url = https://github.com/theoluciano/phosphor-icons-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1326,6 +1326,10 @@
 	path = extensions/phine-theme
 	url = https://github.com/phisch/phine-zed.git
 
+[submodule "extensions/phosphor-icons-theme"]
+	path = extensions/phosphor-icons-theme
+	url = https://github.com/theoluciano/phosphor-icons-theme.git
+
 [submodule "extensions/php"]
 	path = extensions/php
 	url = https://github.com/zed-extensions/php.git
@@ -1989,6 +1993,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/phosphor-icons-theme"]
-	path = extensions/phosphor-icons-theme
-	url = https://github.com/theoluciano/phosphor-icons-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1379,7 +1379,7 @@ version = "0.0.1"
 
 [phosphor-icons-theme]
 submodule = "extensions/phosphor-icons-theme"
-version = "0.0.1"
+version = "0.0.2"
 
 [php]
 submodule = "extensions/php"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1349,6 +1349,10 @@ version = "0.1.0"
 submodule = "extensions/phine-theme"
 version = "0.0.1"
 
+[phosphor-icons-theme]
+submodule = "extensions/phosphor-icons-theme"
+version = "0.0.1"
+
 [php]
 submodule = "extensions/php"
 version = "0.2.7"


### PR DESCRIPTION
I realized there was a bunch of recent work I hadn't pushed so the current extension is quite out of date. This should fix it.