### PR TITLE
Update mcp-server-buildkite to v0.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1122,6 +1122,10 @@
 	path = extensions/mcp-server-brave-search
 	url = https://github.com/zed-extensions/mcp-server-brave-search.git
 
+[submodule "extensions/mcp-server-buildkite"]
+	path = extensions/mcp-server-buildkite
+	url = https://github.com/mcncl/zed-mcp-server-buildkite
+
 [submodule "extensions/mcp-server-context7"]
 	path = extensions/mcp-server-context7
 	url = https://github.com/akbxr/zed-mcp-server-context7

--- a/extensions.toml
+++ b/extensions.toml
@@ -1147,6 +1147,10 @@ version = "0.2.0"
 submodule = "extensions/mcp-server-brave-search"
 version = "0.0.2"
 
+[mcp-server-buildkite]
+submodule = "extensions/mcp-server-buildkite"
+version = "0.0.1"
+
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1149,7 +1149,7 @@ version = "0.0.2"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
-version = "0.0.2"
+version = "0.0.3"
 
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1149,7 +1149,7 @@ version = "0.0.2"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"


### PR DESCRIPTION
This version contains important fixes for installing the MCP if it doesn't yet exist in `PATH`