### PR TITLE
Update fortran to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -758,7 +758,7 @@ version = "0.1.0"
 
 [fortran]
 submodule = "extensions/fortran"
-version = "0.0.2"
+version = "0.0.3"
 
 [fountain]
 submodule = "extensions/fountain"


### PR DESCRIPTION
Update syncs the WASM build of fortran tree-sitter with the current fortran tree-sitter base repo, and adds more fortran file extensions.