### PR TITLE
Add ass subtitles extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -90,6 +90,10 @@
 	path = extensions/asciidoc
 	url = https://github.com/andreicek/zed-asciidoc.git
 
+[submodule "extensions/ass"]
+	path = extensions/ass
+	url = https://github.com/huaium/zed-ass.git
+
 [submodule "extensions/assembly"]
 	path = extensions/assembly
 	url = https://github.com/DevBlocky/zed-asm.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -91,6 +91,10 @@ version = "0.0.1"
 submodule = "extensions/asciidoc"
 version = "0.0.1"
 
+[ass]
+submodule = "extensions/ass"
+version = "0.0.1"
+
 [assembly]
 submodule = "extensions/assembly"
 version = "0.0.1"


### PR DESCRIPTION
Add syntax highlighting support for ASS/SSA subtitles by integrating the tree-sitter parser from [tree-sitter-ass](https://github.com/huaium/tree-sitter-ass).