### PR TITLE
Upgrade `graphql` extension to v1.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -705,7 +705,7 @@ version = "0.2.1"
 
 [graphql]
 submodule = "extensions/graphql"
-version = "1.0.1"
+version = "1.0.2"
 
 [graphviz]
 submodule = "extensions/graphviz"


### PR DESCRIPTION
Second part of the windows fix ([issue](https://github.com/11bit/zed-extension-graphql/issues/10))