### PR TITLE
clojure: Bump to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -386,7 +386,7 @@ version = "0.0.1"
 
 [clojure]
 submodule = "extensions/clojure"
-version = "0.2.0"
+version = "0.2.1"
 
 [cobalt2]
 submodule = "extensions/cobalt2"


### PR DESCRIPTION
This PR updates the Clojure extension to v0.2.1

Relevant changes: 

- https://github.com/zed-extensions/clojure/pull/9