### PR TITLE
Update mcp-server-axiom to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1137,7 +1137,7 @@ version = "0.4.5"
 
 [mcp-server-axiom]
 submodule = "extensions/mcp-server-axiom"
-version = "0.1.0"
+version = "0.2.0"
 
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"


### PR DESCRIPTION
This updates the mcp-server-axiom extension to v0.2.0.
This version adds support for the new context-server-configuration API.