### PR TITLE
Add gruvbox-crisp-themes extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2425,3 +2425,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/gruvbox-crisp-themes"]
+	path = extensions/gruvbox-crisp-themes
+	url = https://github.com/VatsalSy/zed-gruvbox_custom_themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -815,6 +815,10 @@ version = "0.0.8"
 submodule = "extensions/gruber-flavors"
 version = "0.8.0"
 
+[gruvbox-crisp-themes]
+submodule = "extensions/gruvbox-crisp-themes"
+version = "0.1.2"
+
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"
 version = "0.0.1"


### PR DESCRIPTION
## Summary
- Add Gruvbox Crisp Themes extension to the Zed editor extensions repository
- High contrast Gruvbox theme variant optimized for clarity and readability

## Details
This PR adds the `gruvbox-crisp-themes` extension which provides enhanced Gruvbox color themes for Zed Editor with:
- High contrast dark theme variant
- Optimized syntax highlighting for multiple languages
- Carefully selected colors for maximum readability

Extension repository: https://github.com/VatsalSy/zed-gruvbox_custom_themes