### PR TITLE
Update Ruby to v0.11.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2003,7 +2003,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.10.1"
+version = "0.11.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this pull request updates the Ruby extension to [v0.11.0](https://github.com/zed-extensions/ruby/releases/tag/v0.11.0) which includes fixes for the debugger feature. Thanks!