### PR TITLE
Add an extension for WebIDL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2150,6 +2150,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-webidl"]
+	path = extensions/webidl
+	url = https://github.com/padenot/zed-webidl.git
+
 [submodule "extensions/zedburn"]
 	path = extensions/zedburn
 	url = https://github.com/rmoraes92/zedburn.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2138,6 +2138,10 @@ version = "0.1.0"
 submodule = "extensions/wdl"
 version = "0.0.1"
 
+[webidl]
+submodule = "extensions/webidl/"
+version = "0.0.1"
+
 [wgsl]
 submodule = "extensions/wgsl"
 version = "0.0.1"


### PR DESCRIPTION
WebIDL is the language we (browser implementors) use to specify Web interfaces. Its own spec is at https://webidl.spec.whatwg.org/, and you can find examples of uses all over, e.g. https://w3c.github.io/webcodecs/#videodecoder-interface.

We use those exact files (literaly copy/pasted) as the input for a binding generator, when implement new features in Web browsers, so we often edit them when working on browsers.

The [underlying tree-sitter grammar](https://w3c.github.io/webcodecs/#videodecoder-interface) is a work in progress, as I'm learning tree-sitter itself, but it is enough to correcly highlight most of the WebIDL files I threw at it from within the Firefox repo, and uninstall vscode.