### PR TITLE
Update Perplexity to v0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1742,6 +1742,10 @@
 	path = extensions/perm
 	url = https://github.com/theoriginalstove/perm.git
 
+[submodule "extensions/perplexity"]
+	path = extensions/perplexity
+	url = https://github.com/zed-extensions/perplexity.git
+
 [submodule "extensions/pest"]
 	path = extensions/pest
 	url = https://github.com/pest-parser/zed-pest.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1772,9 +1772,8 @@ submodule = "extensions/perm"
 version = "0.0.4"
 
 [perplexity]
-submodule = "extensions/zed"
-path = "extensions/perplexity"
-version = "0.1.0"
+submodule = "extensions/perplexity"
+version = "0.2.0"
 
 [pest]
 submodule = "extensions/pest"


### PR DESCRIPTION
Move Perplexity extension out of the main zed repo: [zed-industries/zed](https://github.com/zed-industries/zed/) into to [zed-extensions/perplexity](https://github.com/zed-extensions/perplexity/) 

Includes:

- https://github.com/zed-extensions/perplexity/pull/1
- https://github.com/zed-extensions/perplexity/pull/2
- https://github.com/zed-extensions/perplexity/pull/3
- https://github.com/zed-extensions/perplexity/pull/4

Fixes:
- https://github.com/zed-industries/zed/issues/34063