### PR TITLE
Update Github Classic Themes to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -782,7 +782,7 @@ version = "0.5.1"
 
 [github-classic]
 submodule = "extensions/github-classic"
-version = "0.0.1"
+version = "0.0.2"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"


### PR DESCRIPTION
This PR adds missing syntax highlighting colors to the GitHub Classic themes.

**Full Changelog**: https://github.com/meocoder31099/Github-Classic-Theme-Zed/compare/v0.0.1...v0.0.2 