### PR TITLE
Update Ruby to v0.7.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1760,7 +1760,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.7.0"
+version = "0.7.1"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this pull request updates the Ruby extension to [v0.7.1](https://github.com/zed-extensions/ruby/releases/tag/v0.7.1) that contains two bug fixes:

1. Improve language server binary lookup in PATH by @vitallium in https://github.com/zed-extensions/ruby/pull/84
2. Fix gem environment and language server configuration by @vitallium in https://github.com/zed-extensions/ruby/pull/85

Thanks!