### PR TITLE
Add Postgres Language Server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1422,6 +1422,10 @@
 	path = extensions/postgres-context-server
 	url = https://github.com/zed-extensions/postgres-context-server.git
 
+[submodule "extensions/postgres-language-server"]
+	path = extensions/postgres-language-server
+	url = https://github.com/LoamStudios/zed-postgres-language-server.git
+
 [submodule "extensions/powershell"]
 	path = extensions/powershell
 	url = https://github.com/wingyplus/zed-powershell.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1445,6 +1445,10 @@ version = "0.8.1"
 submodule = "extensions/postgres-context-server"
 version = "0.0.2"
 
+[postgres-language-server]
+submodule = "extensions/postgres-language-server"
+version = "0.0.1"
+
 [powershell]
 submodule = "extensions/powershell"
 version = "0.1.0"


### PR DESCRIPTION
In this PR, I introduce an extension to add the [Postgres Language Server](https://pgtools.dev) built by the lovely folks at Supabase.