### PR TITLE
Bump ruby to v0.10.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2003,7 +2003,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.10.0"
+version = "0.10.1"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
This version includes:

- https://github.com/zed-extensions/ruby/pull/119
- https://github.com/zed-extensions/ruby/pull/111
- https://github.com/zed-extensions/ruby/pull/113

Also, as a result of rebuilding the extension with #2927, the new rdbg debug adapter will be registered successfully.