### PR TITLE
Update marksman to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1154,7 +1154,7 @@ version = "0.0.4"
 
 [marksman]
 submodule = "extensions/marksman"
-version = "0.0.3"
+version = "0.0.5"
 
 [martianized]
 submodule = "extensions/martianized"


### PR DESCRIPTION
Release notes:

https://github.com/vitallium/zed-marksman/releases/tag/v0.0.5