### PR TITLE
poc: update extensions with renovate

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1,123 +1,153 @@
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"
+repository = "filipjanevski/zed-theme"
 
 [actionscript]
 submodule = "extensions/actionscript"
 version = "0.0.1"
+repository = "pngdrift/zed-actionscript"
 
 [activitywatch]
 submodule = "extensions/activitywatch"
 version = "0.1.2"
+repository = "sachk/aw-watcher-zed"
 
 [ada]
 submodule = "extensions/ada"
 version = "0.3.0"
+repository = "wisn/zed-ada-language"
 
 [adaltas-theme]
 submodule = "extensions/adaltas-theme"
 version = "0.0.2"
+repository = "adaltas/zed-adaltas-theme"
 
 [adech]
 submodule = "extensions/adech"
 version = "2.0.1"
+repository = "adechlien/adech-theme-zed"
 
 [adwaita]
 submodule = "extensions/adwaita"
 version = "1.0.0"
+repository = "somepaulo/adwaita-zed-theme"
 
 [adwaita-pastel]
 submodule = "extensions/adwaita-pastel"
 version = "0.0.2"
+repository = "Benjamin-Davies/zed-theme-adwaita"
 
 [agda]
 submodule = "extensions/agda"
 version = "0.1.0"
+repository = "haohanyang/agda-zed"
 
 [aiken]
 submodule = "extensions/aiken"
 version = "1.0.0"
+repository = "aiken-lang/zed-aiken"
 
 [air]
 submodule = "extensions/air"
 path = "editors/zed"
 version = "0.1.0"
+repository = "posit-dev/air"
 
 [alabaster]
 submodule = "extensions/alabaster"
 version = "0.0.3"
+repository = "tsimoshka/zed-theme-alabaster"
 
 [alabaster-dark]
 submodule = "extensions/alabaster-dark"
 version = "0.0.3"
+repository = "findrakecil/alabaster-dark-zed-theme"
 
 [amber]
 submodule = "extensions/amber"
 version = "0.2.0"
+repository = "Ph0enixKM/zed-amber-extension"
 
 [amber-monochrome-monitor-crt-phosphor]
 submodule = "extensions/amber-monochrome-monitor-crt-phosphor"
 version = "0.1.3"
+repository = "Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed"
 
 [andromeda]
 submodule = "extensions/andromeda"
 version = "0.1.1"
+repository = "ChocolateNao/andromeda-zed"
 
 [angular]
 submodule = "extensions/angular"
 version = "0.0.4"
+repository = "nathansbradshaw/zed-angular"
 
 [ansible]
 submodule = "extensions/ansible"
 version = "0.1.2"
+repository = "kartikvashistha/zed-ansible"
 
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"
+repository = "boycsuk/anthracite-theme"
 
 [anysphere-theme]
 submodule = "extensions/anysphere-theme"
 version = "0.0.1"
+repository = "stpn48/anysphere-zed-theme"
 
 [aquarium-theme]
 submodule = "extensions/aquarium-theme"
 version = "0.7.1"
+repository = "biaqat/aquarium-theme-zed"
 
 [arctic-depth]
 submodule = "extensions/arctic-depth"
 version = "1.0.0"
+repository = "MarvellinusVincent/Arctic-Depth-Zed"
 
 [ariake]
 submodule = "extensions/ariake"
 version = "0.0.1"
+repository = "artivilla/zed-ariake-theme"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
 version = "0.0.1"
+repository = "andreicek/zed-asciidoc"
 
 [ass]
 submodule = "extensions/ass"
 version = "0.0.1"
+repository = "huaium/zed-ass"
 
 [assembly]
 submodule = "extensions/assembly"
 version = "0.1.0"
+repository = "DevBlocky/zed-asm"
 
 [ast-grep]
 submodule = "extensions/ast-grep"
 version = "0.1.0"
+repository = "mathieulj/ast-grep-zed"
 
 [asteroid]
 submodule = "extensions/asteroid"
 version = "0.0.1"
+repository = "webhooked/asteroid-zed"
 
 [astro]
 submodule = "extensions/astro"
 version = "0.1.7"
+repository = "zed-extensions/astro"
 
 [atomize]
 submodule = "extensions/atomize"
 version = "0.0.1"
+repository = "zhouyuxiang0/atomize.zed"
 
 [aura-theme]
 submodule = "extensions/aura"
@@ -127,10 +157,12 @@ version = "1.0.0"
 [authzed]
 submodule = "extensions/authzed"
 version = "0.0.2"
+repository = "mleonidas/authzed-zed"
 
 [autocorrect]
 submodule = "extensions/autocorrect"
 version = "0.1.0"
+repository = "huacnlee/zed-autocorrect"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"
@@ -139,444 +171,554 @@ version = "0.0.1"
 [awk]
 submodule = "extensions/awk"
 version = "0.0.1"
+repository = "dangh/zed-awk"
 
 [axolosin]
 submodule = "extensions/axolosin"
 version = "1.1.1"
+repository = "LightTreasure/axolosin-theme"
 
 [aylin-theme]
 submodule = "extensions/aylin-theme"
 version = "0.6.1"
+repository = "biaqat/aylin-theme-zed"
 
 [aystra]
 submodule = "extensions/aystra"
 version = "0.0.3"
+repository = "dotcypress/aystra"
 
 [ayu-darker]
 submodule = "extensions/ayu-darker"
 version = "1.0.0"
+repository = "k4yt3x/zed-theme-ayu-darker"
 
 [azure-context-server]
 submodule = "extensions/azure-context-server"
 version = "1.0.0"
+repository = "oWretch/zed-extension-azure-mcp"
 
 [azutiku-theme]
 submodule = "extensions/azutiku-theme"
 version = "0.1.0"
+repository = "bwind/zed-azutiku-theme"
 
 [bamboo-theme]
 submodule = "extensions/bamboo-theme"
 version = "0.1.0"
+repository = "LoamStudios/zed-bamboo-theme"
 
 [baml]
 submodule = "extensions/baml"
 version = "0.0.1"
