### PR TITLE
Update Ruby to v0.8.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1881,7 +1881,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.7.3"
+version = "0.8.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This PR updates the Ruby extension to [v0.8.0](https://github.com/zed-extensions/ruby/releases/tag/v0.8.0) that includes the following changes:

- Expose `runnables` captures (https://github.com/zed-extensions/ruby/pull/94)
- Update Rust crate `zed_extension_api` to v0.5.0 (https://github.com/zed-extensions/ruby/pull/86)
- ruby: Update tasks format (https://github.com/zed-extensions/ruby/pull/100)
- ruby: Add .irbrc to language config (https://github.com/zed-extensions/ruby/pull/101)

Thanks!