### PR TITLE
Add markdownlint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1230,6 +1230,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdownlint"]
+	path = extensions/markdownlint
+	url = https://github.com/vitallium/zed-markdownlint.git
+
 [submodule "extensions/marksman"]
 	path = extensions/marksman
 	url = https://github.com/vitallium/zed-marksman.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1259,6 +1259,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.4"
 
+[markdownlint]
+submodule = "extensions/markdownlint"
+version = "0.1.1"
+
 [marksman]
 submodule = "extensions/marksman"
 version = "0.0.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1261,7 +1261,7 @@ version = "0.0.4"
 
 [markdownlint]
 submodule = "extensions/markdownlint"
-version = "0.1.1"
+version = "0.1.2"
 
 [marksman]
 submodule = "extensions/marksman"


### PR DESCRIPTION
Hi! This pull request adds a new extension called `markdownlint` that uses `markdownlint-lsp` NPM package for running `markdownlint` program for linting Markdown files:

<img width="3248" height="2112" alt="CleanShot 2025-07-10 at 21 39 20@2x" src="https://github.com/user-attachments/assets/3bfd325f-86b9-4c4f-9105-49585b51af16" />
<img width="3248" height="2112" alt="CleanShot 2025-07-10 at 21 39 34@2x" src="https://github.com/user-attachments/assets/820e1e34-9894-488a-98c6-fcd1c3b07c8a" />
<img width="3248" height="2112" alt="CleanShot 2025-07-10 at 21 39 55@2x" src="https://github.com/user-attachments/assets/fabfd92e-b7e3-42fd-8c8b-67a95efda750" />

Thanks!