### PR TITLE
material-icon-theme: Bump to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1166,7 +1166,7 @@ version = "0.0.3"
 
 [material-icon-theme]
 submodule = "extensions/material-icon-theme"
-version = "0.1.2"
+version = "1.0.0"
 
 [material-theme]
 submodule = "extensions/material-theme"


### PR DESCRIPTION
This PR updates the Material Icon Theme extension to v1.0.0.