### PR TITLE
Update Slint extension submodule to official repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2076,7 +2076,7 @@
 
 [submodule "extensions/slint"]
 	path = extensions/slint
-	url = https://gitlab.com/flukejones/zed-slint.git
+	url = https://github.com/slint-ui/slint.git
 
 [submodule "extensions/smithy"]
 	path = extensions/smithy

--- a/extensions.toml
+++ b/extensions.toml
@@ -2120,6 +2120,7 @@ version = "1.0.1"
 
 [slint]
 submodule = "extensions/slint"
+path = "editors/zed"
 version = "0.0.7"
 
 [smithy]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2125,7 +2125,7 @@ version = "1.0.1"
 [slint]
 submodule = "extensions/slint"
 path = "editors/zed"
-version = "0.0.7"
+version = "0.0.8"
 
 [smithy]
 submodule = "extensions/smithy"


### PR DESCRIPTION
Change `extensions/slint` submodule origin from [flukejones/zed-slint](https://gitlab.com/flukejones/zed-slint) to [slint-ui/slint](https://github.com/slint-ui/slint).