### PR TITLE
java: Bump to v6.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1112,7 +1112,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "6.2.0"
+version = "6.3.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
Release notes: https://github.com/zed-extensions/java/releases/tag/v6.3.0