### PR TITLE
Add JSON5 language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2321,3 +2321,7 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+
+[submodule "extensions/json5"]
+	path = extensions/json5
+	url = https://github.com/ChunzhengLab/json5-zed-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -938,6 +938,10 @@
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
 
+[submodule "extensions/json5"]
+	path = extensions/json5
+	url = https://github.com/ChunzhengLab/json5-zed-extension.git
+
 [submodule "extensions/jsonnet"]
 	path = extensions/jsonnet
 	url = https://github.com/narqo/zed-jsonnet.git
@@ -2321,7 +2325,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-
-[submodule "extensions/json5"]
-	path = extensions/json5
-	url = https://github.com/ChunzhengLab/json5-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -963,6 +963,10 @@ version = "0.0.1"
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
 
+[json5]
+submodule = "extensions/json5"
+version = "0.0.1"
+
 [jsonnet]
 submodule = "extensions/jsonnet"
 version = "0.3.2"


### PR DESCRIPTION
This PR adds a new extension for the [JSON5](https://json5.org/) file format.

The grammar is based on [@Joakker](https://github.com/Joakker)'s excellent [tree-sitter-json5](https://github.com/Joakker/tree-sitter-json5) project.