### PR TITLE
Add Tomorrow Minimal Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2050,6 +2050,10 @@
 	path = extensions/tombi
 	url = https://github.com/tombi-toml/tombi.git
 
+[submodule "extensions/tomorrow-min-theme"]
+	path = extensions/tomorrow-min-theme
+	url = https://github.com/biaqat/tomorrow-min-theme-zed.git
+
 [submodule "extensions/tomorrow-theme"]
 	path = extensions/tomorrow-theme
 	url = https://github.com/biaqat/tomorrow-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2102,6 +2102,10 @@ submodule = "extensions/zed"
 path = "extensions/toml"
 version = "0.1.3"
 
+[tomorrow-min-theme]
+submodule = "extensions/tomorrow-min-theme"
+version = "1.1.0"
+
 [tomorrow-theme]
 submodule = "extensions/tomorrow-theme"
 version = "1.1.0"


### PR DESCRIPTION
Adding the removed "Minimal" variants of the [Tomorrow Theme](https://github.com/biaqat/tomorrow-theme-zed.git) as a separate extension 
(As reminded to do by https://github.com/bIaqat/tomorrow-theme-zed/issues/7)

### Preview:
<table>
  <tr>
   <td> Normal </td>
   <td> Minimal </td>
  </tr>
  <tr>
    <td rowspan="2"><img src="https://github.com/bIaqat/tomorrow-theme-zed/raw/main/assets/tomorrow.png" width="500"></td>
    <td><img src="https://github.com/bIaqat/tomorrow-min-theme-zed/raw/main/assets/tomorrow-min.png" width="475"></td>
  </tr>
</table>

Tomorrow Min was originally removed from "Tomorrow" in this PR https://github.com/zed-industries/extensions/pull/2146