### PR TITLE
postgres-context-server: Bump to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1423,7 +1423,7 @@ version = "0.8.1"
 
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
-version = "0.0.1"
+version = "0.0.2"
 
 [powershell]
 submodule = "extensions/powershell"


### PR DESCRIPTION
This PR updates the Postgres Context Server extension to v0.0.2.