### PR TITLE
Update Modus Themes to v0.0.11

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1019,7 +1019,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.10"
+version = "0.0.11"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this PR updates Modus Themes to v0.0.11 which includes a small fix to address the background for inlay hints when you enable the background for them:
```jsonc
  "inlay_hints": {
    "enable": true,
    "show_background": true // This configuration option
  },
```

|before|after|
|-----|------|
|![CleanShot 2025-03-28 at 13 37 04@2x](https://github.com/user-attachments/assets/abe9f7b1-1237-458b-841d-ce243a1e5ab6)|![after](https://github.com/user-attachments/assets/5057f70e-9fa0-4a62-a572-d5d1a28cfb4a)|

Thanks!