### PR TITLE
Update mcp-server-github to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1165,7 +1165,7 @@ version = "0.0.2"
 
 [mcp-server-github]
 submodule = "extensions/mcp-server-github"
-version = "0.0.2"
+version = "0.0.3"
 
 [mcp-server-gitlab]
 submodule = "extensions/mcp-server-gitlab"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-github/releases/tag/v0.0.3