### PR TITLE
Add Hot Dog Stand

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -966,6 +966,10 @@
 	path = extensions/horizon
 	url = https://github.com/ayn2op/zed-horizon.git
 
+[submodule "extensions/hot-dog-stand"]
+	path = extensions/hot-dog-stand
+	url = https://github.com/CoasterFan5/hotdog-stand-zed.git
+
 [submodule "extensions/html-jinja"]
 	path = extensions/html-jinja
 	url = https://github.com/JaagupAverin/html-jinja.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -990,6 +990,10 @@ version = "0.2.0"
 submodule = "extensions/horizon"
 version = "0.0.1"
 
+[hot-dog-stand]
+submodule = "extensions/hot-dog-stand"
+version = "0.0.1"
+
 [html]
 submodule = "extensions/zed"
 path = "extensions/html"

--- a/extensions.toml
+++ b/extensions.toml
@@ -992,7 +992,7 @@ version = "0.0.1"
 
 [hot-dog-stand]
 submodule = "extensions/hot-dog-stand"
-version = "0.0.1"
+version = "0.0.2"
 
 [html]
 submodule = "extensions/zed"


### PR DESCRIPTION
Adds my version of the hot dog stand theme, as well as a more usable version. 
This is an original theme, but it is inspired by the [Windows 3.1 theme](https://blog.codinghorror.com/a-tribute-to-the-windows-31-hot-dog-stand-color-scheme/) and the [Vscode Extension](https://marketplace.visualstudio.com/items?itemName=somekittens.hot-dog-stand)
<details>
<summary>Screenshots</summary>
<img width="732" height="1014" alt="Screenshot 2025-07-17 at 11 31 54 AM" src="https://static.coasterfan5.com/classic.png" />
<img width="732" height="1014" alt="Screenshot 2025-07-17 at 11 31 54 AM" src="https://static.coasterfan5.com/midnight.png" />
</details>