### PR TITLE
Update mcp-server-webflow to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1189,7 +1189,7 @@ version = "0.0.1"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
-version = "0.0.1"
+version = "0.0.2"
 
 [melange]
 submodule = "extensions/melange"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-webflow/releases/tag/v0.0.2