+repository = "BoundaryML/zed-baml"
 
 [barbenheimer]
 submodule = "extensions/barbenheimer"
 version = "1.3.1"
+repository = "jayvicsanantonio/barbenheimer-zed-theme"
 
 [base16]
 submodule = "extensions/base16"
 version = "0.1.2"
+repository = "bswinnerton/base16-zed"
 
 [basedpyright]
 submodule = "extensions/basedpyright"
 version = "0.1.2"
+repository = "m1guer/basedpyright-zed"
 
 [basher]
 submodule = "extensions/basher"
 version = "0.0.3"
+repository = "zed-extensions/bash"
 
 [batman]
 submodule = "extensions/batman"
 version = "0.0.3"
+repository = "devzaidi/batman-theme-zed"
 
 [beancount]
 submodule = "extensions/beancount"
 version = "0.0.5"
+repository = "zed-extensions/beancount"
 
 [beanseeds-pro]
 submodule = "extensions/beanseeds-pro"
 version = "1.0.0"
+repository = "tokiory/beanseeds-pro"
 
 [bearded]
 submodule = "extensions/bearded"
 version = "1.0.0"
+repository = "lassejlv/bearded-themes"
 
 [bearded-icon-theme]
 submodule = "extensions/bearded-icon-theme"
 version = "0.4.0"
+repository = "sethstha/bearded-icons-theme"
 
 [bend]
 submodule = "extensions/bend"
 version = "0.0.1"
+repository = "mrpedrobraga/zed-bend"
 
 [bicep]
 submodule = "extensions/bicep"
 version = "1.2.0"
+repository = "oWretch/zed-extension-bicep"
 
 [biome]
 submodule = "extensions/biome"
 version = "0.2.0"
+repository = "biomejs/biome-zed"
 
 [bitbake]
 submodule = "extensions/bitbake"
 version = "0.0.4"
+repository = "anikinmd/zed_bitbake"
 
 [blackfox]
 submodule = "extensions/blackfox"
 version = "0.4.0"
+repository = "matejcerny/BlackFoxZed"
 
 [blackrain-theme]
 submodule = "extensions/blackrain-theme"
 version = "0.1.1"
+repository = "kurokirasama/zed_blackrain_theme"
 
 [blackula]
 submodule = "extensions/blackula"
 version = "0.1.1"
+repository = "JacobCoffee/blackula"
 
 [blade]
 submodule = "extensions/blade"
 version = "0.2.1"
+repository = "bajrangCoder/zed-laravel-blade"
 
 [blade-runner-2049]
 submodule = "extensions/blade-runner-2049"
 version = "1.0.4"
+repository = "Takk8IS/blade-runner-2049-theme-for-zed"
 
 [blanche]
 submodule = "extensions/blanche"
 version = "0.0.1"
+repository = "kwonoj/zed-blanche"
 
 [blankeos-zen]
 submodule = "extensions/blankeos-zen"
 version = "0.0.5"
+repository = "Blankeos/zen.zed"
 
 [blinds-theme]
 submodule = "extensions/blinds-theme"
 version = "0.1.0"
+repository = "orbulant/zed-blinds-theme"
 
 [blueprint]
 submodule = "extensions/blueprint"
 version = "0.3.1"
+repository = "tfuxu/zed-blueprint"
 
 [bluloco-theme]
 submodule = "extensions/bluloco-theme"
 version = "1.0.0"
+repository = "uloco/bluloco-zed"
 
 [bqn]
 submodule = "extensions/bqn"
 version = "0.0.1"
+repository = "DavidZwitser/zed-bqn"
 
 [brainfuck]
 submodule = "extensions/brainfuck"
 version = "0.0.4"
+repository = "JosephTLyons/zed-brainfuck"
 
 [brook-code-theme]
 submodule = "extensions/brook-code-theme"
 version = "1.0.0"
+repository = "brook-code-theme/zed-theme"
 
 [browser-tools-context-server]
 submodule = "extensions/browser-tools-context-server"
 version = "0.0.2"
+repository = "mirageN1349/browser-tools-context-server"
 
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"
+repository = "AineeJames/c3-zed"
 
 [caddyfile]
 submodule = "extensions/caddyfile"
 version = "0.0.2"
+repository = "nusnewob/caddyfile-zed"
 
 [cadence]
 submodule = "extensions/cadence"
 version = "0.0.2"
+repository = "janezpodhostnik/cadence.zed"
 
 [cairo]
 submodule = "extensions/cairo"
 version = "0.1.1"
+repository = "trbutler4/zed-cairo"
 
 [call-trans-opt-received]
 submodule = "extensions/call-trans-opt-received"
 version = "0.1.1"
+repository = "takk8is/call-trans-opt-received-2-19-98-13-24-18-rec-log-theme-for-zed"
 
 [capnp]
 submodule = "extensions/capnp"
 version = "0.0.1"
+repository = "cmackenzie1/zed-capnp"
 
 [cargo-appraiser]
 submodule = "extensions/cargo-appraiser"
 version = "0.0.1"
+repository = "washanhanzi/zed-cargo-appraiser"
 
 [cargo-tom]
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
+repository = "frederik-uni/zed-cargotom"
 
 [catbox]
 submodule = "extensions/catbox"
 version = "0.0.1"
+repository = "adibhanna/catbox"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
 version = "0.2.23"
+repository = "catppuccin/zed"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"
 version = "0.3.0"
+repository = "jenslys/zed-catppuccin-blur"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"
 version = "0.1.1"
+repository = "taciturnaxolotl/catppuccin-blur-zed"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
 version = "1.21.0"
+repository = "catppuccin/zed-icons"
 
 [cedar]
 submodule = "extensions/cedar"
 version = "0.0.1"
+repository = "chrnorm/zed-cedar"
 
 [cfengine]
 submodule = "extensions/cfengine"
 version = "1.0.1"
+repository = "olehermanse/zed-cfengine"
 
 [cfml]
 submodule = "extensions/cfml"
 version = "0.1.5"
+repository = "cfmleditor/zed-cfml"
 
 [chai-theme]
 submodule = "extensions/chai-theme"
 version = "0.0.2"
