### PR TITLE
Add Quadlet extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2018,6 +2018,10 @@
 	path = extensions/qml
 	url = https://github.com/lkroll/zed-qml.git
 
+[submodule "extensions/quadlet"]
+	path = extensions/quadlet
+	url = https://github.com/mufeedali/zed-quadlet.git
+
 [submodule "extensions/quakec"]
 	path = extensions/quakec
 	url = https://github.com/schraf/zed-quakec.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2048,6 +2048,10 @@ version = "0.1.1"
 submodule = "extensions/qml"
 version = "0.0.4"
 
+[quadlet]
+submodule = "extensions/quadlet"
+version = "0.1.0"
+
 [quakec]
 submodule = "extensions/quakec"
 version = "0.0.2"


### PR DESCRIPTION
This is a language extension that provides support for [Podman Quadlet](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) files using the [quadlet-lsp](https://github.com/onlyati/quadlet-lsp) language server.