### PR TITLE
Update nebula-pulse to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1134,7 +1134,7 @@ version = "0.4.0"
 
 [nebula-pulse]
 submodule = "extensions/nebula-pulse"
-version = "0.0.5"
+version = "0.0.6"
 
 [neocmake]
 submodule = "extensions/neocmake"


### PR DESCRIPTION
This PR updates the nebula-pulse extension submodule to version 0.0.6 and updates the version in extensions.toml