### PR TITLE
Add Statamic Antlers extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1942,6 +1942,10 @@
 	path = extensions/starlark
 	url = https://github.com/zaucy/zed-starlark.git
 
+[submodule "extensions/statamic-antlers"]
+	path = extensions/statamic-antlers
+	url = https://github.com/mynetx/zed-statamic-antlers.git
+
 [submodule "extensions/stimulus"]
 	path = extensions/stimulus
 	url = https://github.com/vitallium/zed-stimulus

--- a/extensions.toml
+++ b/extensions.toml
@@ -1988,6 +1988,10 @@ version = "0.0.1"
 submodule = "extensions/starlark"
 version = "0.2.0"
 
+[statamic-antlers]
+submodule = "extensions/statamic-antlers"
+version = "0.1.0"
+
 [stimulus]
 submodule = "extensions/stimulus"
 version = "0.0.2"


### PR DESCRIPTION
This adds a Zed extension that enables IntelliSense and syntax highlighting for [Statamic](https://statamic.com/)’s [Antlers](https://statamic.dev/antlers) templating language.