### PR TITLE
Add base64-slash-command extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,6 +134,10 @@
 	path = extensions/base16
 	url = https://github.com/bswinnerton/base16-zed.git
 
+[submodule "extensions/base64-slash-command"]
+	path = extensions/base64-slash-command
+	url = https://github.com/miguelmartens/zed-base64-slash-command.git
+
 [submodule "extensions/basedpyright"]
 	path = extensions/basedpyright
 	url = https://github.com/m1guer/basedpyright-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -136,6 +136,10 @@ version = "1.0.1"
 submodule = "extensions/base16"
 version = "0.1.1"
 
+[base64-slash-command]
+submodule = "extensions/base64-slash-command"
+version = "0.1.0"
+
 [basedpyright]
 submodule = "extensions/basedpyright"
 version = "0.1.2"


### PR DESCRIPTION
## Overview
This pull request adds the **base64-slash-command** extension to the Zed extensions repository. The extension is added as a Git submodule, and the top-level configuration has been updated to register this extension at version **0.1.0**. This is our first stable release of the extension.

## Changes
- **Submodule Addition:**  
  - Added the repository [zed-base64-slash-command](https://github.com/miguelmartens/zed-base64-slash-command.git) as a submodule under `extensions/base64-slash-command`.
  - The submodule was added using:
    ```bash
    git submodule add https://github.com/miguelmartens/zed-base64-slash-command.git extensions/base64-slash-command
    git add extensions/base64-slash-command
    ```

- **Configuration Update:**  
  - Updated the top-level **extensions.toml** file with a new entry:
    ```toml
    [base64-slash-command]
    submodule = "extensions/base64-slash-command"
    version = "0.1.0"
    ```
  - This entry ensures that the extension is correctly registered with a unique ID (without including “zed” or “Zed”).

- **File Sorting:**  
  - Ran `pnpm sort-extensions` to sort **extensions.toml** and **.gitmodules** according to repository conventions:
    ```bash
    pnpm sort-extensions
    ```
    
## Testing
- Verified that the submodule exists at the correct path.
- Ensured that **extensions.toml** and **.gitmodules** are properly sorted and formatted.
- Built and verified local functionality to confirm the extension is integrated as expected.

## Additional Notes
- The extension is set to version **0.1.0** for this initial release.

## Checklist
- [x] Submodule added correctly under `extensions/base64-slash-command`
- [x] **extensions.toml** updated with new extension entry
- [x] Files sorted using `pnpm sort-extensions`

Thank you for reviewing this PR. Please let me know if any adjustments are needed.