### PR TITLE
Update Blueprint to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -218,7 +218,7 @@ version = "0.0.5"
 
 [blueprint]
 submodule = "extensions/blueprint"
-version = "0.1.0"
+version = "0.2.0"
 
 [bluloco-theme]
 submodule = "extensions/bluloco-theme"


### PR DESCRIPTION
Switch to a better, more complete grammar and update `zed_extension_api` to `0.3.0`.