### PR TITLE
Update shades-of-purple-theme to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1962,7 +1962,7 @@ version = "0.1.1"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
-version = "0.0.5"
+version = "0.0.6"
 
 [short-giraffe-theme]
 submodule = "extensions/short-giraffe-theme"


### PR DESCRIPTION
Release notes:

https://github.com/irmhonde/shades-of-purple-theme/releases/tag/v0.0.6