### PR TITLE
emmet: Bump to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -684,7 +684,7 @@ version = "0.0.2"
 [emmet]
 submodule = "extensions/zed"
 path = "extensions/emmet"
-version = "0.0.5"
+version = "0.0.6"
 
 [env]
 submodule = "extensions/env"


### PR DESCRIPTION
This PR updates the Emmet extension to v0.0.6.

See https://github.com/zed-industries/zed/pull/36129 for the changes in this version.