### PR TITLE
html: Bump to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1033,7 +1033,7 @@ version = "0.0.2"
 [html]
 submodule = "extensions/zed"
 path = "extensions/html"
-version = "0.2.1"
+version = "0.2.2"
 
 [html-jinja]
 submodule = "extensions/html-jinja"


### PR DESCRIPTION
This PR bumps the HTML extension to v0.2.2.

Changes:

- https://github.com/zed-industries/zed/pull/28184
- https://github.com/zed-industries/zed/pull/36948
- https://github.com/zed-industries/zed/pull/37098
