### PR TITLE
Add Willow v0.1.0 - TODO/FIXME highlighter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2877,3 +2877,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/willow"]
+	path = extensions/willow
+	url = https://github.com/willibrandon/willow.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2923,3 +2923,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.1.0"
+
+[willow]
+submodule = "extensions/willow"
+version = "0.1.0"


### PR DESCRIPTION
## Willow v0.1.0

TODO/FIXME highlighter extension for Zed.

### Features
- Highlights TODO, FIXME, HACK, NOTE, WARNING, and other markers
- Works across all languages
- Customizable through themes
- Zero configuration required

### Testing
- Tested on macOS and Linux
- Validated with multiple languages
- Performance tested with large files