### PR TITLE
emmet: Bump to 0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -668,7 +668,7 @@ version = "0.0.2"
 [emmet]
 submodule = "extensions/zed"
 path = "extensions/emmet"
-version = "0.0.3"
+version = "0.0.4"
 
 [env]
 submodule = "extensions/env"


### PR DESCRIPTION
This PR updates the emmet extension to version 0.0.4

See https://github.com/zed-industries/zed/pull/35305 for more context.