### PR TITLE
Add mcp-server-grafana

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1174,6 +1174,10 @@
 	path = extensions/mcp-server-gitlab
 	url = https://github.com/akbxr/gitlab-mcp-zed
 
+[submodule "extensions/mcp-server-grafana"]
+	path = extensions/mcp-server-grafana
+	url = https://github.com/sd2k/zed-mcp-grafana.git
+
 [submodule "extensions/mcp-server-linear"]
 	path = extensions/mcp-server-linear
 	url = https://github.com/LoamStudios/zed-mcp-server-linear.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1199,6 +1199,10 @@ version = "0.0.3"
 submodule = "extensions/mcp-server-gitlab"
 version = "0.0.2"
 
+[mcp-server-grafana]
+submodule = "extensions/mcp-server-grafana"
+version = "0.1.1"
+
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"
 version = "0.0.1"


### PR DESCRIPTION
This commit adds an extension for the Grafana MCP server. It's useful
when adding observability to existing code, as the MCP server can
do things like search for existing Prometheus metrics or create a
dashboard using the metrics it finds in the code.
