### PR TITLE
Update Modus Themes to v0.0.20

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1358,7 +1358,7 @@ version = "0.1.8"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.0.19"
+version = "0.0.20"
 
 [molten-theme]
 submodule = "extensions/molten-theme"


### PR DESCRIPTION
Hi! This PR updates Modus Theme to [v0.0.20](https://github.com/vitallium/zed-modus-themes/releases/tag/v0.0.20). This release has the only change:

-[Stop using bold font for certain code syntax highlighting](https://github.com/vitallium/zed-modus-themes/commit/b638be0fd92bd642759ab8b69d8df339bee6e883)

Thanks!