### PR TITLE
Update Ruby to v0.6.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1756,7 +1756,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.5.6"
+version = "0.6.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this PR updates the Ruby extension to [v0.6.0](https://github.com/zed-extensions/ruby/releases/tag/v0.6.0).

## What's changed

- Update Rust crate zed_extension_api to 0.5.0 by @renovate in https://github.com/zed-extensions/ruby/pull/44
- Fix RSpec outlines by @joeldrapper in https://github.com/zed-extensions/ruby/pull/78

Thanks!