### PR TITLE
Update halcyon extension to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -753,7 +753,7 @@ version = "0.0.1"
 
 [halcyon]
 submodule = "extensions/halcyon"
-version = "0.2.0"
+version = "0.2.1"
 
 [hami-melon-theme]
 submodule = "extensions/hami-melon-theme"


### PR DESCRIPTION
Upgrade the halcyon extension to version 0.2.1, reflecting the latest changes and improvements.