### PR TITLE
Update Ruby extension to v0.10.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1991,7 +1991,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.9.0"
+version = "0.10.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This pull request updates the Ruby extension to [v0.10.0](https://github.com/zed-extensions/ruby/releases/tag/v0.10.0). As always, here is the changelog with notable changes:

- Debugger prototype for Ruby by @osiewicz in https://github.com/zed-extensions/ruby/pull/96
- feat(herb): add Herb LSP by @vitallium in https://github.com/zed-extensions/ruby/pull/110
- Update herb-language-server executable path by @marcoroth

Thanks!