### PR TITLE
Update mcp-server-supabase to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1318,7 +1318,7 @@ version = "0.0.1"
 
 [mcp-server-supabase]
 submodule = "extensions/mcp-server-supabase"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"


### PR DESCRIPTION
The new versions of Supabase MCP server put entry point `stdio.js` under `transports/stdio.js`.