### PR TITLE
Update catppuccin-icons to v1.20.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -298,7 +298,7 @@ version = "0.1.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
-version = "1.19.0"
+version = "1.20.0"
 
 [cedar]
 submodule = "extensions/cedar"


### PR DESCRIPTION
Release notes:

https://github.com/catppuccin/zed-icons/releases/tag/v1.20.0