### PR TITLE
emmet: Bump to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -684,7 +684,7 @@ version = "0.0.2"
 [emmet]
 submodule = "extensions/zed"
 path = "extensions/emmet"
-version = "0.0.4"
+version = "0.0.5"
 
 [env]
 submodule = "extensions/env"


### PR DESCRIPTION
This PR updates the Emmet extension to v0.0.5.

See https://github.com/zed-industries/zed/pull/36066 for the changes in this version.