### PR TITLE
Update basher to v0.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -150,6 +150,10 @@
 	path = extensions/basedpyright
 	url = https://github.com/m1guer/basedpyright-zed.git
 
+[submodule "extensions/basher"]
+	path = extensions/basher
+	url = https://github.com/zed-extensions/bash.git
+
 [submodule "extensions/batman"]
 	path = extensions/batman
 	url = https://github.com/devzaidi/batman-theme-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -150,10 +150,6 @@
 	path = extensions/basedpyright
 	url = https://github.com/m1guer/basedpyright-zed.git
 
-[submodule "extensions/basher"]
-	path = extensions/basher
-	url = https://github.com/d1y/bash.zed
-
 [submodule "extensions/batman"]
 	path = extensions/batman
 	url = https://github.com/devzaidi/batman-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -154,7 +154,7 @@ version = "0.1.2"
 
 [basher]
 submodule = "extensions/basher"
-version = "0.0.1"
+version = "0.0.3"
 
 [batman]
 submodule = "extensions/batman"


### PR DESCRIPTION
Updates repository URL and removes redundant bash tree-sitter for Shell Script already provided in Zed core.

Diff:
- https://github.com/zed-extensions/bash/compare/v0.0.1...v0.0.3
