### PR TITLE
Add language support for Ledger (plain text accounting) files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2038,6 +2038,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-language-ledger"]
+	path = extensions/zed-language-ledger
+	url = https://github.com/claytonrcarter/zed-language-ledger
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2078,6 +2078,10 @@ version = "0.1.0"
 submodule = "extensions/yue-theme"
 version = "1.2.1"
 
+[zed-language-ledger]
+submodule = "extensions/zed-language-ledger"
+version = "0.0.2"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.2"


### PR DESCRIPTION
This adds support for [Ledger](https://ledger-cli.org/) [plain text accounting](https://plaintextaccounting.org/) files, including highlighting and a language server, which itself provides completions, formatting and some code actions.

The `tree-sitter-ledger` grammar is currently pinned to [my own fork](https://github.com/claytonrcarter/tree-sitter-ledger/) of [tree-sitter-ledger](https://github.com/cbarrete/tree-sitter-ledger) because I needed some additional changes that I haven't pushed upstream yet.

The language server is also my own, at https://github.com/claytonrcarter/ledger-language-server/

This has been working well locally for some time, and I believe that I have all of deps pushed and magic configured. Happy to make changes if something is amiss, though. 

Thank you!