### PR TITLE
Bump fsharp to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -770,7 +770,7 @@ version = "0.0.1"
 
 [fsharp]
 submodule = "extensions/fsharp"
-version = "0.0.6"
+version = "0.0.7"
 
 [fsm]
 submodule = "extensions/fsm"


### PR DESCRIPTION
Bumps fsharp extension to [0.0.7](https://github.com/nathanjcollins/zed-fsharp/releases/tag/0.0.7)