### PR TITLE
Update postgres-context-server to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1599,7 +1599,7 @@ version = "0.8.1"
 
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
-version = "0.0.2"
+version = "0.0.3"
 
 [postgres-language-server]
 submodule = "extensions/postgres-language-server"


### PR DESCRIPTION
This updates the postgres-context-server to v0.0.3.
This version adds support for the new `context-server-configuration` API.