+repository = "rushabhcodes/zed-chai-theme"
 
 [chanterelle]
 submodule = "extensions/chanterelle"
 version = "0.0.1"
+repository = "steffenhaug/chanterelle-zed"
 
 [chaos-theory-theme]
 submodule = "extensions/chaos-theory-theme"
 version = "0.0.2"
+repository = "FeurJak/Chaos-Theory-Zed"
 
 [charmed-icons]
 submodule = "extensions/charmed-icons"
 version = "0.10.0"
+repository = "jmesrje/zed-charmed-icons"
 
 [chatgpt]
 submodule = "extensions/chatgpt"
 version = "0.1.3"
+repository = "Takk8IS/chatgpt-theme-for-zed"
 
 [chawyehsu-vscode-icons]
 submodule = "extensions/chawyehsu-vscode-icons"
 version = "0.3.0"
+repository = "chawyehsu/zed-vscode-icons-theme"
 
 [circom]
 submodule = "extensions/circom"
 version = "0.1.0"
+repository = "ThinkingFrog/zed-circom"
 
 [cisco-theme]
 submodule = "extensions/cisco-theme"
 version = "1.0.0"
+repository = "thommorais/zed-cisco-theme"
 
 [city-lights]
 submodule = "extensions/city-lights"
 version = "0.0.2"
+repository = "DP19/zed-theme-city-lights"
 
 [clarity]
 submodule = "extensions/clarity"
 version = "0.0.1"
+repository = "hirosystems/clarity-zed"
 
 [clojure]
 submodule = "extensions/clojure"
 version = "0.2.0"
+repository = "zed-extensions/clojure"
 
 [cobalt2]
 submodule = "extensions/cobalt2"
 version = "0.1.0"
+repository = "wesbos/cobalt2-zed"
 
 [cobol]
 submodule = "extensions/cobol"
 version = "0.0.3"
+repository = "willswire/zed-cobol"
 
 [code-stats]
 submodule = "extensions/code-stats"
 version = "0.2.7"
+repository = "maxdeviant/zed-code-stats"
 
 [codebook]
 submodule = "extensions/codebook"
 version = "0.1.9"
+repository = "blopker/codebook-zed"
 
 [codely-theme]
 submodule = "extensions/codely-theme"
 version = "0.0.1"
+repository = "GOI17/codely-theme-zed"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
 version = "0.0.5"
+repository = "MartinRybergLaude/zed-theme-codesandbox"
 
 [codestackr]
 submodule = "extensions/codestackr"
 version = "0.0.1"
+repository = "Pjort/codestackr-zed"
 
 [color-highlight]
 submodule = "extensions/color-highlight"
 version = "0.1.1"
+repository = "huacnlee/color-lsp"
 path = "zed-color-highlight"
 
 [colored-zed-icons-theme]
 submodule = "extensions/colored-zed-icons-theme"
 version = "0.3.1"
+repository = "TheRedXD/zed-icons-colored-theme"
 
 [colorizer]
 submodule = "extensions/colorizer"
 version = "1.0.6"
+repository = "tamimhasandev/colorizer"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"
 version = "1.0.0"
+repository = "mouhamadalmounayar/confluence-context-server"
 
 [conl]
 submodule = "extensions/conl"
 version = "2.0.0"
+repository = "ConradIrwin/zed-extension-conl"
 
 [cooklang]
 submodule = "extensions/cooklang"
 version = "1.3.3"
+repository = "hugginsio/zed-cooklang"
 
 [cosmos]
 submodule = "extensions/cosmos"
 version = "0.0.1"
+repository = "nauvalazhar/cosmos"
 
 [cpp2]
 submodule = "extensions/cpp2"
 version = "0.1.0"
+repository = "tsoj/zed-cpp2"
 
 [cql]
 submodule = "extensions/cql"
 version = "1.0.1"
+repository = "Akzestia/zed-cql"
 
 [crates-lsp]
 submodule = "extensions/crates-lsp"
 version = "0.2.0"
+repository = "appelgriebsch/zed-crates-lsp"
 
 [crimson-theme]
 submodule = "extensions/crimson-theme"
 version = "0.0.1"
+repository = "kaem-e/zed-crimson-theme"
 
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"
+repository = "crystal-lang-tools/zed-crystal"
 
 [crystal-theme]
 submodule = "extensions/crystal-theme"
 version = "0.0.1"
+repository = "https://gitlab.com/crystalnetwork-studio/themes/zed-editor"
 
 [csharp]
 submodule = "extensions/csharp"
 version = "0.1.2"
+repository = "zed-extensions/csharp"
 
 [cspell]
 submodule = "extensions/cspell"
 version = "0.0.3"
+repository = "mantou132/zed-cspell"
 
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
 version = "0.1.0"
+repository = "mizdra/css-modules-kit"
 path = "crates/zed"
 
 [csv]
 submodule = "extensions/csv"
 version = "0.0.2"
+repository = "huacnlee/zed-csv"
 
 [cucumber]
 submodule = "extensions/cucumber"
 version = "0.0.2"
+repository = "thlcodes/zed-extension-cucumber"
 
 [cue]
 submodule = "extensions/cue"
 version = "0.0.4"
+repository = "jkasky/zed-cue"
 
 [curry]
 submodule = "extensions/curry"
 version = "0.0.1"
+repository = "fwcd/zed-curry"
 
 [cursor]
 submodule = "extensions/cursor"
 version = "1.0.0"
+repository = "Takk8IS/cursor-theme-for-zed"
 
 [cursor-dark-theme]
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
+repository = "loosheng/zed-cursor-dark-theme"
 
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"
+repository = "biaqat/cyan-light-theme-zed"
 
 [cyberpunk-2077]
 submodule = "extensions/cyberpunk-2077"
 version = "2.0.0"
+repository = "takk8is/cyberpunk-2077-theme-for-zed"
 
 [cylc]
 submodule = "extensions/cylc"
 version = "0.2.0"
+repository = "elliotfontaine/zed-cylc"
 
 [cypher]
 submodule = "extensions/cypher"
 version = "0.0.1"
