### PR TITLE
Update Ruby to v0.12.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2007,7 +2007,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.10.1"
+version = "0.12.0"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi, this pull request updates the Ruby extension from v0.10.1 to [v0.12.0](https://github.com/zed-extensions/ruby/releases/tag/v0.12.0). Here is the list of changes for each release:

## v0.12.0

```
What's Changed

feat(ruby): add gem uninstall functionality by @vitallium in https://github.com/zed-extensions/ruby/pull/135
Add support for debug locators by @Hawkbawk in https://github.com/zed-extensions/ruby/pull/130
feat(ruby): Add basic support for displaying dbg variables by @vitallium in https://github.com/zed-extensions/ruby/pull/125
Add snippets by @andyw8 in https://github.com/zed-extensions/ruby/pull/53
fix(rdbg): Improve debugger argument handling by @vitallium in https://github.com/zed-extensions/ruby/pull/136
```

## v0.11.0

```
What's Changed

feat(rdbg): support RUBY_DEBUG env vars for host and port by @vitallium in https://github.com/zed-extensions/ruby/pull/123
feat(rdbg): support attach requests for rdbg debugger by @vitallium in https://github.com/zed-extensions/ruby/pull/124
Update Rust crate serde to v1.0.219 by @renovate in https://github.com/zed-extensions/ruby/pull/116
Update Rust crate serde_json to v1.0.140 by @renovate in https://github.com/zed-extensions/ruby/pull/117
Ensure cwd actually has a default by @Hawkbawk in https://github.com/zed-extensions/ruby/pull/127
Ensure command args aren't parsed by rdbg by @Hawkbawk in https://github.com/zed-extensions/ruby/pull/128
Support Rake outlines by @joeldrapper in https://github.com/zed-extensions/ruby/pull/131
```

Thanks!