### PR TITLE
Remove meson extension from list

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1470,10 +1470,6 @@
 	path = extensions/mermaid
 	url = https://github.com/gabeidx/zed-mermaid.git
 
-[submodule "extensions/meson"]
-	path = extensions/meson
-	url = https://github.com/hqnna/zed-meson
-
 [submodule "extensions/min-theme"]
 	path = extensions/min-theme
 	url = https://github.com/phibr0/zed-min-theme/

--- a/extensions.toml
+++ b/extensions.toml
@@ -1495,10 +1495,6 @@ version = "0.0.1"
 submodule = "extensions/mermaid"
 version = "0.1.0"
 
-[meson]
-submodule = "extensions/meson"
-version = "0.4.0"
-
 [min-theme]
 submodule = "extensions/min-theme"
 version = "0.2.1"


### PR DESCRIPTION
Heya, I'm currently the maintainer of the Meson plugin. I'm unable to maintain the plugin due to both technical reasons and lack of time so I am requesting it be removed for now. However if anyone else would like to take up the offer to maintain and update the plugin, feel free to. I just simply don't have the time to maintain it anymore, and don't want people relying on a plugin that could break at any point.