### PR TITLE
+ shell-slash-command extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2045,3 +2045,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/shell-slash-command"]
+	path = extensions/shell-slash-command
+	url = https://github.com/subtleGradient/zed-shell-slash-command.git


### PR DESCRIPTION
This Zed extension adds a /sh slash command that allows you to run shell commands directly from Zed and see their output.
