### PR TITLE
Add InterSystems ObjectScript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1694,6 +1694,10 @@
 	path = extensions/oasis
 	url = https://github.com/aerendem/oasis-zed-theme
 
+[submodule "extensions/objectscript"]
+	path = extensions/objectscript
+	url = https://github.com/intersystems/zed-objectscript.git
+
 [submodule "extensions/obsidian-sunset"]
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1724,6 +1724,10 @@ version = "0.1.0"
 submodule = "extensions/oasis"
 version = "0.0.1"
 
+[objectscript]
+submodule = "extensions/objectscript"
+version = "1.0.0"
+
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"


### PR DESCRIPTION
The zed-objectscript extension initially adds a syntax coloring suppor to Zed for InterSystems ObjectScript via our [tree-sitter-objectscript](https://github.com/intersystems/tree-sitter-objectscript) grammar.