### PR TITLE
Update basedpyright to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -126,7 +126,7 @@ version = "0.1.1"
 
 [basedpyright]
 submodule = "extensions/basedpyright"
-version = "0.1.2"
+version = "0.1.3"
 
 [basher]
 submodule = "extensions/basher"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1641,7 +1641,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "0.0.1"
+version = "0.0.2"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -126,7 +126,7 @@ version = "0.1.1"
 
 [basedpyright]
 submodule = "extensions/basedpyright"
-version = "0.1.1"
+version = "0.1.2"
 
 [basher]
 submodule = "extensions/basher"


### PR DESCRIPTION
- Move repo from [m1guer/basedpyright-zed](https://github.com/m1guer/basedpyright-zed) to [pub-struct/basedpyright-zed](https://github.com/pub-struct/basedpyright-zed)