### PR TITLE
Update HTML to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -782,7 +782,7 @@ version = "0.0.1"
 [html]
 submodule = "extensions/zed"
 path = "extensions/html"
-version = "0.1.5"
+version = "0.2.0"
 
 [html-jinja]
 submodule = "extensions/html-jinja"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/23659
- https://github.com/zed-industries/zed/pull/27175
- https://github.com/zed-industries/zed/pull/27524

HTML v0.1.6 was [accidentally not released](https://github.com/zed-industries/zed/pull/25791) and so this also includes:
- https://github.com/zed-industries/zed/pull/25130