+repository = "pupli/cypher"
 
 [cython]
 submodule = "extensions/cython"
 version = "0.2.0"
+repository = "lgeiger/zed-cython"
 
 [d]
 submodule = "extensions/d"
 version = "0.0.9"
+repository = "staysail/zed-d"
 
 [d2]
 submodule = "extensions/d2"
 version = "0.2.1"
+repository = "gabeidx/zed-d2"
 
 [dafny]
 submodule = "extensions/dafny"
 version = "0.0.1"
+repository = "WeetHet/dafny-zed"
 
 [darcula-dark]
 submodule = "extensions/darcula-dark"
 version = "0.1.1"
+repository = "not-a-cowfr/Darcula-Dark"
 
 [dark-discord]
 submodule = "extensions/dark-discord"
 version = "1.0.0"
+repository = "zangetsu02/zed-dark-discord-theme"
 
 [dark-pop-ui]
 submodule = "extensions/dark-pop-ui"
 version = "0.0.2"
+repository = "kunal-arora/zed-theme-dark-pop-ui"
 
 [darker-horizon]
 submodule = "extensions/darker-horizon"
 version = "0.0.3"
+repository = "ewwwdp/dark-horizon-zed"
 
 [darkmatter-theme]
 submodule = "extensions/darkmatter-theme"
 version = "0.0.1"
+repository = "stevedylandev/darkmatter-theme-zed"
 
 [dart]
 submodule = "extensions/dart"
 version = "0.2.2"
+repository = "zed-extensions/dart"
 
 [datadog-mcp]
 submodule = "extensions/datadog-mcp"
 version = "0.2.0"
+repository = "robertohuertasm/zed-datadog-mcp"
 
 [day-shift]
 submodule = "extensions/day-shift"
 version = "1.0.3"
+repository = "Jean-Tinland/zed-theme-day-shift"
 
 [dbml]
 submodule = "extensions/dbml"
 version = "0.0.1"
+repository = "shuklaayush/zed-dbml"
 
 [decorative-stitch]
 submodule = "extensions/decorative-stitch"
 version = "1.0.0"
+repository = "keithrowell/zed-theme-decorative-stitch"
 
 [denix]
 submodule = "extensions/denix"
@@ -585,11 +727,13 @@ version = "0.0.9"
 [deno]
 submodule = "extensions/deno"
 version = "0.1.1"
+repository = "zed-extensions/deno"
 
 [deputy]
 submodule = "extensions/deputy"
 path = "editors/zed"
 version = "1.0.0"
+repository = "filiptibell/deputy"
 
 [design-tokens]
 submodule = "extensions/design-tokens"
@@ -599,103 +743,128 @@ version = "0.0.17"
 [devicetree]
 submodule = "extensions/devicetree"
 version = "0.0.1"
+repository = "anikinmd/zed_devicetree"
 
 [discord-presence]
 submodule = "extensions/discord-presence"
 version = "0.2.3"
+repository = "xhyrom/zed-discord-presence"
 
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"
+repository = "eth0net/zed-docker-compose"
 
 [dockerfile]
 submodule = "extensions/dockerfile"
 version = "0.0.5"
+repository = "zed-extensions/dockerfile"
 
 [dogi]
 submodule = "extensions/dogi"
 version = "1.0.4"
+repository = "DogukanUrker/DogiZed"
 
 [dracula]
 submodule = "extensions/dracula"
 version = "1.1.0"
+repository = "dracula/zed"
 
 [dram]
 submodule = "extensions/dram"
 version = "1.0.0"
+repository = "clamjohnston/dram"
 
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"
+repository = "Lalolog/duckyscript-zed-extension"
 
 [dune-theme]
 submodule = "extensions/dune-theme"
 version = "1.2.0"
+repository = "Anvell/zed-dune-theme"
 
 [earthfile]
 submodule = "extensions/earthfile"
 version = "0.1.0"
+repository = "glehmann/earthfile.zed"
 
 [edge]
 submodule = "extensions/edge"
 version = "0.1.0"
+repository = "Hexacker/zed-edge"
 
 [edi]
 submodule = "extensions/edi"
 version = "0.0.2"
+repository = "hugginsio/zed-edi"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.1.0"
+repository = "demiurg/zed-theme-eiffel"
 
 [ejs]
 submodule = "extensions/ejs"
 version = "0.0.1"
+repository = "dangh/zed-ejs"
 
 [elderberry]
 submodule = "extensions/elderberry"
 version = "0.1.0"
+repository = "IronGeek/zed-theme-elderberry"
 
 [elisp]
 submodule = "extensions/elisp"
 version = "0.0.4"
+repository = "JosephTLyons/zed-elisp"
 
 [elixir]
 submodule = "extensions/elixir"
 version = "0.1.10"
+repository = "zed-extensions/elixir"
 
 [elle]
 submodule = "extensions/elle"
 path = "editors/zed"
 version = "0.3.0"
+repository = "acquitelol/elle"
 
 [elm]
 submodule = "extensions/elm"
 version = "0.2.0"
+repository = "zed-extensions/elm"
 
 [ember]
 submodule = "extensions/ember"
 version = "0.1.0"
+repository = "jylamont/zed-ember"
 
 [ember-theme]
 submodule = "extensions/ember-theme"
 version = "0.9.1"
+repository = "biaqat/ember-theme-zed"
 
 [emerald-night]
 submodule = "extensions/emerald-night"
 version = "0.0.2"
+repository = "iamngoni/emerald-night-theme"
 
 [emmet]
 submodule = "extensions/emmet"
 version = "0.0.7"
+repository = "zed-extensions/emmet"
 
 [env]
 submodule = "extensions/env"
 version = "0.0.1"
+repository = "zarifpour/zed-env"
 
 [erlang]
 submodule = "extensions/erlang"
 version = "0.1.2"
+repository = "zed-extensions/erlang"
 
 [everforest-theme]
 submodule = "extensions/everforest"
@@ -704,27 +873,33 @@ version = "0.0.3"
 [evil-rabbit-theme]
 submodule = "extensions/evil-rabbit-theme"
 version = "0.0.1"
