### PR TITLE
Add monospace-icon-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1178,6 +1178,10 @@
 	path = extensions/monosami
 	url = https://github.com/borngraced/monosami.git
 
+[submodule "extensions/monospace-icon-theme"]
+	path = extensions/monospace-icon-theme
+	url = https://github.com/irmhonde/monospace-icon-theme
+
 [submodule "extensions/monospace-theme"]
 	path = extensions/monospace-theme
 	url = https://github.com/Abhinav5383/zed-monospace-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1201,6 +1201,10 @@ version = "0.0.4"
 submodule = "extensions/monosami"
 version = "0.1.3"
 
+[monospace-icon-theme]
+submodule = "extensions/monospace-icon-theme"
+version = "0.1.0"
+
 [monospace-theme]
 submodule = "extensions/monospace-theme"
 version = "0.1.3"


### PR DESCRIPTION
Refactor: Add Monospace Icon Theme

**What this PR does:**

This pull request introduces a new icon theme for the Zed editor called "Monospace".

**Basis and Inspiration:**

This icon theme is based on and inspired by the clean and distinctive Monospace Icon theme originally found in [**Firebase Studio**](https://firebase.google.com/studio). The aim is to bring a similar visual style and feel for file and folder icons to the Zed editing environment.

**Testing:**

* I have tested this theme locally in my Zed editor to ensure icons are displayed correctly for various file types and folders.

**Checklist:**

* [X] I have read and followed the contribution guidelines for adding extensions.
* [X] The theme is correctly formatted for Zed.
* [X] I have tested the theme on my system.

Looking forward to your review!