### PR TITLE
Add Neutral Theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1362,6 +1362,10 @@
 	path = extensions/nestjs-snippets
 	url = https://github.com/ayberkgezer/nestjs-snippets.git
 
+[submodule "extensions/neutral-theme"]
+	path = extensions/neutral-theme
+	url = https://github.com/dustinbturner/neutral-theme.git
+
 [submodule "extensions/new-darcula"]
 	path = extensions/new-darcula
 	url = https://github.com/e-simpson/new-darcula-z.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1388,6 +1388,10 @@ version = "0.3.0"
 submodule = "extensions/nestjs-snippets"
 version = "0.1.4"
 
+[neutral-theme]
+submodule = "extensions/neutral-theme"
+version = "0.0.1"
+
 [new-darcula]
 submodule = "extensions/new-darcula"
 version = "1.0.7"


### PR DESCRIPTION
This PR adds the Neutral Theme extension, a clean, minimal theme for Zed featuring a neutral color palette.

Features:
- Dark theme with a neutral color palette based on Tailwind colors
- Clean, minimal design with carefully selected syntax highlighting
- Terminal colors optimized for readability
