### PR TITLE
Remove anya theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,10 +70,6 @@
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git
 
-[submodule "extensions/anya"]
-	path = extensions/anya
-	url = https://github.com/anya-theme/anya-zed.git
-
 [submodule "extensions/anysphere-theme"]
 	path = extensions/anysphere-theme
 	url = https://github.com/stpn48/anysphere-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -71,10 +71,6 @@ version = "0.1.2"
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"
 
-[anya]
-submodule = "extensions/anya"
-version = "0.0.2"
-
 [anysphere-theme]
 submodule = "extensions/anysphere-theme"
 version = "0.0.1"


### PR DESCRIPTION
Upstream repo and org are gone:
- https://github.com/anya-theme/anya-zed

@cwooju0: Have you moved this repo elsewhere or would you like us to just pull it from the extension store?

Previously:
- https://github.com/zed-industries/extensions/pull/635