### PR TITLE
Add haku-dark-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -718,8 +718,8 @@
 	path = extensions/hacker-night-vision
 	url = https://github.com/Takk8IS/hacker-night-vision-theme-for-zed.git
 
-[submodule "extensions/haku_dark"]
-	path = extensions/haku_dark
+[submodule "extensions/haku-dark-theme"]
+	path = extensions/haku-dark-theme
 	url = https://github.com/ArthurBrussee/haku_dark.git
 
 [submodule "extensions/halcyon"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -718,6 +718,10 @@
 	path = extensions/hacker-night-vision
 	url = https://github.com/Takk8IS/hacker-night-vision-theme-for-zed.git
 
+[submodule "extensions/haku_dark"]
+	path = extensions/haku_dark
+	url = https://github.com/ArthurBrussee/haku_dark.git
+
 [submodule "extensions/halcyon"]
 	path = extensions/halcyon
 	url = https://github.com/hichemfantar/halcyon-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,6 +731,10 @@ version = "1.0.0"
 submodule = "extensions/hacker-night-vision"
 version = "2.0.0"
 
+[haku-dark-theme]
+submodule = "extensions/haku-dark-theme"
+version = "0.0.1"
+
 [halcyon]
 submodule = "extensions/halcyon"
 version = "0.0.5"


### PR DESCRIPTION
Hiya,

I'd love to add my theme I've been using for a while. It's a nice pastel-y dark theme, mainly optimized for rust.


Fwiw, when triyng to publish this, the sort script threw an exception for me 

```
const [subginal, key, value] = subline.match(/(.*?)\s*=\s*(.*)/);
                                               ^

TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.deserialize (F:\zed_extensions\node_modules\git-submodule-js\dist\index.js:24:48)
    at readGitmodules (file:///F:/zed_extensions/src/lib/git.js:41:24)
    at async sortGitmodules (file:///F:/zed_extensions/src/lib/git.js:46:22)
    at async file:///F:/zed_extensions/src/sort-extensions.js:5:1
  ```

so I had to sort things manually.