### PR TITLE
Update `github-classic` to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -839,7 +839,7 @@ version = "0.5.1"
 
 [github-classic]
 submodule = "extensions/github-classic"
-version = "0.0.2"
+version = "0.0.3"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"


### PR DESCRIPTION
This PR updates the GitHub Classic theme to v0.0.3.

* Changed `search.match_background ` to a more transparent color.
* Changed `panel.indent_guide` color to increase contrast.
* Changed `players.selection` color to increase contrast.