### PR TITLE
nix: Bump to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1694,7 +1694,7 @@ version = "1.0.0"
 
 [nix]
 submodule = "extensions/nix"
-version = "0.1.1"
+version = "0.1.2"
 
 [nixdorf-8870]
 submodule = "extensions/nixdorf-8870"


### PR DESCRIPTION
This PR updates the Nix extension to v0.1.2.

Includes:

- https://github.com/zed-extensions/nix/pull/30
- https://github.com/zed-extensions/nix/pull/31
- https://github.com/zed-extensions/nix/pull/32 
