### PR TITLE
nu: Bump to v0.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1746,7 +1746,7 @@ version = "0.0.2"
 
 [nu]
 submodule = "extensions/nu"
-version = "0.0.6"
+version = "0.0.7"
 
 [nuisance]
 submodule = "extensions/nuisance"


### PR DESCRIPTION
This PR updates the Nu extension to version v0.0.7.

Includes:

- https://github.com/zed-extensions/nu/pull/12
- https://github.com/zed-extensions/nu/pull/13