### PR TITLE
Bump swift extension to v0.4.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2229,7 +2229,7 @@ version = "0.0.5"
 
 [swift]
 submodule = "extensions/swift"
-version = "0.4.1"
+version = "0.4.2"
 
 [symbols]
 submodule = "extensions/symbols"


### PR DESCRIPTION
This bumps the version of the swift extension to v0.4.2, incorporating https://github.com/zed-extensions/swift/pull/33 which added a Swift debug adapter.