### PR TITLE
Update gosum to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -744,7 +744,7 @@ version = "0.2.0"
 
 [gosum]
 submodule = "extensions/gosum"
-version = "0.0.1"
+version = "0.0.2"
 
 [graphene]
 submodule = "extensions/graphene"


### PR DESCRIPTION
Minor update that changes the `path_suffix` from `sum` to `go.sum`.