### PR TITLE
Bump verilog to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1915,7 +1915,7 @@ version = "0.0.7"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.6"
+version = "0.0.7"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
Changes: https://github.com/someone13574/zed-verilog-extension/releases/tag/v0.0.7