### PR TITLE
sql: Bump to 1.1.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2148,7 +2148,7 @@
 
 [submodule "extensions/sql"]
 	path = extensions/sql
-	url = https://github.com/nervenes/zed-sql.git
+	url = https://github.com/zed-extensions/sql.git
 
 [submodule "extensions/sqlc-snippets"]
 	path = extensions/sqlc-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -2198,7 +2198,7 @@ version = "0.0.0"
 
 [sql]
 submodule = "extensions/sql"
-version = "1.1.3"
+version = "1.1.4"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"


### PR DESCRIPTION
Includes: 

- https://github.com/zed-extensions/sql/pull/23

Also updates the submodule URL to point towards the moved remote repository.