### PR TITLE
Update Haxe to v0.3.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -861,7 +861,7 @@ version = "0.1.5"
 
 [haxe]
 submodule = "extensions/haxe"
-version = "0.3.0"
+version = "0.3.1"
 
 [helm]
 submodule = "extensions/helm"


### PR DESCRIPTION
- **Adds basic grammar for HXML**, Haxe's compiler configuration syntax.
- Extension no longer fails to start when GH releases cannot be reached. That is, if a recent version of the extension has downloaded the LSP sometime in the past.
- Extension now emits warnings when detecting Lime and Ceramic frameworks with default configuration (their build systems are not supported out-of-the-box).