### PR TITLE
Add Shortcut MCP Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1378,6 +1378,10 @@
 	path = extensions/mcp-server-shopify-dev
 	url = https://github.com/TheBeyondGroup/zed-mcp-server-shopify-dev.git
 
+[submodule "extensions/mcp-server-shortcut"]
+	path = extensions/mcp-server-shortcut
+	url = https://github.com/useshortcut/zed-extension-mcp-server-shortcut.git
+
 [submodule "extensions/mcp-server-slack"]
 	path = extensions/mcp-server-slack
 	url = https://github.com/semioz/zed-slack-mcp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1407,6 +1407,10 @@ version = "0.0.2"
 submodule = "extensions/mcp-server-shopify-dev"
 version = "0.0.1"
 
+[mcp-server-shortcut]
+submodule = "extensions/mcp-server-shortcut"
+version = "0.0.1"
+
 [mcp-server-slack]
 submodule = "extensions/mcp-server-slack"
 version = "0.0.1"


### PR DESCRIPTION
Adds an extension for the [Shortcut MCP Server](https://github.com/useshortcut/mcp-server-shortcut/).

This MCP server allows users of [Shortcut](https://shortcut.com) to search and interact with the stories, epics, sprints/iterations, and other project management data in their workspace.

I've also tested the extension locally within Zed to confirm it works as expected.