### PR TITLE
Revert "Update Modus themes to v0.0.14"

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1130,7 +1130,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.14"
+version = "0.0.13"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Reverts zed-industries/extensions#2421
CC: @vitallium

This was the first submodule that is using `git-lfs`.
I don't think we want to make `git-lfs` a requirement to interact with this repo.