### PR TITLE
Update Ruby to v0.7.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1760,7 +1760,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.7.1"
+version = "0.7.3"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This PR updates the Ruby extension to [v0.7.3](https://github.com/zed-extensions/ruby/releases/tag/v0.7.3) that has 2 bug fixes related to using new Process extension API.

Thanks!