### PR TITLE
Add Gitignore Templates extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -830,6 +830,10 @@
 	path = extensions/github-theme
 	url = https://github.com/PyaeSoneAungRgn/github-zed-theme.git
 
+[submodule "extensions/gitignore-templates"]
+	path = extensions/gitignore-templates
+	url = https://github.com/hjr265/zed-gitignore-templates.git
+
 [submodule "extensions/gitlab-ci-ls"]
 	path = extensions/gitlab-ci-ls
 	url = https://github.com/tzabbi/zed-gitlab-ci-ls.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -849,6 +849,10 @@ version = "1.1.0"
 submodule = "extensions/github-theme"
 version = "0.1.3"
 
+[gitignore-templates]
+submodule = "extensions/gitignore-templates"
+version = "2025.08.0"
+
 [gitlab-ci-ls]
 submodule = "extensions/gitlab-ci-ls"
 version = "1.0.1"


### PR DESCRIPTION
Extension: https://github.com/hjr265/zed-gitignore-templates

This extension provides snippets for `.gitignore` files. The snippets are all templates from https://github.com/github/gitignore.

<img width="720" height="340" alt="screenshot" src="https://github.com/user-attachments/assets/17b76804-595e-407a-b6dd-8dfcc9e11057" />

I have written a Bash script (`refresh.sh`) that fetches the templates from that Git repository and turns them into a `git ignore.json` snippets file. I run this script and then track the generated snippets JSON into the extension's Git repository. Whenever there are new or updated templates in that Git repository, I will need to do a refresh and release a new version of the extension.

Perhaps in the future, when the Rust extensions API allows it, we can avoid this and fetch the templates on the fly from the templates Git repository.

I am also including the templates from the root directory only, not any "global" or "community" templates.
