### PR TITLE
Update Modus themes to v0.0.19

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1270,7 +1270,7 @@ version = "0.1.8"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.17"
+version = "0.0.19"
 
 [monokai-nebula]
 submodule = "extensions/monokai-nebula"


### PR DESCRIPTION
Hello! This pull request updates Modus themes to [v0.0.19](https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.19) that contains mostly bug fixes for the VCS stuff:

- [Update version_control.* colors](https://github.com/vitallium/zed-modus-themes/commit/a0c4170d9b462c59ddeb15fbbc2bc9ba63edaf0d)
- [Fix version_control.conflict color](https://github.com/vitallium/zed-modus-themes/commit/0d8504aae7ebe2c2b398364dd04bfc9ac637d2cc)
- [Add success](https://github.com/vitallium/zed-modus-themes/commit/bd8a011112be1dc8e55d90f712c7d93403736628)
- [Change info to info](https://github.com/vitallium/zed-modus-themes/commit/487948e16d77b02fdcdf45f726800953a2b396dd)
- [Change warning to fg_prominent_warning](https://github.com/vitallium/zed-modus-themes/commit/280c032f61db89de87ccbe69fac3118494d76510)
- [Add editor.invisible](https://github.com/vitallium/zed-modus-themes/commit/1b72c8eb7a05801f409f4d6df30c3b534d71b76a)

Thanks!