### PR TITLE
Add seoul256 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1994,6 +1994,10 @@
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git
 
+[submodule "extensions/seoul256"]
+	path = extensions/seoul256
+	url = https://github.com/jcmorrow/seoul256-zed.git
+
 [submodule "extensions/sequoia"]
 	path = extensions/sequoia
 	url = https://github.com/HarshNarayanJha/zed-sequoia-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -2042,6 +2042,10 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.1.1"
 
+[seoul256]
+submodule = "extensions/seoul256"
+version = "0.0.1"
+
 [sequoia]
 submodule = "extensions/sequoia"
 version = "1.31.0"


### PR DESCRIPTION
Adds a port of the [seoul256](https://github.com/junegunn/seoul256.vim) theme to Zed!

- repo: https://github.com/jcmorrow/seoul256-zed