### PR TITLE
Update the Zed Extension CLI version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: acf9b22466fc0f1aa26c4a403278bef6a1560aaa
+  ZED_EXTENSION_CLI_SHA: e34fee55a05e6ceb928b7d57f84c51cdd4fd323a
 
 jobs:
   package:


### PR DESCRIPTION
This includes:
- https://github.com/zed-industries/zed/pull/28608

Which should unblock:
- https://github.com/zed-industries/extensions/pull/2443

New commit: [e34fee55a05e6ceb928b7d57f84c51cdd4fd323a](https://github.com/zed-industries/zed/commits/e34fee55a05e6ceb928b7d57f84c51cdd4fd323a) (2025-04-15)
Old commit: [acf9b22466fc0f1aa26c4a403278bef6a1560aaa](https://github.com/zed-industries/zed/commits/acf9b22466fc0f1aa26c4a403278bef6a1560aaa) (2025-03-13)

Build job was here:
- https://github.com/zed-industries/zed/actions/runs/14479521777/job/40613241316