### PR TITLE
Remove `todo.txt` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2306,10 +2306,6 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
-[submodule "extensions/todo.txt"]
-	path = extensions/todo-txt
-	url = https://github.com/pursvir/zed-todo.txt.git
-
 [submodule "extensions/tokyo-night"]
 	path = extensions/tokyo-night
 	url = https://github.com/ssaunderss/zed-tokyo-night.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2351,10 +2351,6 @@ version = "0.0.1"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
-[todo.txt]
-submodule = "extensions/todo.txt"
-version = "0.2.2"
-
 [tokyo-night]
 submodule = "extensions/tokyo-night"
 version = "0.5.0"


### PR DESCRIPTION
This PR removes the `todo.txt` extension added in https://github.com/zed-industries/extensions/pull/2854.

Extension IDs may not contain `.` characters.

cc @notpeter