### PR TITLE
Update catppuccin to v0.2.23

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -306,7 +306,7 @@ version = "0.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.22"
+version = "0.2.23"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"


### PR DESCRIPTION
Release notes:

https://github.com/catppuccin/zed/releases/tag/v0.2.23