### PR TITLE
Update Elixir to v0.1.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -658,7 +658,7 @@ version = "0.0.4"
 
 [elixir]
 submodule = "extensions/elixir"
-version = "0.1.9"
+version = "0.1.10"
 
 [elle]
 submodule = "extensions/elle"


### PR DESCRIPTION
Fix for upstream changes in release artifact naming.
- https://github.com/zed-extensions/elixir/pull/20