### PR TITLE
elixir: Bump to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -663,7 +663,7 @@ version = "0.0.4"
 
 [elixir]
 submodule = "extensions/elixir"
-version = "0.2.0"
+version = "0.2.1"
 
 [elle]
 submodule = "extensions/elle"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.2.1.

Includes:

- https://github.com/zed-extensions/elixir/pull/28