### PR TITLE
Add Monokai Original theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1438,6 +1438,10 @@
 	path = extensions/monokai-night
 	url = https://github.com/farbodvand/zed-monokai-night.git
 
+[submodule "extensions/monokai-og"]
+	path = extensions/monokai-og
+	url = https://github.com/sidwachche/monokai-og-zed.git
+
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1467,6 +1467,10 @@ version = "0.2.4"
 submodule = "extensions/monokai-night"
 version = "0.2.2"
 
+[monokai-og]
+submodule = "extensions/monokai-og"
+version = "0.1.0"
+
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

This PR adds the Monokai Original theme extension to the Zed extensions directory.

- **Extension ID**: monokai-og
- **Extension Name**: Monokai Original
- **Version**: 0.1.0
- **Description**: A faithful recreation of the original Monokai theme
- **Repository**: https://github.com/sidwachche/monokai-og-zed