### PR TITLE
Reject extensions that don't use `schema_version = 1`

### DIFF
--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -63,6 +63,15 @@ export function validateManifest(manifest) {
       `Extension names should not end with " Zed", as they are all Zed extensions: "${manifest["name"]}".`,
     );
   }
+
+  const schemaVersion = manifest["schema_version"];
+  if (typeof schemaVersion !== "undefined") {
+    if (schemaVersion !== 1) {
+      throw new Error(
+        `Invalid \`schema_version\`. Expected \`1\` but got \`${schemaVersion}\`.`,
+      );
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This PR updates the validation to reject extensions that declare a `schema_version` that isn't set to `1`.