### PR TITLE
ci: Add Git Checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,13 @@ jobs:
             echo -e "Fix by running:\n  pnpm sort-extensions\n"
             exit 1
           fi
+
+      - name: Enforce no Git LFS or Recursive Submodules
+        run: |
+          ! grep -q "recursive = true\|submodule.*=.*submodule" .gitmodules 2>/dev/null || {
+            echo "Recursive submodules found" >&2; exit 1;
+          }
+          git submodule foreach --quiet \
+            '[ ! -f .gitattributes ] || ! grep -q "filter=lfs" .gitattributes && [ ! -d .git/lfs ] || {
+              echo "LFS detected in $path" >&2 && exit 1
+            }'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,8 @@ jobs:
             exit 1
           fi
 
-      - name: Enforce no Git LFS or Recursive Submodules
+      - name: Enforce no Git LFS
         run: |
-          ! grep -q "recursive = true\|submodule.*=.*submodule" .gitmodules 2>/dev/null || {
-            echo "Recursive submodules found" >&2; exit 1;
-          }
           git submodule foreach --quiet \
             '[ ! -f .gitattributes ] || ! grep -q "filter=lfs" .gitattributes && [ ! -d .git/lfs ] || {
               echo "LFS detected in $path" >&2 && exit 1


### PR DESCRIPTION
We don't want to make `git-lfs` be a requirement for interacting with this repo so prevent submodules from using git-lfs.

If submodule includes git-lfs it'll fail tests like this: (test run [here](https://github.com/zed-industries/extensions/actions/runs/14311780680/job/40108330859)):

<img width="735" alt="Screenshot 2025-04-07 at 10 32 23" src="https://github.com/user-attachments/assets/fdb30e72-736c-47e0-a253-5b57b13694c8" />


Follow-up to:
- https://github.com/zed-industries/extensions/pull/2428