### PR TITLE
Update assembly-syntax to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -97,7 +97,7 @@ version = "0.0.1"
 
 [assembly]
 submodule = "extensions/assembly"
-version = "0.0.1"
+version = "0.0.2"
 
 [ast-grep]
 submodule = "extensions/ast-grep"


### PR DESCRIPTION
Uses the new `extension.toml` format for the extension

Fixes my extension for #2104 

Does the folder name need to be the same as the extension ID? If so, I can update that