### PR TITLE
Update QML to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1899,7 +1899,7 @@ version = "0.1.0"
 
 [qml]
 submodule = "extensions/qml"
-version = "0.0.3"
+version = "0.0.4"
 
 [quakec]
 submodule = "extensions/quakec"


### PR DESCRIPTION
This PR will update the QML extension to version 0.0.4 which allows to set custom CLI arguments for qmlls.