### PR TITLE
Add jj-lsp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1078,6 +1078,10 @@
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
 
+[submodule "extensions/jj-lsp"]
+	path = extensions/jj-lsp
+	url = https://github.com/nilskch/zed-jj-lsp.git
+
 [submodule "extensions/json5"]
 	path = extensions/json5
 	url = https://github.com/ChunzhengLab/json5-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1107,6 +1107,10 @@ version = "0.0.1"
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
 
+[jj-lsp]
+submodule = "extensions/jj-lsp"
+version = "0.1.0"
+
 [json5]
 submodule = "extensions/json5"
 version = "0.0.1"


### PR DESCRIPTION
I wrote a little [lsp](https://github.com/nilskch/jj-lsp) to resolve conflicts in the [jj-vcs](https://github.com/jj-vcs/jj) since Zed currently does not have native support for that.

PS: Happy to help adding native support for jj in Zed if there is interest and ongoing development on your side. I currently [colocate](https://jj-vcs.github.io/jj/latest/git-compatibility/#co-located-jujutsugit-repos) the `.git` folder to get the diff and blame, but this comes with a performance hit and I would love to not do that.

