### PR TITLE
Add Spai Zero theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2030,6 +2030,10 @@
 	path = extensions/sourcepawn
 	url = https://github.com/tsuza/zed-sourcepawn-ext.git
 
+[submodule "extensions/spai-zero-theme"]
+	path = extensions/spai-zero-theme
+	url = https://github.com/BasaiCorp/zed-spai-zero-theme.git
+
 [submodule "extensions/sql"]
 	path = extensions/sql
 	url = https://github.com/nervenes/zed-sql.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2081,6 +2081,10 @@ version = "0.1.1"
 submodule = "extensions/sourcepawn"
 version = "0.0.1"
 
+[spai-zero-theme]
+submodule = "extensions/spai-zero-theme"
+version = "0.1.0"
+
 [sql]
 submodule = "extensions/sql"
 version = "1.1.3"


### PR DESCRIPTION
## Description
Adding Spai Zero theme - a sleek dark theme with cyan accents and modern styling.

## Features
- Dark background with high contrast
- Cyan accent colors for better visibility
- Carefully crafted syntax highlighting
- Modern and clean design

## Screenshots
1. Screenshot1: [screenshots/screenshot1.png](https://github.com/BasaiCorp/zed-spai-zero-theme/blob/59a189b3cc0263c529d661d6843a64cf8e693cd7/screenshots/screenshot1.png)
2. Screenshot2: [screenshots/screenshot2.png](https://github.com/BasaiCorp/zed-spai-zero-theme/blob/59a189b3cc0263c529d661d6843a64cf8e693cd7/screenshots/screenshot2.png)
3. Screenshot3: [screenshots/screenshot3.png](https://github.com/BasaiCorp/zed-spai-zero-theme/blob/59a189b3cc0263c529d661d6843a64cf8e693cd7/screenshots/screenshot3.png)
4. Screenshot4: [screenshots/screenshot4.png](https://github.com/BasaiCorp/zed-spai-zero-theme/blob/59a189b3cc0263c529d661d6843a64cf8e693cd7/screenshots/screenshot4.png)

## Testing
- [x] Extension installs locally without errors
- [x] Theme displays correctly in Zed
- [x] All syntax highlighting works as expected

Thank you for your time!