### PR TITLE
kotlin: Bump to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1208,7 +1208,7 @@ version = "0.0.1"
 
 [kotlin]
 submodule = "extensions/kotlin"
-version = "0.1.3"
+version = "0.1.4"
 
 [koto]
 submodule = "extensions/koto"


### PR DESCRIPTION
This PR updates the Kotlin extension to v0.1.4

Includes:
- https://github.com/zed-extensions/kotlin/pull/40