### PR TITLE
Update elle to v0.3.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -538,6 +538,10 @@
 	path = extensions/elixir
 	url = https://github.com/zed-extensions/elixir.git
 
+[submodule "extensions/elle"]
+	path = extensions/elle
+	url = https://github.com/acquitelol/elle.git
+
 [submodule "extensions/elm"]
 	path = extensions/elm
 	url = https://github.com/zed-extensions/elm.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -552,7 +552,7 @@ version = "0.1.7"
 [elle]
 submodule = "extensions/elle"
 path = "editors/zed"
-version = "0.2.4"
+version = "0.3.0"
 
 [elm]
 submodule = "extensions/elm"

--- a/extensions.toml
+++ b/extensions.toml
@@ -544,6 +544,11 @@ version = "0.0.4"
 submodule = "extensions/elixir"
 version = "0.1.7"
 
+[elle]
+submodule = "extensions/elle"
+path = "editors/zed"
+version = "0.2.4"
+
 [elm]
 submodule = "extensions/elm"
 version = "0.2.0"


### PR DESCRIPTION
This pull request:

- adds syntax highlighting support for enums (https://github.com/acquitelol/elle/commit/4c807696b47debb58abe8850edcc649a22acccd8)
- adds the `type` keyword for pretty hover diagnostics when hovering primitive types 
(https://github.com/acquitelol/elle/commit/27d8f64b723f27dbafc3f5fd8e17bc9465130599 and https://github.com/acquitelol/elle/commit/eb4e12e665948f7c18353cef367b6264077aa506)

The submodule itself has many more changes (it's the whole compiler toolchain), but you can view the changes specifically for the extension since April 18th (my last pull request) [here](https://github.com/acquitelol/elle/commits/rewrite/editors/zed?since=2025-04-19&until=2025-04-30)