### PR TITLE
Update mcp-server-sequential-thinking to v0.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1144,7 +1144,7 @@
 
 [submodule "extensions/mcp-server-sequential-thinking"]
 	path = extensions/mcp-server-sequential-thinking
-	url = https://github.com/LoamStudios/zed-mcp-sequential-thinking.git
+	url = https://github.com/LoamStudios/zed-mcp-server-sequential-thinking.git
 
 [submodule "extensions/mcp-server-shopify-dev"]
 	path = extensions/mcp-server-shopify-dev

--- a/extensions.toml
+++ b/extensions.toml
@@ -1169,7 +1169,7 @@ version = "0.0.1"
 
 [mcp-server-sequential-thinking]
 submodule = "extensions/mcp-server-sequential-thinking"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-shopify-dev]
 submodule = "extensions/mcp-server-shopify-dev"


### PR DESCRIPTION
In this PR, I update the repo url for the extension. I made a typo and didn't follow my convention when I created this extension.

I bump the version to make sure people get the latest. (Probably not needed.)