### PR TITLE
astro: Bump to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -85,7 +85,7 @@ version = "0.0.1"
 
 [astro]
 submodule = "extensions/astro"
-version = "0.1.4"
+version = "0.1.5"
 
 [atomize]
 submodule = "extensions/atomize"


### PR DESCRIPTION
This PR updates the Astro extension to v0.1.5.