### PR TITLE
Update css-modules-kit to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -479,7 +479,7 @@ version = "0.0.3"
 
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
-version = "0.0.1"
+version = "0.1.0"
 path = "crates/zed"
 
 [csv]


### PR DESCRIPTION
release note: https://github.com/mizdra/css-modules-kit/releases/tag/css-modules-kit-zed%400.1.0