### PR TITLE
Update neocmake extension to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1230,7 +1230,7 @@ version = "0.0.6"
 
 [neocmake]
 submodule = "extensions/neocmake"
-version = "0.0.5"
+version = "0.0.6"
 
 [neon-cyberpunk]
 submodule = "extensions/neon-cyberpunk"


### PR DESCRIPTION
Small update

Changelog:
- Add aarch64 support for Linux
- Update zed_extension_api version to 0.3.0