### PR TITLE
Update racket to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1987,7 +1987,7 @@ version = "0.2.3"
 
 [racket]
 submodule = "extensions/racket"
-version = "0.0.3"
+version = "0.1.0"
 
 [railscast]
 submodule = "extensions/railscast"


### PR DESCRIPTION
This PR updates racket extension to v0.1.0 which adds lsp support