### PR TITLE
Bump extension CLI version to `332626e`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: 52f2b3255781999fda28a2f6d3c94402c4b29fa9
+  ZED_EXTENSION_CLI_SHA: 332626e5825564e97afc969292c90d9b0fb40b6d
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/332626e5825564e97afc969292c90d9b0fb40b6d.

This adds support for the new comment structure in the language config added in https://github.com/zed-industries/zed/pull/34861.