### PR TITLE
Add ast-grep extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,6 +86,10 @@
 	path = extensions/assembly
 	url = https://github.com/DevBlocky/zed-asm.git
 
+[submodule "extensions/ast-grep"]
+	path = extensions/ast-grep
+	url = https://github.com/mathieulj/ast-grep-zed
+
 [submodule "extensions/asteroid"]
 	path = extensions/asteroid
 	url = https://github.com/webhooked/asteroid-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -87,6 +87,10 @@ version = "0.0.1"
 submodule = "extensions/assembly"
 version = "0.0.1"
 
+[ast-grep]
+submodule = "extensions/ast-grep"
+version = "0.1.0"
+
 [asteroid]
 submodule = "extensions/asteroid"
 version = "0.0.1"


### PR DESCRIPTION
# Overview

The very powerful [ast-grep](https://ast-grep.github.io/) tool can be used to write custom lints. Since it supports LSP integration, we can get those errors/warnings/suggestion inline while editing our files.

This first version of the ast-grep extension is pretty basic. Since ast-grep itself is configured via files in the project itself, we don't need anything special in the extension. To keep things simple, we are requiring that the user installs ast-grep themselves. I suspect many users will already be doing so anyways since ast-grep has other useful commands (ex. to test rules as you write them) but I may attempt to add auto install in a future version.

- Extension Repo: [mathieulj/ast-grep-zed](https://github.com/mathieulj/ast-grep-zed)