### PR TITLE
java: Bump to v6.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -886,7 +886,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "6.0.1"
+version = "6.0.2"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v6.0.2