### PR TITLE
Add Dram theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/dracula
 	url = https://github.com/dracula/zed.git
 
+[submodule "extensions/dram"]
+	path = extensions/dram
+	url = https://github.com/clamjohnston/dram.git
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension
@@ -2565,6 +2569,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/dram"]
-	path = extensions/dram
-	url = https://github.com/clamjohnston/dram.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2565,3 +2565,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/dram"]
+	path = extensions/dram
+	url = https://github.com/clamjohnston/dram.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,7 +1,3 @@
-[dram]
-submodule = "extensions/dram"
-version = "1.0.0"
-
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"
@@ -568,6 +564,10 @@ version = "0.0.5"
 
 [dracula]
 submodule = "extensions/dracula"
+version = "1.0.0"
+
+[dram]
+submodule = "extensions/dram"
 version = "1.0.0"
 
 [duckyscript]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[dram]
+submodule = "extensions/dram"
+version = "1.0.0"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"


### PR DESCRIPTION
Dram is a lush green and blue color scheme for Zed utilizing the color palette from the science fantasy roguelike epic Caves of Qud. It is evocative of the venerable Solarized Dark by Ethan Schoonover.

![image](https://github.com/user-attachments/assets/30645122-4b9c-45bf-befb-8d898cbc9789)
