### PR TITLE
Bump verilog to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2119,7 +2119,7 @@ version = "0.0.8"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.7"
+version = "0.0.8"
 
 [vesper]
 submodule = "extensions/vesper"


### PR DESCRIPTION
I forgot to update the tag which veridian was downloading from, so it was downloading the veridian build from 0.0.5.

tree-sitter diff: https://github.com/gmlarumbe/tree-sitter-systemverilog/compare/0dacb911daa9614a7c7e79a594d4cb9f478e6554...ba3c1e305caf948f718293c86c6018a82ed5043e
language-server diff: https://github.com/someone13574/zed-verilog-extension/compare/v0.0.5...v0.0.8
