### PR TITLE
Update tron-legacy to v1.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2420,7 +2420,7 @@ version = "0.0.2"
 
 [tron-legacy]
 submodule = "extensions/tron-legacy"
-version = "1.1.3"
+version = "1.1.4"
 
 [tsar]
 submodule = "extensions/tsar"


### PR DESCRIPTION
Fixes sticky panel list transparency among other, mainly organizational and tooling tweaks.