### PR TITLE
Add react-typescript-snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1650,6 +1650,10 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
+[submodule "extensions/react-typescript-snippets"]
+	path = extensions/react-typescript-snippets
+	url = https://github.com/vishnuroshan/zed-react-ts-snippets.git
+
 [submodule "extensions/redscript"]
 	path = extensions/redscript
 	url = https://github.com/jac3km4/redscript-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1686,6 +1686,10 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.8.0"
 
+[react-typescript-snippets]
+submodule = "extensions/react-typescript-snippets"
+version = "0.1.0"
+
 [redscript]
 submodule = "extensions/redscript"
 version = "0.2.0"


### PR DESCRIPTION
This PR adds a Zed extension with useful React + TypeScript snippets that I often use. Thought it’d be helpful for others to have them bundled in one place.

#### Checklist:
- [x] Added `extension.toml` with correct metadata  
- [x] Created `tsx.json` & `typescript.json` with some core React + TS snippets  
- [x] Verified all snippet loading and usage in Zed IDE

Looking forward to the review!