### PR TITLE
Add Svelte Snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1706,6 +1706,10 @@
 	path = extensions/svelte
 	url = https://github.com/zed-extensions/svelte.git
 
+[submodule "extensions/svelte-snippets"]
+	path = extensions/svelte-snippets
+	url = https://github.com/bobbymannino/svelte-snippets-for-zed.git
+
 [submodule "extensions/swift"]
 	path = extensions/swift
 	url = https://github.com/samuser107/zed-swift-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1744,6 +1744,10 @@ version = "0.0.2"
 submodule = "extensions/svelte"
 version = "0.2.6"
 
+[svelte-snippets]
+submodule = "extensions/svelte-snippets"
+version = "0.0.1"
+
 [swift]
 submodule = "extensions/swift"
 version = "0.4.0"


### PR DESCRIPTION
this adds a few `.svelte` only snippets

I am looking into having `.ts` snippets for svelte in the same extension but not sure at the moment how to have multiple files in the snippets field in extension.toml 

if I use multiple it does not show any snippets