### PR TITLE
Add VSCode-Material-Icon-Theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,10 @@
 	path = extensions/0x96f
 	url = https://github.com/filipjanevski/zed-theme.git
 
+[submodule "extensions/VSCode-Material-Icon-Theme"]
+	path = extensions/VSCode-Material-Icon-Theme
+	url = https://github.com/A-caibird/material-icon-theme
+
 [submodule "extensions/actionscript"]
 	path = extensions/actionscript
 	url = https://github.com/pngdrift/zed-actionscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2,6 +2,10 @@
 submodule = "extensions/0x96f"
 version = "1.3.0"
 
+[VSCode-Material-Icon-Theme]
+submodule = "extensions/VSCode-Material-Icon-Theme"
+version = "0.1.2"
+
 [actionscript]
 submodule = "extensions/actionscript"
 version = "0.0.1"


### PR DESCRIPTION
Add VSCode-Material-Icon-Theme extension to zed. Although Material-Icon-Theme extension already exists, the icons are still incomplete, and they don't have time to process pr