### PR TITLE
Fix Material UI MCP submodule path location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -642,10 +642,6 @@
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets
 
-[submodule "extensions/extensions/mcp-server-mui"]
-	path = extensions/extensions/mcp-server-mui
-	url = https://github.com/danilo-leal/zed-mui-mcp-server.git
-
 [submodule "extensions/ezio-theme"]
 	path = extensions/ezio-theme
 	url = https://github.com/dsantolo/ezio-zed.git
@@ -1269,6 +1265,10 @@
 [submodule "extensions/mcp-server-miaoduo"]
 	path = extensions/mcp-server-miaoduo
 	url = https://github.com/benmooo/zed-mcp-server-miaoduo.git
+
+[submodule "extensions/mcp-server-mui"]
+	path = extensions/mcp-server-mui
+	url = https://github.com/danilo-leal/zed-mui-mcp-server.git
 
 [submodule "extensions/mcp-server-newsnow"]
 	path = extensions/mcp-server-newsnow

--- a/extensions.toml
+++ b/extensions.toml
@@ -1292,6 +1292,10 @@ version = "0.0.1"
 submodule = "extensions/mcp-server-miaoduo"
 version = "0.0.1"
 
+[mcp-server-mui]
+submodule = "extensions/mcp-server-mui"
+version = "0.1.0"
+
 [mcp-server-newsnow]
 submodule = "extensions/mcp-server-newsnow"
 version = "0.0.1"


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/extensions/pull/2889 where I added the extension in an incorrect submodule path, and thus the `extensions.toml` wasn't being updated, leading to the extension not being published.