### PR TITLE
Add Authzed (SpiceDB) extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,6 +122,10 @@
 	path = extensions/aura
 	url = https://github.com/daltonmenezes/aura-theme.git
 
+[submodule "extensions/authzed"]
+	path = extensions/authzed
+	url = https://github.com/mleonidas/authzed-zed.git
+
 [submodule "extensions/autocorrect"]
 	path = extensions/autocorrect
 	url = https://github.com/huacnlee/zed-autocorrect.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -124,6 +124,10 @@ submodule = "extensions/aura"
 path = "packages/zed"
 version = "1.0.0"
 
+[authzed]
+submodule = "extensions/authzed"
+version = "0.0.1"
+
 [autocorrect]
 submodule = "extensions/autocorrect"
 version = "0.1.0"


### PR DESCRIPTION
Adds syntax highlighting support for the authzed/spicedb schema language.

- Extension: https://github.com/mleonidas/authzed-zed
- Tree-sitter: https://github.com/mleonidas/tree-sitter-authzed