### PR TITLE
Add vscode-default-dark-modern theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2657,3 +2657,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/vscode-default-dark-modern"]
+	path = extensions/vscode-default-dark-modern
+	url = https://github.com/T1ckbase/zed-vscode-default-dark-modern.git


### PR DESCRIPTION
This is a port of VSCode's Dark Modern theme to Zed.

<img width="1920" height="1080" alt="zed-screenshot" src="https://github.com/user-attachments/assets/5d9939ec-2b9d-42d3-8fdb-5f3f2ee91677" />
