### PR TITLE
Add Figma MCP Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1046,6 +1046,10 @@
 	path = extensions/mcp-server-brave-search
 	url = https://github.com/zed-extensions/mcp-server-brave-search.git
 
+[submodule "extensions/mcp-server-figma"]
+	path = extensions/mcp-server-figma
+	url = https://github.com/LoamStudios/zed-mcp-server-figma.git
+
 [submodule "extensions/mcp-server-linear"]
 	path = extensions/mcp-server-linear
 	url = https://github.com/LoamStudios/zed-mcp-server-linear.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1064,6 +1064,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-brave-search"
 version = "0.0.1"
 
+[mcp-server-figma]
+submodule = "extensions/mcp-server-figma"
+version = "0.0.1"
+
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"
 version = "0.0.1"


### PR DESCRIPTION
This extension integrates [Framelink Figma MCP Server](https://github.com/GLips/Figma-Context-MCP) as a context server for Zed's Assistant.