### PR TITLE
Bump java to v6.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -850,7 +850,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "6.0.0"
+version = "6.0.1"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v6.0.1