### PR TITLE
Add Liquid snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1038,6 +1038,10 @@
 	path = extensions/liquid
 	url = https://github.com/TheBeyondGroup/zed-shopify-liquid.git
 
+[submodule "extensions/liquid-snippets"]
+	path = extensions/liquid-snippets
+	url = https://github.com/hcmlopes/zed-liquid-snippets.git
+
 [submodule "extensions/live-server"]
 	path = extensions/live-server
 	url = https://github.com/frederik-uni/zed-live-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1063,6 +1063,10 @@ version = "0.0.9"
 submodule = "extensions/liquid"
 version = "0.2.0"
 
+[liquid-snippets]
+submodule = "extensions/liquid-snippets"
+version = "0.0.1"
+
 [live-server]
 submodule = "extensions/live-server"
 version = "0.3.1"


### PR DESCRIPTION
Adds Liquid snippets to facilitate Shopify Theme development following the official [Shopify docs](https://shopify.dev/docs/api/liquid)