### PR TITLE
CONL language server

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -411,7 +411,7 @@ version = "1.0.0"
 
 [conl]
 submodule = "extensions/conl"
-version = "1.0.0"
+version = "2.0.0"
 
 [cooklang]
 submodule = "extensions/cooklang"


### PR DESCRIPTION
Updates the CONL extension to download the language server
from https://github.com/conradirwin/conl-lsp
