### PR TITLE
Bump objectscript to v1.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1753,7 +1753,7 @@ version = "0.0.1"
 
 [objectscript]
 submodule = "extensions/objectscript"
-version = "1.0.0"
+version = "1.0.1"
 
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"


### PR DESCRIPTION
Fixes precedent issues around using `*` in $EXTRACT()/$PIECE() etc.