### PR TITLE
Update Ruby to v0.9.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1937,7 +1937,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.7.3"
+version = "0.9.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This pull request updates the Ruby language extension to [v0.9.0](https://github.com/zed-extensions/ruby/releases/tag/v0.9.0). The list of changes is below:

- Added two new language servers `steep` and `sorbet`
- Fixed runnable queries for Ruby language

I also created a corresponding pull request for updating the Ruby documentation [here](https://github.com/zed-industries/zed/pull/32345).

Thanks!