### PR TITLE
Update Modern-Icons to v0.4.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2369,6 +2369,7 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+
 [submodule "extensions/modern-icons"]
 	path = extensions/modern-icons
 	url = https://github.com/BadRat-in/zed-modern-icons.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2369,3 +2369,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/modern-icons"]
+	path = extensions/modern-icons
+	url = https://github.com/BadRat-in/zed-modern-icons.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1230,6 +1230,10 @@
 	path = extensions/mnemonic
 	url = https://github.com/mnemonic-theme/zed
 
+[submodule "extensions/modern-icons"]
+	path = extensions/modern-icons
+	url = https://github.com/BadRat-in/zed-modern-icons.git
+
 [submodule "extensions/modest-dark"]
 	path = extensions/modest-dark
 	url = https://github.com/timcole/modest-dark.git
@@ -2369,7 +2373,3 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-
-[submodule "extensions/modern-icons"]
-	path = extensions/modern-icons
-	url = https://github.com/BadRat-in/zed-modern-icons.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2226,6 +2226,10 @@
 	path = extensions/vscode-dark-plus
 	url = https://github.com/d1y/vscode_dark_plus.zed.git
 
+[submodule "extensions/vscode-dark-polished"]
+	path = extensions/vscode-dark-polished
+	url = https://github.com/yayashn/vscode-dark-polished.git
+
 [submodule "extensions/vscode-great-icons"]
 	path = extensions/vscode-great-icons
 	url = https://github.com/RandaZraik/zed-vscode-great-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1417,7 +1417,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.3.0"
+version = "0.4.0"
 
 [modest-dark]
 submodule = "extensions/modest-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1255,6 +1255,10 @@ version = "0.2.0"
 submodule = "extensions/mnemonic"
 version = "0.0.1"
 
+[modern-icons]
+submodule = "extensions/modern-icons"
+version = "0.2.0"
+
 [modest-dark]
 submodule = "extensions/modest-dark"
 version = "0.1.7"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1257,7 +1257,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.2.0"
+version = "0.3.0"
 
 [modest-dark]
 submodule = "extensions/modest-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2278,6 +2278,10 @@ version = "0.0.5"
 submodule = "extensions/vscode-dark-plus"
 version = "0.0.1"
 
+[vscode-dark-polished]
+submodule = "extensions/vscode-dark-polished"
+version = "0.0.5"
+
 [vscode-great-icons]
 submodule = "extensions/vscode-great-icons"
 version = "0.2.3"


### PR DESCRIPTION
- BadRat-in/zed-modern-icons/issues/1

**Vite icon is supported for following files:**
- vite
- vite.config.js
- vite.config.ts
- vite.config.mjs
- vite.config.mts
- vite.config.cjs
- vite.config.cts