### PR TITLE
zig: Bump to v0.3.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2892,7 +2892,7 @@ version = "0.1.0"
 
 [zig]
 submodule = "extensions/zig"
-version = "0.3.4"
+version = "0.3.5"
 
 [ziggy]
 submodule = "extensions/ziggy"


### PR DESCRIPTION
This PR updates the Zig extension to v0.3.5

Includes:

- https://github.com/zed-extensions/zig/pull/6
- https://github.com/zed-extensions/zig/pull/1