### PR TITLE
Update Modus Themes to v0.0.16

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1183,7 +1183,7 @@ version = "0.1.7"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.15"
+version = "0.0.16"
 
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"


### PR DESCRIPTION
This PR updates Modus Themes to v0.0.16. This release syncs changes with the upstream release of [Modus Themes v4.7.0](https://github.com/protesilaos/modus-themes/releases/tag/4.7.0). The following changes apply specifically to the Zed themes:

- [Make yellow-cooler of modus-operandi-tinted even more dark](https://github.com/vitallium/zed-modus-themes/commit/eb060dc362cb35fd1d313a5a3494143329c5f918)
- [Swap the mappings of 'type' and 'variable' in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/ff28588924eeb149b929f03b91e0892912ac497c)
- [Make yellow-faint of modus-operandi-tinted a bit darker](https://github.com/vitallium/zed-modus-themes/commit/32a69dfe21c3eea21ca7b7ea97c962c1b27fdae0)
- [Make yellow-cooler of modus-operandi-tinted a bit darker](https://github.com/vitallium/zed-modus-themes/commit/7cbd71758a5d86aca9efd1684516194270d71771)
- [Make modus-vivendi-tinted 'green-cooler' a bit more bright](https://github.com/vitallium/zed-modus-themes/commit/c5f54a8ee53662491b5543411ef31875fb196d9f)
- [Make modus-vivendi-tinted type a bit more blue](https://github.com/vitallium/zed-modus-themes/commit/3072d7340dd8543dee375c3ab81073185dc8ab24)
- [Make modus-vivendi-tinted strings blue instead of teal](https://github.com/vitallium/zed-modus-themes/commit/cd43c28cebf536ccea185597b08c38eaf35f1e80)
- [Refine 'green-warmer' in modus-vivendi-tinted](https://github.com/vitallium/zed-modus-themes/commit/483104559b2aab586ef8636f9a81acf4c47cb4cc)
- [Refine 'green-warmer' in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/1fe382afac66738a4c77791537e44fa6e6f8d601)
- [Refine 'yellow-cooler' and 'yellow-faint' in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/c3137037131bf4be08aa934aacc31b73105a6642)
- [Tweak value of yellow-cooler in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/ad7ec0b2366b517aa19561cb6201d19497558606)
- [Refine the value of bg-hover-secondary in most themes](https://github.com/vitallium/zed-modus-themes/commit/5da0054adb30556dc29f2ed5048b4e1171d00b78)
- [Tweak the value of modus-vivendi-tinted 'green-warmer'](https://github.com/vitallium/zed-modus-themes/commit/4cf00ec6e776ad612faca3d36a7681ae7fa949dc)
- [Tweak the value of 'yellow-cooler' in modus-operandi-tinted](https://github.com/vitallium/zed-modus-themes/commit/bf769c51fcec9d44355110d3163abbef0de0ae47)
- [Tweak the blue used in modus-operandi-tinted 'keyword' mapping](https://github.com/vitallium/zed-modus-themes/commit/412e29ee465bc055cf3870cb275ce8d7fde292c6)
- [Tweak the fg-alt value of the tritanopia themes](https://github.com/vitallium/zed-modus-themes/commit/a156582987f90221120a5dd1a095b7713fa64bc0)
- [Make modus-vivendi-tinted 'green-warmer' less intense](https://github.com/vitallium/zed-modus-themes/commit/464220e8383a41f8b09d3a93d84b0e34a8697a89)
- [Make modus-vivendi-tinted 'red-faint' a bit darker](https://github.com/vitallium/zed-modus-themes/commit/22e9c4358203ecbfba8f23971adda12ea7aa89ea)

The list appears quite long, with many small changes. To help illustrate the differences, check out [this commit](https://github.com/vitallium/zed-modus-themes/commit/40a621b43195aa8249c993f7c00a4b610303558a) with updated screenshots. Thanks!

Full Changelog: https://github.com/vitallium/zed-modus-themes/compare/v0.0.14...v0.0.16