+repository = "kettanaito/zed-theme-evil-rabbit"
 
 [evolved-theme]
 submodule = "extensions/evolved-theme"
 path = "dist/zed"
 version = "0.3.0"
+repository = "evoL/evolved-theme"
 
 [exograph]
 submodule = "extensions/exograph"
 version = "0.0.2"
+repository = "exograph/zed-extension"
 
 [exquisite]
 submodule = "extensions/exquisite"
 version = "0.1.3"
+repository = "xqsit94/zed-xqsit-theme"
 
 [ezio-theme]
 submodule = "extensions/ezio-theme"
 version = "0.0.6"
+repository = "dsantolo/ezio-zed"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
 version = "0.1.0"
+repository = "NarmadaWeb/fastapi-snippets-zed"
 
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
@@ -733,30 +908,37 @@ version = "0.1.0"
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
 version = "0.1.1"
+repository = "keturiosakys/zed-fp-studio"
 
 [firebase-security-rules]
 submodule = "extensions/firebase-security-rules"
 version = "0.1.0"
+repository = "ChemisTechlabs/zed-firebase-security-rules"
 
 [fish]
 submodule = "extensions/fish"
 version = "0.0.8"
+repository = "hasit/zed-fish"
 
 [flask-snippets]
 submodule = "extensions/flask-snippets"
 version = "0.0.2"
+repository = "ayberkgezer/flask-snippets"
 
 [flat-theme]
 submodule = "extensions/flat-theme"
 version = "0.5.1"
+repository = "biaqat/flat-theme-zed"
 
 [flatbuffers]
 submodule = "extensions/flatbuffers"
 version = "0.0.1"
+repository = "smpanaro/zed-flatbuffers"
 
 [fleet-themes]
 submodule = "extensions/fleet-themes"
 version = "1.2.0"
+repository = "skarline/zed-fleet-themes"
 
 [flexoki-themes]
 submodule = "extensions/flexoki"
@@ -766,38 +948,47 @@ version = "2.0.1"
 [flow-theme]
 submodule = "extensions/flow-theme"
 version = "1.1.0"
+repository = "Rics-Dev/zed-flow-theme"
 
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
 version = "0.1.0"
+repository = "luisdanieldlcg/flutter-snippets"
 
 [focus-theme]
 submodule = "extensions/focus-theme"
 version = "0.0.1"
+repository = "jigyansunanda/focus"
 
 [forest-night]
 submodule = "extensions/forest-night"
 version = "0.1.0"
+repository = "jarith/forest-night-zed"
 
 [fortran]
 submodule = "extensions/fortran"
 version = "0.0.3"
+repository = "Xavier-Maruff/zed-fortran"
 
 [fountain]
 submodule = "extensions/fountain"
 version = "0.2.0"
+repository = "LaPingvino/zed-fountain"
 
 [frosted-theme]
 submodule = "extensions/frosted-theme"
 version = "0.0.1"
+repository = "daviiiL/frosted-theme"
 
 [fsharp]
 submodule = "extensions/fsharp"
 version = "0.0.7"
+repository = "nathanjcollins/zed-fsharp"
 
 [fsm]
 submodule = "extensions/fsm"
 version = "0.3.0"
+repository = "https://codeberg.org/reesericci/zed-extension-fsm"
 
 [gafelson]
 submodule = "extensions/gafelson"
@@ -806,79 +997,98 @@ version = "1.0.1"
 [gcode]
 submodule = "extensions/gcode"
 version = "0.0.1"
+repository = "ChocolateNao/zed-gcode"
 
 [gdscript]
 submodule = "extensions/gdscript"
 version = "0.5.0"
+repository = "GDQuest/zed-gdscript"
 
 [gem]
 submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
 version = "0.0.3"
+repository = "mantou132/gem"
 
 [gemini]
 submodule = "extensions/gemini"
 version = "0.0.1"
+repository = "clseibold/gemini-zed"
 
 [gentle-dark]
 submodule = "extensions/gentle-dark"
 version = "1.2.1"
+repository = "gentlelionstudios/gentle-dark-zed"
 
 [git-firefly]
 submodule = "extensions/git-firefly"
 version = "0.1.1"
+repository = "d1y/git_firefly"
 
 [github-actions]
 submodule = "extensions/github-actions"
 version = "0.0.1"
+repository = "neoncitylights/zed-github-actions"
 
 [github-activity-summarizer]
 submodule = "extensions/github-activity-summarizer"
 version = "0.5.1"
+repository = "rubiojr/gas"
 
 [github-classic]
 submodule = "extensions/github-classic"
 version = "0.0.2"
+repository = "meocoder31099/Github-Classic-Theme-Zed"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"
 version = "0.1.1"
+repository = "ssaunderss/zed-gh-copilot-theme"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
 version = "1.0.9"
+repository = "MordFustang21/zed-github-dark"
 
 [github-monochrome-theme]
 submodule = "extensions/github-monochrome-theme"
 version = "0.0.1"
+repository = "Nishantdd/github-monochrome-zed"
 
 [github-plus-theme]
 submodule = "extensions/github-plus-theme"
 version = "1.1.0"
+repository = "thenikso/github-plus-theme-zed"
 
 [github-theme]
 submodule = "extensions/github-theme"
 version = "0.1.3"
+repository = "PyaeSoneAungRgn/github-zed-theme"
 
 [gitignore-templates]
 submodule = "extensions/gitignore-templates"
 version = "2025.08.0"
+repository = "hjr265/zed-gitignore-templates"
 
 [gitlab-ci-ls]
 submodule = "extensions/gitlab-ci-ls"
 version = "1.0.1"
+repository = "tzabbi/zed-gitlab-ci-ls"
 
 [glazier]
 submodule = "extensions/glazier"
 version = "0.0.2"
+repository = "airgap/glazier"
 
 [gleam]
 submodule = "extensions/gleam"
 version = "0.5.1"
+repository = "gleam-lang/zed-gleam"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"
 version = "0.2.1"
