### PR TITLE
Update mcp-server-linear to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1086,7 +1086,7 @@ version = "0.0.1"
 
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-puppeteer]
 submodule = "extensions/mcp-server-puppeteer"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-github/releases/tag/v0.0.2