### PR TITLE
Add TeXpresso extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1922,6 +1922,10 @@
 	path = extensions/terrible-theme
 	url = https://github.com/nooooaaaaah/terrible-zed.git
 
+[submodule "extensions/texpresso"]
+	path = extensions/texpresso
+	url = https://github.com/lnay/zed-texpresso.git
+
 [submodule "extensions/the-best-theme"]
 	path = extensions/the-best-theme
 	url = https://github.com/Nidal-Bakir/zed-the-best-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1967,6 +1967,10 @@ version = "0.1.3"
 submodule = "extensions/terrible-theme"
 version = "0.0.3"
 
+[texpresso]
+submodule = "extensions/texpresso"
+version = "0.0.1"
+
 [the-best-theme]
 submodule = "extensions/the-best-theme"
 version = "0.0.1"


### PR DESCRIPTION
This is an extension to be used alongside the LaTeX one, providing a (very new) language server which only deals with live preview of a LaTeX document using [TeXpresso](https://github.com/let-def/texpresso), while `texlab` (from other extension) will provide all the other language server capabilities (go-to-definition, completions, snippets...). TeXpresso is a very experimental project but pulls off something not seen anywhere else in the LaTeX world with the preview updating smoothly with every keystroke. This particular project (LSP and zed integration) was prompted by a [user request in the LaTeX extension](https://github.com/rzukic/zed-latex/issues/85) and since then I have personally found it incredibly compelling.

*Demo showing live preview and inverse-search (clicking on parts of preview to move cursor in editor:*

https://github.com/user-attachments/assets/e3fd9773-c396-419b-8a12-c3925cdd28a3



