### PR TITLE
Add symbols icon theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2617,3 +2617,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/symbols-icon-theme"]
+	path = extensions/symbols-icon-theme
+	url = https://github.com/gilmar-sales/symbols-icon-theme-zed.git


### PR DESCRIPTION
Porting VSCode [Symbols icon theme](https://github.com/miguelsolorio/vscode-symbols) to zed.
![image](https://github.com/user-attachments/assets/61ee3f59-56c4-4aa4-b705-e6dc9655f1e5)
Custom folders icons by name aren't supported by zed, so the port is incomplete...