### PR TITLE
Update mcp-server-brave-search to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1145,7 +1145,7 @@ version = "0.1.0"
 
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"


### PR DESCRIPTION
This updates the mcp-server-axiom extension to v0.0.2.
This version adds support for the new context-server-configuration API.