### PR TITLE
Remove denix extension; fix submodule urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -368,7 +368,7 @@
 
 [submodule "extensions/crimson-theme"]
 	path = extensions/crimson-theme
-	url = https://www.github.com/kaem-e/zed-crimson-theme
+	url = https://github.com/kaem-e/zed-crimson-theme.git
 
 [submodule "extensions/crystal"]
 	path = extensions/crystal
@@ -461,10 +461,6 @@
 [submodule "extensions/decorative-stitch"]
 	path = extensions/decorative-stitch
 	url = https://github.com/keithrowell/zed-theme-decorative-stitch.git
-
-[submodule "extensions/denix"]
-	path = extensions/denix
-	url = https://github.com/denix666/zed-theme.git
 
 [submodule "extensions/deno"]
 	path = extensions/deno
@@ -904,7 +900,7 @@
 
 [submodule "extensions/kamui-dark-theme"]
 	path = extensions/kamui-dark-theme
-	url = https://gitlab.com/kamuiqf/zed-kamui-theme
+	url = https://gitlab.com/kamuiqf/zed-kamui-theme.git
 
 [submodule "extensions/kanagawa-themes"]
 	path = extensions/kanagawa-themes


### PR DESCRIPTION
Remove `denix` as it is no longer available:
- https://github.com/denix666/zed-theme

Fix two submodules which had redirects.

CC: @denix666