### PR TITLE
Add extension for the `container-use` MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1302,6 +1302,10 @@
 	path = extensions/mcp-server-byterover
 	url = https://github.com/ngduyanhece/byterover-zed-extension.git
 
+[submodule "extensions/mcp-server-container-use"]
+	path = extensions/mcp-server-container-use
+	url = https://github.com/danilo-leal/zed-container-use-mcp.git
+
 [submodule "extensions/mcp-server-context7"]
 	path = extensions/mcp-server-context7
 	url = https://github.com/akbxr/zed-mcp-server-context7

--- a/extensions.toml
+++ b/extensions.toml
@@ -1331,6 +1331,10 @@ version = "0.0.4"
 submodule = "extensions/mcp-server-byterover"
 version = "0.0.1"
 
+[mcp-server-container-use]
+submodule = "extensions/mcp-server-container-use"
+version = "0.1.0"
+
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1333,7 +1333,7 @@ version = "0.0.1"
 
 [mcp-server-container-use]
 submodule = "extensions/mcp-server-container-use"
-version = "0.1.0"
+version = "0.0.1"
 
 [mcp-server-context7]
 submodule = "extensions/mcp-server-context7"


### PR DESCRIPTION
A first-class extension for the https://container-use.com/ MCP server.