### PR TITLE
Add GitHub Actions extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -806,6 +806,10 @@
 	path = extensions/git-firefly
 	url = https://github.com/d1y/git_firefly.git
 
+[submodule "extensions/github-actions"]
+	path = extensions/github-actions
+	url = https://github.com/neoncitylights/zed-github-actions
+
 [submodule "extensions/github-activity-summarizer"]
 	path = extensions/github-activity-summarizer
 	url = https://github.com/rubiojr/gas.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -825,6 +825,10 @@ version = "1.2.1"
 submodule = "extensions/git-firefly"
 version = "0.1.1"
 
+[github-actions]
+submodule = "extensions/github-actions"
+version = "0.0.1"
+
 [github-activity-summarizer]
 submodule = "extensions/github-activity-summarizer"
 version = "0.5.1"


### PR DESCRIPTION
Adds LSP support for GitHub Actions. Since these files are YAML, to avoid conflicting with yaml-language-server, it follows suite how Ansible and Docker Compose do it by copying the YAML grammar but having it identified as a unique language.

- Extension: [neoncitylights/zed-github-actions](https://github.com/neoncitylights/zed-github-actions)
- Tree-sitter: [zed-industries/tree-sitter-yaml](https://github.com/zed-industries/tree-sitter-yaml)
- Language Server: [actions/languageservices](https://github.com/actions/languageservices)
- Language Server (binary): [lttb/gh-actions-language-server](https://github.com/lttb/gh-actions-language-server)

Also, here's a note copied from the extension's README.md (since I figure it's important to point out):

> The LSP provided by the official NPM package [`@actions/languageserver`](https://www.npmjs.com/package/@actions/languageserver) does not include a binary (see [issue #56](https://github.com/actions/languageservices/issues/56)), so this repository uses a third-party NPM package to install it via [`gh-actions-language-server`](https://www.npmjs.com/package/gh-actions-language-server).