+repository = "DanielleMaywood/gleam-theme-zed"
 
 [glsl]
 submodule = "extensions/zed"
@@ -888,146 +1098,182 @@ version = "0.1.0"
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.0"
+repository = "ayberkgezer/go-zed-snippets"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
 version = "0.2.0"
+repository = "zed-extensions/golangci-lint"
 
 [gosum]
 submodule = "extensions/gosum"
 version = "0.0.2"
+repository = "kartikvashistha/zed-gosum"
 
 [graphene]
 submodule = "extensions/graphene"
 version = "0.2.1"
+repository = "adinack/graphene"
 
 [graphql]
 submodule = "extensions/graphql"
 version = "1.0.2"
+repository = "11bit/zed-extension-graphql"
 
 [graphviz]
 submodule = "extensions/graphviz"
 version = "0.1.0"
+repository = "gabeidx/zed-graphviz"
 
 [green-monochrome-monitor-crt-phosphor]
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"
 version = "0.1.3"
+repository = "Takk8IS/green-monochrome-monitor-crt-phosphor-theme-for-zed"
 
 [gren]
 submodule = "extensions/gren"
 version = "0.1.0"
+repository = "johanalkstal/gren-lang-extension"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
 version = "0.1.0"
+repository = "mvrcoag/zed-grey-theme"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"
 version = "0.1.0"
+repository = "ssaunderss/grimaces-birthday"
 
 [grit]
 submodule = "extensions/grit"
 version = "0.0.1"
+repository = "mantou132/zed-grit"
 
 [groovy]
 submodule = "extensions/groovy"
 version = "1.3.0"
+repository = "valentinegb/zed-groovy"
 
 [groq]
 submodule = "extensions/groq"
 version = "0.0.1"
+repository = "juice49/zed-groq"
 
 [gruber-darker]
 submodule = "extensions/gruber-darker"
 version = "0.0.8"
+repository = "th0jensen/gruber-darker.zed"
 
 [gruber-flavors]
 submodule = "extensions/gruber-flavors"
 version = "0.8.0"
+repository = "biaqat/gruber-theme-zed"
 
 [gruvbox-baby]
 submodule = "extensions/gruvbox-baby"
 version = "0.0.1"
+repository = "gbo-dev/gruvbox-baby-zed"
 
 [gruvbox-crisp-themes]
 submodule = "extensions/gruvbox-crisp-themes"
 version = "0.1.2"
+repository = "VatsalSy/zed-gruvbox_custom_themes"
 
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"
 version = "0.0.1"
+repository = "LeoDog896/zed-gruvbox-ish"
 
 [gruvbox-material]
 submodule = "extensions/gruvbox-material"
 version = "1.0.0"
+repository = "tokiory/zed-gruvbox-material"
 
 [hacker-night-vision]
 submodule = "extensions/hacker-night-vision"
 version = "2.0.0"
+repository = "Takk8IS/hacker-night-vision-theme-for-zed"
 
 [hacker-theme]
 submodule = "extensions/hacker-theme"
 version = "1.0.1"
+repository = "0xSandiem/zedhacker"
 
 [haku-dark-theme]
 submodule = "extensions/haku-dark-theme"
 version = "0.0.1"
+repository = "ArthurBrussee/haku_dark"
 
 [halcyon]
 submodule = "extensions/halcyon"
 version = "0.2.3"
+repository = "hichemfantar/halcyon-zed"
 
 [hami-melon-theme]
 submodule = "extensions/hami-melon-theme"
 version = "0.2.0"
+repository = "isunjn/hami-melon-zed"
 
 [haml]
 submodule = "extensions/haml"
 version = "0.1.1"
+repository = "davidcornu/zed-haml"
 
 [hare]
 submodule = "extensions/hare"
 version = "0.0.1"
+repository = "xdBronch/hare-zed"
 
 [harper]
 submodule = "extensions/harper"
 version = "0.1.0"
+repository = "zed-extensions/harper"
 
 [haskell]
 submodule = "extensions/haskell"
 version = "0.1.5"
+repository = "zed-extensions/haskell"
 
 [haxe]
 submodule = "extensions/haxe"
 version = "0.3.1"
+repository = "Frixuu/Zed-Haxe"
 
 [helm]
 submodule = "extensions/helm"
 version = "0.0.1"
+repository = "cabrinha/helm.zed"
 
 [hex-light-theme]
 submodule = "extensions/hex-light-theme"
 version = "0.0.4"
+repository = "coghost/light-zed-theme"
 
 [hivacruz-theme]
 submodule = "extensions/hivacruz-theme"
 version = "0.1.0"
+repository = "kinoute/zed-hivacruz-theme"
 
 [hlsl]
 submodule = "extensions/hlsl"
 version = "0.0.1"
+repository = "igordreher/zed-hlsl"
 
 [hocon]
 submodule = "extensions/hocon"
 version = "0.2.0"
+repository = "tomatitito/hocon-zed-extension"
 
 [horizon]
 submodule = "extensions/horizon"
 version = "0.0.1"
+repository = "ayn2op/zed-horizon"
 
 [hot-dog-stand]
 submodule = "extensions/hot-dog-stand"
 version = "0.0.2"
+repository = "CoasterFan5/hotdog-stand-zed"
 
 [html]
 submodule = "extensions/zed"
@@ -1037,138 +1283,172 @@ version = "0.2.1"
 [html-jinja]
 submodule = "extensions/html-jinja"
 version = "0.1.0"
+repository = "JaagupAverin/html-jinja"
 
 [http]
 submodule = "extensions/http"
 version = "0.0.1"
+repository = "tie304/zed-http"
 
 [hurl]
 submodule = "extensions/hurl"
 version = "0.1.0"
+repository = "tommy/zed-hurl"
 
 [hyprlang]
 submodule = "extensions/hyprlang"
 version = "0.0.1"
+repository = "WhySoBad/zed-hyprlang-extension"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"
 version = "1.0.0"
+repository = "Takk8IS/ibm-5151-theme-for-zed"
 
 [ical]
 submodule = "extensions/ical"
 version = "0.1.0"
