### PR TITLE
Add opentofu

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1666,6 +1666,10 @@
 	path = extensions/openscad
 	url = https://github.com/dotcypress/zed-openscad.git
 
+[submodule "extensions/opentofu"]
+	path = extensions/opentofu
+	url = https://github.com/ashpool37/zed-extension-opentofu
+
 [submodule "extensions/org"]
 	path = extensions/org
 	url = https://github.com/hron/zed-org

--- a/extensions.toml
+++ b/extensions.toml
@@ -1695,6 +1695,10 @@ version = "0.2.0"
 submodule = "extensions/openscad"
 version = "0.0.1"
 
+[opentofu]
+submodule = "extensions/opentofu"
+version = "0.2.0"
+
 [org]
 submodule = "extensions/org"
 version = "0.0.1"


### PR DESCRIPTION
This is the official [Terraform extension](https://github.com/zed-extensions/terraform) modified to use the recently released `tofu-ls` language server by the [OpenTofu](https://opentofu.org/) project.

Requested by: zed-industries/zed#10373, zed-industries/zed#31876

`zed_extension_api` dependency version bumped from `0.1.0` to `0.6.0` as recommended in [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions#webassembly), requiring Zed 0.192.x or newer to run. However, `0.1.0` will also work and I can revert the dependency version bump to support more versions of Zed if desired.

The only changes made to the code were to rename symbols and IDs where appropriate, and to change the download URL for the binaries. Tested on Linux x86_64 only. As confirmed by a core OpenTofu developer in Slack, no changes to the syntax or language server interaction code are necessary at this time.

- tree-sitter: https://github.com/MichaHoffmann/tree-sitter-hcl
- lsp: https://github.com/opentofu/tofu-ls
- extension: https://github.com/ashpool37/zed-extension-opentofu