### PR TITLE
Update Stylelint to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1726,7 +1726,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "0.0.3"
+version = "0.0.4"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"


### PR DESCRIPTION
- Fixes support for `Vue.js` files