### PR TITLE
Update Tron Legacy to v1.1.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2484,7 +2484,7 @@ version = "0.0.2"
 
 [tron-legacy]
 submodule = "extensions/tron-legacy"
-version = "1.1.4"
+version = "1.1.7"
 
 [tsar]
 submodule = "extensions/tsar"


### PR DESCRIPTION
Fixes some bugs around highlight contrast and improves colors for conflict markers selectors. 