### PR TITLE
html: Bump to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -818,7 +818,7 @@ version = "0.0.1"
 [html]
 submodule = "extensions/zed"
 path = "extensions/html"
-version = "0.2.0"
+version = "0.2.1"
 
 [html-jinja]
 submodule = "extensions/html-jinja"


### PR DESCRIPTION
This PR updates the HTML extension to v0.2.1.

See https://github.com/zed-industries/zed/pull/28575 for the changes in this version.