### PR TITLE
Update rainbow-csv to v1.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1504,7 +1504,7 @@ version = "0.1.0"
 
 [rainbow-csv]
 submodule = "extensions/rainbow-csv"
-version = "1.0.0"
+version = "1.0.1"
 
 [rcl]
 submodule = "extensions/rcl"


### PR DESCRIPTION
revert: Remove empty string parsing support due to critical bugs

This reverts commits 81bfb05 and 5d0abb3. The changes caused unexpected parsing failures in quoted CSV fields. Rollback to stable parser behavior