### PR TITLE
Update Dockerfile to v0.0.5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -500,7 +500,7 @@
 
 [submodule "extensions/dockerfile"]
 	path = extensions/dockerfile
-	url = https://github.com/d1y/dockerfile.zed.git
+	url = https://github.com/zed-extensions/dockerfile.git
 
 [submodule "extensions/dracula"]
 	path = extensions/dracula

--- a/extensions.toml
+++ b/extensions.toml
@@ -506,7 +506,7 @@ version = "0.1.0"
 
 [dockerfile]
 submodule = "extensions/dockerfile"
-version = "0.0.4"
+version = "0.0.5"
 
 [dracula]
 submodule = "extensions/dracula"


### PR DESCRIPTION
Repository migrated from d1y to [zed-extensions/dockerfile](https://github.com/zed-extensions/dockerfile).

Includes:
- https://github.com/zed-extensions/dockerfile/pull/18
- https://github.com/zed-extensions/dockerfile/pull/17
- https://github.com/zed-extensions/dockerfile/pull/16