### PR TITLE
toml: Bump to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2145,7 +2145,7 @@ version = "0.1.3"
 [toml]
 submodule = "extensions/zed"
 path = "extensions/toml"
-version = "0.1.3"
+version = "0.1.4"
 
 [tomorrow-min-theme]
 submodule = "extensions/tomorrow-min-theme"


### PR DESCRIPTION
This PR updates the TOML extension to v0.1.4.

See https://github.com/zed-industries/zed/pull/31272 for the changes in this version.