### PR TITLE
Update fsharp to 0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -719,7 +719,7 @@ version = "0.0.1"
 
 [fsharp]
 submodule = "extensions/fsharp"
-version = "0.0.5"
+version = "0.0.6"
 
 [fsm]
 submodule = "extensions/fsm"


### PR DESCRIPTION
Updates fsharp extension to 0.0.6, resolves a highlighting issue, changelog [here](https://github.com/nathanjcollins/zed-fsharp/releases/tag/0.0.6)