### PR TITLE
Bump extension CLI version to `3e8a07f`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: e34fee55a05e6ceb928b7d57f84c51cdd4fd323a
+  ZED_EXTENSION_CLI_SHA: 3e8a07f496de79a3ed53b6a221ede554762611bc
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/3e8a07f496de79a3ed53b6a221ede554762611bc.