### PR TITLE
Bump extension CLI version to `52f2b32`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: f338c46bf79f773ec7a41729270227da8c2660b5
+  ZED_EXTENSION_CLI_SHA: 52f2b3255781999fda28a2f6d3c94402c4b29fa9
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/52f2b3255781999fda28a2f6d3c94402c4b29fa9.

This fixes snippets files not being bundled with extensions.

cc @osiewicz