### PR TITLE
Update the Material UI MCP server

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1294,7 +1294,7 @@ version = "0.0.1"
 
 [mcp-server-mui]
 submodule = "extensions/mcp-server-mui"
-version = "0.1.0"
+version = "0.2.0"
 
 [mcp-server-newsnow]
 submodule = "extensions/mcp-server-newsnow"


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/extensions/pull/2891.
Bumping the extension version so the latest instruction changes are picked up.