### PR TITLE
Add Modern Material Icon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -938,6 +938,10 @@
 	path = extensions/iceicebergy
 	url = https://github.com/jmsdnns/zed-iceicebergy.git
 
+[submodule "extensions/icons-modern-material"]
+	path = extensions/icons-modern-material
+	url = https://github.com/JosMiguelMM/icons-modern-material.git
+
 [submodule "extensions/indigo"]
 	path = extensions/indigo
 	url = https://github.com/p3rception/Indigo-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -964,6 +964,10 @@ version = "0.2.10"
 submodule = "extensions/iceicebergy"
 version = "0.3.14"
 
+[icons-modern-material]
+submodule = "extensions/icons-modern-material"
+version = "1.0.0"
+
 [indigo]
 submodule = "extensions/indigo"
 version = "0.1.2"


### PR DESCRIPTION
Hello Zed team,

This Pull Request introduces a new icon theme called **Icons Modern Material**.

### Key Features

*   **Modern Aesthetics:** The icons are inspired by Google's Material Design, providing a clean, minimalist, and visually consistent look.
*   **Comprehensive Coverage:** This theme includes a wide array of custom icons for many popular languages, frameworks, and tools, including:
    *   Frontend frameworks (React, Vue, Svelte, Angular, Astro)
    *   Backend technologies (Node.js, Go, Rust, Elixir)
    *   DevOps tools (Docker, Terraform, GitHub Actions, Jenkins)
    *   And many more common file types.
*   **Dark and Light Variants:** The theme is designed to work beautifully in both dark and light appearances, ensuring a great experience for all users.

I've been working on this theme to provide Zed users with a fresh and modern visual option for their editor. I believe it would be a valuable addition to the official extension registry.


Thank you for your time and consideration.