### PR TITLE
Add Maple theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1264,7 +1264,7 @@
 
 [submodule "extensions/maple-theme"]
 	path = extensions/maple-theme
-	url = https://github.com/subframe7536/zed-theme-maple
+	url = https://github.com/subframe7536/zed-theme-maple.git
 
 [submodule "extensions/marble"]
 	path = extensions/marble

--- a/.gitmodules
+++ b/.gitmodules
@@ -2394,6 +2394,10 @@
 	path = extensions/the-dark-side
 	url = https://github.com/Imgkl/the-dark-side.git
 
+[submodule "extensions/theme-maple"]
+	path = extensions/theme-maple
+	url = https://github.com/subframe7536/zed-theme-maple
+
 [submodule "extensions/theme-rainbow"]
 	path = extensions/theme-rainbow
 	url = https://github.com/athxx/zed-theme-rainbow.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1264,7 +1264,7 @@
 
 [submodule "extensions/maple-theme"]
 	path = extensions/maple-theme
-	url = https://github.com/bushuai/zed-maple
+	url = https://github.com/subframe7536/zed-theme-maple
 
 [submodule "extensions/marble"]
 	path = extensions/marble
@@ -2393,10 +2393,6 @@
 [submodule "extensions/the-dark-side"]
 	path = extensions/the-dark-side
 	url = https://github.com/Imgkl/the-dark-side.git
-
-[submodule "extensions/theme-maple"]
-	path = extensions/theme-maple
-	url = https://github.com/subframe7536/zed-theme-maple
 
 [submodule "extensions/theme-rainbow"]
 	path = extensions/theme-rainbow

--- a/extensions.toml
+++ b/extensions.toml
@@ -1293,7 +1293,7 @@ version = "0.0.1"
 
 [maple-theme]
 submodule = "extensions/maple-theme"
-version = "0.1.5"
+version = "0.1.6"
 
 [marble]
 submodule = "extensions/marble"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2446,7 +2446,7 @@ version = "0.3.0"
 
 [theme-maple]
 submodule = "extensions/theme-maple"
-version = "0.1.2"
+version = "0.1.3"
 
 [thrift]
 submodule = "extensions/thrift"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2446,7 +2446,7 @@ version = "0.3.0"
 
 [theme-maple]
 submodule = "extensions/theme-maple"
-version = "0.1.3"
+version = "0.1.4"
 
 [thrift]
 submodule = "extensions/thrift"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1293,7 +1293,7 @@ version = "0.0.1"
 
 [maple-theme]
 submodule = "extensions/maple-theme"
-version = "0.0.1"
+version = "0.1.5"
 
 [marble]
 submodule = "extensions/marble"
@@ -2443,10 +2443,6 @@ version = "0.0.1"
 [the-dark-side]
 submodule = "extensions/the-dark-side"
 version = "0.3.0"
-
-[theme-maple]
-submodule = "extensions/theme-maple"
-version = "0.1.4"
 
 [thrift]
 submodule = "extensions/thrift"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2444,6 +2444,10 @@ version = "0.0.1"
 submodule = "extensions/the-dark-side"
 version = "0.3.0"
 
+[theme-maple]
+submodule = "extensions/theme-maple"
+version = "0.1.2"
+
 [thrift]
 submodule = "extensions/thrift"
 version = "0.0.1"


### PR DESCRIPTION
While I'm porting my [VSCode theme](https://github.com/subframe7536/vscode-theme-maple) to Zed, I found someone already have already port it (extension id: `maple-theme`), but lack some font styles in syntax and use the old color palette, also the project seems inactive. So I want to submit a new theme extension here.