### PR TITLE
Update firebase-security-rules to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -625,7 +625,7 @@ version = "0.1.1"
 
 [firebase-security-rules]
 submodule = "extensions/firebase-security-rules"
-version = "0.0.1"
+version = "0.1.0"
 
 [fish]
 submodule = "extensions/fish"


### PR DESCRIPTION
Updates to match tree-sitter improvements and bug fixes.

Tree-sitter-diff: https://github.com/ChemisTechlabs/tree-sitter-firebase-security-rules/compare/b855571222af65f32df5e7c9e9e93f1a5a6b3a1b...065c18e6f18436b1d4594f2cb2d6e448a987b737