### PR TITLE
Update base16 to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -162,7 +162,7 @@ version = "1.3.1"
 
 [base16]
 submodule = "extensions/base16"
-version = "0.1.1"
+version = "0.1.2"
 
 [basedpyright]
 submodule = "extensions/basedpyright"


### PR DESCRIPTION
updating base16 theme to 0.1.2

have submitted a PR [#12](https://github.com/bswinnerton/base16-zed/pull/12) to increase version number