### PR TITLE
Update tree-sitter-query to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2019,7 +2019,7 @@ version = "1.1.0"
 
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"
-version = "0.0.1"
+version = "0.0.2"
 
 [tsar]
 submodule = "extensions/tsar"


### PR DESCRIPTION
Release notes:

https://github.com/vitallium/zed-tree-sitter-query/releases/tag/v0.0.2