### PR TITLE
elixir: Bump to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -663,7 +663,7 @@ version = "0.0.4"
 
 [elixir]
 submodule = "extensions/elixir"
-version = "0.1.10"
+version = "0.2.0"
 
 [elle]
 submodule = "extensions/elle"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.2.0.

This version brings support for [Expert](https://github.com/elixir-lang/expert), the official Elixir language server.