### PR TITLE
svelte: Bump to v0.2.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1738,7 +1738,7 @@ version = "0.0.2"
 
 [svelte]
 submodule = "extensions/svelte"
-version = "0.2.5"
+version = "0.2.6"
 
 [swift]
 submodule = "extensions/swift"


### PR DESCRIPTION
This PR updates the Svelte extension to v0.2.6.