### PR TITLE
Remove idris2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -938,10 +938,6 @@
 	path = extensions/iceicebergy
 	url = https://github.com/jmsdnns/zed-iceicebergy.git
 
-[submodule "extensions/idris2"]
-	path = extensions/idris2
-	url = https://github.com/srghma/zed-idris2
-
 [submodule "extensions/indigo"]
 	path = extensions/indigo
 	url = https://github.com/p3rception/Indigo-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -964,10 +964,6 @@ version = "0.2.10"
 submodule = "extensions/iceicebergy"
 version = "0.3.14"
 
-[idris2]
-submodule = "extensions/idris2"
-version = "0.0.1"
-
 [indigo]
 submodule = "extensions/indigo"
 version = "0.1.2"


### PR DESCRIPTION
Upstream repo is missing:
- https://github.com/srghma/zed-idris2

See also:
- https://github.com/zed-industries/extensions/commit/a1554b532f3d83d8fa04e55b34161757855d3e31
- https://github.com/zed-industries/extensions/pull/1629 (deleted somehow?)