### PR TITLE
Remove becker-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -206,10 +206,6 @@
 	path = extensions/bearded-icon-theme
 	url = https://github.com/sethstha/bearded-icons-theme.git
 
-[submodule "extensions/becker-theme"]
-	path = extensions/becker-theme
-	url = https://github.com/Becker-Theme/zed.git
-
 [submodule "extensions/bend"]
 	path = extensions/bend
 	url = https://github.com/mrpedrobraga/zed-bend.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -208,10 +208,6 @@ version = "1.0.0"
 submodule = "extensions/bearded-icon-theme"
 version = "0.4.0"
 
-[becker-theme]
-submodule = "extensions/becker-theme"
-version = "0.0.2"
-
 [bend]
 submodule = "extensions/bend"
 version = "0.0.1"


### PR DESCRIPTION
This PR removes the becker-theme extension, as the upstream repo is gone: https://github.com/Becker-Theme/zed