### PR TITLE
Update min-theme to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1249,7 +1249,7 @@ version = "0.4.0"
 
 [min-theme]
 submodule = "extensions/min-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [mnemonic]
 submodule = "extensions/mnemonic"


### PR DESCRIPTION
Release notes:

https://github.com/phibr0/zed-min-theme/releases/tag/v0.2.1