### PR TITLE
Update oxlint to 0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1861,7 +1861,7 @@ version = "0.2.0"
 
 [oxlint]
 submodule = "extensions/oxlint"
-version = "0.0.1"
+version = "0.0.2"
 
 [oxocarbon]
 submodule = "extensions/oxocarbon"


### PR DESCRIPTION
Updates `extensions/oxlint` to 0.0.2. 

Primarily fixes using the extension on linux. 