+repository = "TitouanReal/zed-ical"
 
 [iceberg]
 submodule = "extensions/iceberg"
 version = "0.2.10"
+repository = "EFDos/iceberg-zed-theme"
 
 [iceicebergy]
 submodule = "extensions/iceicebergy"
 version = "0.3.14"
+repository = "jmsdnns/zed-iceicebergy"
 
 [icons-modern-material]
 submodule = "extensions/icons-modern-material"
 version = "1.0.1"
+repository = "JosMiguelMM/icons-modern-material"
 
 [indigo]
 submodule = "extensions/indigo"
 version = "0.1.2"
+repository = "p3rception/Indigo-zed"
 
 [inform6]
 submodule = "extensions/inform6"
 version = "1.0.0"
+repository = "Or4c/zed-inform6"
 
 [ini]
 submodule = "extensions/ini"
 version = "0.0.5"
+repository = "bajrangCoder/zed-ini"
 
 [ink]
 submodule = "extensions/ink"
 version = "0.0.1"
+repository = "yuna0x0/zed-ink"
 
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
 version = "0.1.0"
+repository = "kpitt/zed-theme-intellij-newui"
 
 [ion]
 submodule = "extensions/ion"
 version = "0.1.1"
+repository = "tartarughina/zed-amazon-ion"
 
 [ir-black]
 submodule = "extensions/ir-black"
 version = "0.0.1"
+repository = "sametaylak/ir-black-zed-theme"
 
 [isle]
 submodule = "extensions/isle"
 version = "0.0.1"
+repository = "eagr/zed-isle"
 
 [iwe]
 submodule = "extensions/iwe"
 version = "0.0.2"
+repository = "iwe-org/zed-iwe"
 
 [janet]
 submodule = "extensions/janet"
 version = "0.0.1"
+repository = "vijaykiran/janet-zed"
 
 [java]
 submodule = "extensions/java"
 version = "6.2.0"
+repository = "samuser107/zed-java-extension"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"
 version = "0.2.5"
+repository = "ABckh/zed-java-language-support-jdtls"
 
 [jellybeans-vim]
 submodule = "extensions/jellybeans-vim"
 version = "0.0.2"
+repository = "rajerthat1/jellybeans.zed"
 
 [jetbrains-icons]
 submodule = "extensions/jetbrains-icons"
 version = "0.0.3"
+repository = "ziishaned/zed-jetbrains-icons"
 
 [jetbrains-new-ui-icons]
 submodule = "extensions/jetbrains-new-ui-icons"
 version = "2.1.0"
+repository = "ankddev/zed-jetbrains-newui-icons"
 
 [jetbrains-rider]
 submodule = "extensions/jetbrains-rider"
 version = "0.0.2"
+repository = "NarmadaWeb/jetbrains-rider-zed"
 
 [jetbrains-themes]
 submodule = "extensions/jetbrains-themes"
 version = "0.0.8"
+repository = "artemevsevev/zed-theme-jetbrains"
 
 [jinja2]
 submodule = "extensions/jinja2"
 version = "0.0.1"
+repository = "ArcherHume/jinja2-support"
 
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
+repository = "trbroyles1/jira-slash-command"
 
 [jj-lsp]
 submodule = "extensions/jj-lsp"
 version = "0.1.0"
+repository = "nilskch/zed-jj-lsp"
 
 [json5]
 submodule = "extensions/json5"
 version = "0.0.1"
+repository = "ChunzhengLab/json5-zed-extension"
 
 [jsonnet]
 submodule = "extensions/jsonnet"
 version = "0.4.0"
+repository = "narqo/zed-jsonnet"
 
 [jsp]
 submodule = "extensions/jsp"
 version = "0.1.0"
+repository = "tartarughina/zed-jsp"
 
 [julia]
 submodule = "extensions/julia"
 version = "0.1.7"
+repository = "JuliaEditorSupport/zed-julia"
 
 [just]
 submodule = "extensions/just"
 version = "0.1.4"
+repository = "jackTabsCode/zed-just"
 
 [just-ls]
 submodule = "extensions/just-ls"

--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,59 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+ "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
     "helpers:pinGitHubActionDigests"
   ],
-  "dependencyDashboard": true,
-  "timezone": "America/New_York",
-  "schedule": ["after 3pm on Wednesday"],
-  "major": {
-    "dependencyDashboardApproval": true
+    "git-submodules": {
+      "enabled": false
+    },
+    "customDatasources": {
+      "extension-toml": {
+        "defaultRegistryUrlTemplate": "https://raw.githubusercontent.com/{{{packageName}}}/main/extension.toml",
+        "format": "toml",
+        "transformTemplates": [
+          "{\"releases\":[{\"version\": version}]}"
+        ]
+      }
+    },
+    "customManagers": [
+      {
+        "customType": "regex",
+        "description": "Track extension versions from upstream extension.toml files",
+        "fileMatch": ["^extensions\\.toml$"],
+        "matchStrings": [
+          "submodule\\s*=\\s*\\\"extensions(?<repo>[^\\\"]+)\\\"\\n\\s*version\\s*=\\s*\\\"(?<currentValue>[^\\\"]+)\\\"\\n\\s*repository\\s*=\\s*\\\"(?<packageName>[^\\\"]+)\\\""
+
+             ],
+        "datasourceTemplate": "custom.extension-toml",
+        "packageNameTemplate": "{{{packageName}}}",
+        "depTypeTemplate": "extension"
+      }
+    ],
+    "packageRules": [
+      {
+        "description": "Extension version updates",
+        "matchManagers": ["custom.regex"],
+        "matchDepTypes": ["extension"],
+        "commitMessageTopic": "extension {{depName}}",
+        "semanticCommitType": "feat",
+        "semanticCommitScope": "extensions",
+        "prBodyTemplate": "This PR updates the {{depName}} extension from version {{currentVersion}} to {{newVersion}}.\n\n- Repository: {{packageName}}\n- Version change: {{currentVersion}} → {{newVersion}}\n- Submodule will be updated to match the new version"
+      }
+    ],
+    "allowedPostUpgradeCommands": [
+      "^scripts/sync-extension-submodule\\.sh .*$"
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "scripts/sync-extension-submodule.sh {{{depName}}} extensions/{{{repo}}} {{{newVersion}}} {{{packageName}}}"
+      ],
+      "fileFilters": [
+        "extensions.toml",
+        ".gitmodules",
+        "extensions/**"
+      ]
+    }
   }
