### PR TITLE
Update yara to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2144,7 +2144,7 @@ version = "0.0.2"
 
 [yara]
 submodule = "extensions/yara"
-version = "0.0.3"
+version = "0.0.4"
 
 [yellowed]
 submodule = "extensions/yellowed"


### PR DESCRIPTION
This PR bumps the Yara extension to `0.0.4` which adds support for the Yara Language Server if installed.

I can install the new version locally as a dev extension without having YLS installed, so this shouldn't cause any issues.

More info: https://github.com/egibs/yara.zed/pull/1