### PR TITLE
Update mcp-server-vercel to v1.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1356,7 +1356,7 @@ version = "0.0.2"
 
 [mcp-server-vercel]
 submodule = "extensions/mcp-server-vercel"
-version = "1.0.0"
+version = "1.0.1"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"


### PR DESCRIPTION
Release notes:

https://github.com/Takk8IS/vercel-mcp-server-for-zed/releases/tag/v1.0.1