-}

--- a/scripts/sync-extension-submodule.sh
+++ b/scripts/sync-extension-submodule.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+set -e
+
+EXTENSION_NAME="$1"
+SUBMODULE_PATH="$2"
+TARGET_VERSION="$3"
+REPO_NAME="$4"
+
+if [[ -z "$EXTENSION_NAME" || -z "$SUBMODULE_PATH" || -z "$TARGET_VERSION" || -z "$REPO_NAME" ]]; then
+    echo "Usage: $0 <extension_name> <submodule_path> <target_version> <repo_name>"
+    exit 1
+fi
+
+echo "Syncing extension: $EXTENSION_NAME"
+echo "Submodule path: $SUBMODULE_PATH"
+echo "Target version: $TARGET_VERSION"
+echo "Repository: $REPO_NAME"
+
+# Function to get version from extension.toml
+get_extension_version() {
+    local path="$1"
+    if [[ -f "$path/extension.toml" ]]; then
+        grep '^version = ' "$path/extension.toml" | head -n1 | sed 's/version = \"(.*)\"/\1/'
+    fi
+}
+
+# Function to find commit with specific version in extension.toml
+find_commit_with_version() {
+    local submodule_path="$1"
+    local target_version="$2"
+    
+    cd "$submodule_path"
+    
+    # Fetch latest from remote
+    git fetch origin
+    
+    # Get all commits and check their extension.toml version
+    git log --oneline --format="%H" origin/main | while read commit; do
+        git checkout "$commit" 2>/dev/null || continue
+        current_version=$(get_extension_version ".")
+        if [[ "$current_version" == "$target_version" ]]; then
+            echo "$commit"
+            break
+        fi
+    done
+    
+    cd - > /dev/null
+}
+
+# Check if submodule exists
+if [[ ! -d "$SUBMODULE_PATH" ]]; then
+    echo "Error: Submodule path $SUBMODULE_PATH does not exist"
+    exit 1
+fi
+
+# Initialize and update submodule to get latest commits
+git submodule update --init --remote "$SUBMODULE_PATH"
+
+# Find the commit that has the target version
+echo "Looking for commit with version $TARGET_VERSION in $SUBMODULE_PATH..."
+target_commit=$(find_commit_with_version "$SUBMODULE_PATH" "$TARGET_VERSION")
+
+if [[ -z "$target_commit" ]]; then
+    echo "Error: Could not find commit with version $TARGET_VERSION in $SUBMODULE_PATH"
+    echo "Available versions in recent commits:"
+    
+    cd "$SUBMODULE_PATH"
+    git log --oneline --format="%H %s" -10 origin/main | while read commit message; do
+        git checkout "$commit" 2>/dev/null || continue
+        version=$(get_extension_version ".")
+        if [[ -n "$version" ]]; then
+            echo "  $commit: $version - $message"
+        fi
+    done
+    cd - > /dev/null
+    
+    exit 1
+fi
+
+echo "Found target commit: $target_commit"
+
+# Update submodule to the specific commit
+cd "$SUBMODULE_PATH"
+git checkout "$target_commit"
+cd - > /dev/null
+
+# Update extensions.toml with the new version
+update_extensions_toml() {
+    local temp_file=$(mktemp)
+    local in_target_section=false
+    
+    while IFS= read -r line; do
+        if [[ $line =~ ^\[([^\]]+)\]$ ]]; then
+            local section_name="${BASH_REMATCH[1]}"
+            if [[ "$section_name" == "$EXTENSION_NAME" ]]; then
+                in_target_section=true
+            else
+                in_target_section=false
+            fi
+            echo "$line" >> "$temp_file"
+        elif [[ $in_target_section == true && $line =~ ^version[[:space:]]*=[[:space:]]*[\"'](.*)[\"']*$ ]]; then
+            echo "version = \"$TARGET_VERSION\"" >> "$temp_file"
+            echo "Updated extensions.toml: $EXTENSION_NAME version → $TARGET_VERSION"
+        else
+            echo "$line" >> "$temp_file"
+        fi
+    done < extensions.toml
+    
+    mv "$temp_file" extensions.toml
+}
+
+# Update the extensions.toml file
+update_extensions_toml
+
+# Verify the submodule is at the correct commit
+current_commit=$(cd "$SUBMODULE_PATH" && git rev-parse HEAD)
+if [[ "$current_commit" == "$target_commit" ]]; then
+    echo "✓ Submodule successfully updated to commit $target_commit"
+else
+    echo "✗ Warning: Submodule commit mismatch. Expected: $target_commit, Got: $current_commit"
+fi
+
+# Verify the version in the submodule matches
+actual_version=$(get_extension_version "$SUBMODULE_PATH")
+if [[ "$actual_version" == "$TARGET_VERSION" ]]; then
+    echo "✓ Version verification successful: $actual_version"
+else
+    echo "✗ Warning: Version mismatch. Expected: $TARGET_VERSION, Got: $actual_version"
+fi
+
+# Stage the changes
+git add "$SUBMODULE_PATH" extensions.toml
+
+echo "Successfully synced $EXTENSION_NAME to version $TARGET_VERSION (commit: $target_commit)"


### PR DESCRIPTION
This is a POC for how renovate could be used to automate the update of the extension.
It works by using a custom datasource that fetches the extension.toml from each extension repo to check if it matches extensions.toml in this repo and then bumps extensions.toml.

Additional one could run a script that then updates the git submodule of the updated extension (using renovates postUpgradeTasks (this requires self-hosting renovate i guess) or an CI job).

The poc only works for github repos currently is very hacky but I would like to know if you would be interested in this. I think the automation potential is huge since updating the submodules manually is quite error prone.