### PR TITLE
Update python-requirements to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1915,7 +1915,7 @@ version = "0.0.3"
 
 [python-requirements]
 submodule = "extensions/python-requirements"
-version = "0.0.1"
+version = "0.0.2"
 
 [python-snippets]
 submodule = "extensions/python-snippets"


### PR DESCRIPTION
Tree-sitter update: https://github.com/tree-sitter-grammars/tree-sitter-requirements/compare/5ad9b7581b3334f6ad492847d007f2fac6e6e5f2...caeb2ba854dea55931f76034978de1fd79362939