### PR TITLE
Update motoko extension to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1398,7 +1398,7 @@ version = "0.0.2"
 
 [motoko]
 submodule = "extensions/motoko"
-version = "0.0.2"
+version = "0.0.3"
 
 [move]
 submodule = "extensions/move"


### PR DESCRIPTION
### Update Motoko extension to v0.0.3

#### Changes
- Update extension version from v0.0.2 -> v0.0.3
- Improve syntax highlighting
- Update tree-sitter: https://github.com/christoph-dfinity/tree-sitter-motoko/compare/baf083737baf0750be3ea25538a5b2d98937a51c...b2df9eee5f207d26201b2a934c9d2655c6cdfda4