### PR TITLE
Updated TCL to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2314,7 +2314,7 @@ version = "0.0.1"
 
 [tcl]
 submodule = "extensions/tcl"
-version = "0.0.1"
+version = "0.0.2"
 
 [templ]
 submodule = "extensions/templ"


### PR DESCRIPTION
This update fixes highlighting going off-rails when encountering advanced TCL command usage - especially in legacy codebases

- Tree-sitter diff: https://github.com/richnou/tree-sitter-tcl/compare/8f11ac7206a54ed11210491cee1e0657e2962c47...8e5ab6524dc7d081b1e5b980a7bbfba167e72332