### PR TITLE
Update mcp-server-github to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1082,7 +1082,7 @@ version = "0.0.2"
 
 [mcp-server-github]
 submodule = "extensions/mcp-server-github"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-github/releases/tag/v0.0.2