### PR TITLE
Update github-activity-summarizer to v0.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -703,7 +703,7 @@ version = "0.0.3"
 
 [github-activity-summarizer]
 submodule = "extensions/github-activity-summarizer"
-version = "0.5.0"
+version = "0.5.1"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -703,7 +703,7 @@ version = "0.0.3"
 
 [github-activity-summarizer]
 submodule = "extensions/github-activity-summarizer"
-version = "0.4.0"
+version = "0.5.0"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"


### PR DESCRIPTION
Implements context server configuration API - https://github.com/rubiojr/gas/pull/6

This probably needs to wait until Zed 0.186.X is released.