### PR TITLE
chore: update mcp-server-buildkite to 0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1250,7 +1250,7 @@ version = "0.0.2"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
-version = "0.0.3"
+version = "0.0.4"
 
 [mcp-server-byterover]
 submodule = "extensions/mcp-server-byterover"


### PR DESCRIPTION
## Changes

- Updates the `zed_extension_api`
- Adds pre-filled API options to helper

Signed-off-by: Ben McNicholl <git@benmcnicholl.com>
