### PR TITLE
Add `prisma-mcp` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1486,6 +1486,10 @@
 	path = extensions/prisma
 	url = https://github.com/zed-extensions/prisma.git
 
+[submodule "extensions/prisma-mcp"]
+	path = extensions/prisma-mcp
+	url = https://github.com/aqrln/prisma-mcp-zed
+
 [submodule "extensions/prolog"]
 	path = extensions/prolog
 	url = https://github.com/Piefayth/zed-prolog

--- a/extensions.toml
+++ b/extensions.toml
@@ -1510,6 +1510,10 @@ version = "0.1.0"
 submodule = "extensions/prisma"
 version = "0.1.0"
 
+[prisma-mcp]
+submodule = "extensions/prisma-mcp"
+version = "0.1.0"
+
 [prolog]
 submodule = "extensions/prolog"
 version = "0.0.1"


### PR DESCRIPTION
Add `prisma-mcp` extension that provides support for the MCP server in Prisma ORM.