### PR TITLE
Bump swift to v0.4.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2241,7 +2241,7 @@ version = "0.0.5"
 
 [swift]
 submodule = "extensions/swift"
-version = "0.4.2"
+version = "0.4.3"
 
 [symbols]
 submodule = "extensions/symbols"


### PR DESCRIPTION
There are no functional changes from v0.4.2, this is just to force the extension to be republished with a fixed version of zed_extension_cli (#2927).