### PR TITLE
Add Linear MCP Server Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1038,6 +1038,10 @@
 	path = extensions/mcp-server-brave-search
 	url = https://github.com/zed-extensions/mcp-server-brave-search.git
 
+[submodule "extensions/mcp-server-linear"]
+	path = extensions/mcp-server-linear
+	url = https://github.com/LoamStudios/zed-mcp-server-linear.git
+
 [submodule "extensions/mcp-server-puppeteer"]
 	path = extensions/mcp-server-puppeteer
 	url = https://github.com/zed-extensions/mcp-server-puppeteer.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1056,6 +1056,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-brave-search"
 version = "0.0.1"
 
+[mcp-server-linear]
+submodule = "extensions/mcp-server-linear"
+version = "0.0.1"
+
 [mcp-server-puppeteer]
 submodule = "extensions/mcp-server-puppeteer"
 version = "0.0.1"


### PR DESCRIPTION
In this PR, I create a context server extension for Linear. It leverages the work of https://github.com/odgrim/linear-mcp which seemed to have the widest range of tools.

One of the more popular versions is: https://github.com/jerhadf/linear-mcp-server. However, it is currently broken due to an issue in the code.

I'm open to changing the package used in the future. Also, I suspect Linear will release a first-party MCP server in the not too distant future. If that happens, this extension will use it.


Did I get the naming right this time @maxdeviant? 😉 