### PR TITLE
Update mcp-server-gitlab to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1157,7 +1157,7 @@ version = "0.0.2"
 
 [mcp-server-gitlab]
 submodule = "extensions/mcp-server-gitlab"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"


### PR DESCRIPTION
Release notes:

https://github.com/akbxr/gitlab-mcp-zed/releases/tag/v0.0.2