### PR TITLE
Update color-highlight to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -390,7 +390,7 @@ version = "0.0.1"
 
 [color-highlight]
 submodule = "extensions/color-highlight"
-version = "0.1.0"
+version = "0.1.1"
 path = "zed-color-highlight"
 
 [colored-zed-icons-theme]


### PR DESCRIPTION
Release notes:

- Fix the previous version can't download lsp binary.

https://github.com/huacnlee/color-lsp/releases/tag/v0.1.1