### PR TITLE
Update Meson to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1110,7 +1110,7 @@ version = "0.1.0"
 
 [meson]
 submodule = "extensions/meson"
-version = "0.3.0"
+version = "0.4.0"
 
 [min-theme]
 submodule = "extensions/min-theme"


### PR DESCRIPTION
Updating the meson extension due to changes in the build process.

It should also be noted that I can't really maintain the extension much anymore as noted on the README now. I do not have a Linux or macOS machine with the capability to maintain it as my only machine as of right now is Windows.

If there's anyone who would take up the mantle in maintaining the extension, please let me know.