### PR TITLE
Add PlanetScale MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1158,6 +1158,10 @@
 	path = extensions/maya
 	url = https://github.com/sbowman/maya.zed
 
+[submodule "extensions/mcp-planetscale"]
+	path = extensions/mcp-planetscale
+	url = https://github.com/hunterjsb/zed-planetscale-mcp.git
+
 [submodule "extensions/mcp-server-axiom"]
 	path = extensions/mcp-server-axiom
 	url = https://github.com/zed-extensions/mcp-server-axiom.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1184,6 +1184,10 @@ version = "0.0.4"
 submodule = "extensions/maya"
 version = "0.4.5"
 
+[mcp-planetscale]
+submodule = "extensions/mcp-planetscale"
+version = "0.4.1"
+
 [mcp-server-axiom]
 submodule = "extensions/mcp-server-axiom"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1186,7 +1186,7 @@ version = "0.4.5"
 
 [mcp-planetscale]
 submodule = "extensions/mcp-planetscale"
-version = "0.4.1"
+version = "0.0.1"
 
 [mcp-server-axiom]
 submodule = "extensions/mcp-server-axiom"


### PR DESCRIPTION
Adds PlanetScale Model Context Protocol extension that integrates PlanetScale's MCP server with Zed.

- Extension: https://github.com/hunterjsb/zed-planetscale-mcp
- MCP: https://github.com/planetscale/cli