### PR TITLE
Update Modus themes to v0.0.13

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1122,7 +1122,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.11"
+version = "0.0.13"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this PR updates Modus Themes to v0.0.13. Just minor changes:

- [Add `document_highlight` colors](https://github.com/vitallium/zed-modus-themes/commit/6a40f0537d80cdf7c2becc9f907835bb8310e1bd)
- [Update the foreground color for inlay hints](https://github.com/vitallium/zed-modus-themes/commit/11a07c36b8968468e416c8ee7adfb095e89b8b28)

Thanks!