### PR TITLE
Add RDF Turtle extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2078,6 +2078,10 @@
 	path = extensions/tsarcasm
 	url = https://github.com/xtrasmal/zed-theme-tsarcasm.git
 
+[submodule "extensions/turtle"]
+	path = extensions/turtle
+	url = https://github.com/MoskitoHero/zed-turtle.git
+
 [submodule "extensions/twig"]
 	path = extensions/twig
 	url = https://github.com/YussufSassi/zed-twig.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2130,6 +2130,10 @@ version = "0.0.2"
 submodule = "extensions/tsarcasm"
 version = "0.0.9"
 
+[turtle]
+submodule = "extensions/turtle"
+version = "0.1.0"
+
 [twig]
 submodule = "extensions/twig"
 version = "0.2.0"


### PR DESCRIPTION
Here is an extension for the RDF Turtle format `.ttl` and `.turtle` extensions.

It provides a tree-sitter grammar, highlighting and a LSP.

Let me know if anything needs to be sorted to be able to merge this.

Links:
- Extension: https://github.com/MoskitoHero/zed-turtle
- LSP NPM package: https://www.npmjs.com/package/turtle-language-server
- LSP Repo: https://github.com/stardog-union/stardog-language-servers
- Tree-sitter: https://github.com/GordianDziwis/tree-sitter-turtle