### PR TITLE
Update Modus themes to v0.0.15

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1130,7 +1130,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.13"
+version = "0.0.15"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
Hi, this is the second version of the previously reverted MR where GIT LFS was enabled: I disabled it and bumped theme to v0.0.15. The changelist is basically the same as in https://github.com/zed-industries/extensions/pull/2421:

1. [Changed license to GPL-v3](https://github.com/vitallium/zed-modus-themes/commit/14134b703a8faba646fdc8f3ca4a61c26aa9d231)
2. [Refine many color values in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/3eedc6fb55567afaad7c768fab144806664ba0b3)
3. [Refine green-warmer in modus-vivendi-tinted](https://github.com/vitallium/zed-modus-themes/commit/21308c30e7135b1f2d5739dd35575fc65ef1155e)
4. [Reduce the amount of magenta in some parts of the deuteranopia variants](https://github.com/vitallium/zed-modus-themes/commit/63389742546709e0ebcddb6cc297ab2b3529e3c7)
5. [Use magenta-cooler for the deuteranopia date-weekend mappings](https://github.com/vitallium/zed-modus-themes/commit/37d46eccb5173ec373ebd65db1c97b83387dc665)
6. [Use proper color for number](https://github.com/vitallium/zed-modus-themes/commit/102b01b76e970a44e18709c475eee6c5abdfe6f8)
7. [Use proper color for type](https://github.com/vitallium/zed-modus-themes/commit/28c48d44118514af9408019965c8326453105a1f)
8. [Use proper color for boolean](https://github.com/vitallium/zed-modus-themes/commit/5585f7e3cb354ce7072194c899d3d56b70c0cd70)
9. [Refine the bg-char-* values of the deuteranopia themes](https://github.com/vitallium/zed-modus-themes/commit/33fe76690089651a5d2f5e15da49ab73e5f9cdd9)
10. [Tweak accent-0 in modus-vivendi-deuteranopia](https://github.com/vitallium/zed-modus-themes/commit/afe05f9b509b577b512ac55b7ff623cb7d06f69f)
11. [Revise some of the prose mappings in the deuteranopia themes](https://github.com/vitallium/zed-modus-themes/commit/d36fd13c4a7b6cef6fe1976c046b28d97ea9ed61)

You can check before&after screenshots in [this](https://github.com/vitallium/zed-modus-themes/commit/0461cbfc4bded1ab8ca85f037622f63c4f1d51f7) commit.

Thanks!