### PR TITLE
Add Dogi theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -554,6 +554,10 @@
 	path = extensions/dockerfile
 	url = https://github.com/zed-extensions/dockerfile.git
 
+[submodule "extensions/dogi"]
+	path = extensions/dogi
+	url = https://github.com/dogukanurker/DogiZed.git
+
 [submodule "extensions/dracula"]
 	path = extensions/dracula
 	url = https://github.com/dracula/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -562,6 +562,10 @@ version = "0.1.0"
 submodule = "extensions/dockerfile"
 version = "0.0.5"
 
+[dogi]
+submodule = "extensions/dogi"
+version = "1.0.0"
+
 [dracula]
 submodule = "extensions/dracula"
 version = "1.0.0"


### PR DESCRIPTION
## Add Dogi theme

This PR adds **Dogi**, a minimalist flat theme for Zed.

### Theme Features
- Pure black (#0B0B0B) and white (#FFFFFF) backgrounds
- Vibrant syntax highlighting with carefully selected colors
- Consistent medium font weights (500) for improved readability
- Both dark and light variants included

### Screenshots

**Dark**
<img width="911" alt="dark" src="https://github.com/user-attachments/assets/af518ba1-0f17-4d57-a1aa-49097799b21a" />


**Light**
<img width="911" alt="light" src="https://github.com/user-attachments/assets/3fc99891-c471-429d-80cf-ddc0ba575ebe" />


### Repository
https://github.com/dogukanurker/DogiZed