### PR TITLE
Add BAML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,10 @@
 	path = extensions/adech
 	url = https://github.com/adechlien/adech-theme-zed.git
 
+[submodule "extensions/adwaita"]
+	path = extensions/adwaita
+	url = https://github.com/somepaulo/adwaita-zed-theme.git
+
 [submodule "extensions/adwaita-pastel"]
 	path = extensions/adwaita-pastel
 	url = https://github.com/Benjamin-Davies/zed-theme-adwaita.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -166,6 +166,10 @@
 	path = extensions/bamboo-theme
 	url = https://github.com/LoamStudios/zed-bamboo-theme
 
+[submodule "extensions/baml"]
+	path = extensions/baml
+	url = https://github.com/BoundaryML/zed-baml
+
 [submodule "extensions/barbenheimer"]
 	path = extensions/barbenheimer
 	url = https://github.com/jayvicsanantonio/barbenheimer-zed-theme.git
@@ -697,10 +701,6 @@
 [submodule "extensions/exquisite"]
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
-
-[submodule "extensions/baml"]
-	path = extensions/baml
-	url = https://github.com/BoundaryML/zed-baml
 
 [submodule "extensions/extensions/fiber-snippets"]
 	path = extensions/fiber-snippets

--- a/.gitmodules
+++ b/.gitmodules
@@ -678,8 +678,8 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
-[submodule "extensions/extensions/baml"]
-	path = extensions/extensions/baml
+[submodule "extensions/baml"]
+	path = extensions/baml
 	url = https://github.com/BoundaryML/zed-baml
 
 [submodule "extensions/extensions/fiber-snippets"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -678,6 +678,10 @@
 	path = extensions/exquisite
 	url = https://github.com/xqsit94/zed-xqsit-theme.git
 
+[submodule "extensions/extensions/baml"]
+	path = extensions/extensions/baml
+	url = https://github.com/BoundaryML/zed-baml
+
 [submodule "extensions/extensions/fiber-snippets"]
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -22,6 +22,10 @@ version = "0.0.2"
 submodule = "extensions/adech"
 version = "2.0.1"
 
+[adwaita]
+submodule = "extensions/adwaita"
+version = "1.0.0"
+
 [adwaita-pastel]
 submodule = "extensions/adwaita-pastel"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -156,6 +156,10 @@ version = "0.1.0"
 submodule = "extensions/bamboo-theme"
 version = "0.1.0"
 
+[baml]
+submodule = "extensions/baml"
+version = "0.0.1"
+
 [barbenheimer]
 submodule = "extensions/barbenheimer"
 version = "1.3.1"


### PR DESCRIPTION
This PR adds Baml Language support to Zed.

Extension: https://github.com/BoundaryML/zed-baml
Tree-sitter: https://github.com/BoundaryML/tree-sitter-baml

Playground (included in extension): https://github.com/BoundaryML/baml/tree/canary/typescript/packages/playground-common

Language repo: https://github.com/BoundaryML/baml