### PR TITLE
Bump groovy to v1.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -920,7 +920,7 @@ version = "0.0.1"
 
 [groovy]
 submodule = "extensions/groovy"
-version = "1.2.0"
+version = "1.3.0"
 
 [groq]
 submodule = "extensions/groq"


### PR DESCRIPTION
Release notes: https://github.com/valentinegb/zed-groovy/releases/tag/v1.3.0