### PR TITLE
Update omnetpp to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1307,7 +1307,7 @@ version = "0.0.1"
 
 [omnetpp]
 submodule = "extensions/omnetpp"
-version = "0.0.2"
+version = "0.0.3"
 
 [one-black-theme]
 submodule = "extensions/one-black-theme"


### PR DESCRIPTION
Fixed potential security issue in ned grammar in OMNeT++ extension and updated version to 0.0.3

Tree-sitter diff: https://github.com/omnetpp/tree-sitter-ned/compare/f008614a9db91a39e6ba58461c3cbea30c3e4fd8...f18d2c7c0224ff868d8610367ed720147aa227e4