### PR TITLE
Update termux submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2180,7 +2180,7 @@
 
 [submodule "extensions/termux"]
 	path = extensions/termux
-	url = https://gitlab.com/paveloom-g/rust/zed-termux
+	url = https://gitlab.com/paveloom-g/rust/zed-termux.git
 
 [submodule "extensions/terraform"]
 	path = extensions/terraform


### PR DESCRIPTION
Gitlab submodules should have a trailing .git or else they trigger a cli warning.