### PR TITLE
Add PLUTO extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2853,3 +2853,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/PLUTO"]
+	path = extensions/PLUTO
+	url = https://github.com/s7g4/pluto.git


### PR DESCRIPTION
Adds support and syntax highlighting for Pluto, a superset of Lua 5.4 with enhanced syntax and standard library, developed by LibreCube.
