### PR TITLE
Update vercel-theme to v0.0.9

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2612,7 +2612,7 @@ version = "0.0.1"
 
 [vercel-theme]
 submodule = "extensions/vercel-theme"
-version = "0.0.8"
+version = "0.0.9"
 
 [verilog]
 submodule = "extensions/verilog"


### PR DESCRIPTION
Release notes:

https://github.com/NathanBrodin/zed-vercel-theme/releases/tag/v0.0.9