### PR TITLE
Update autocorrect to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -134,7 +134,7 @@ version = "0.0.2"
 
 [autocorrect]
 submodule = "extensions/autocorrect"
-version = "0.1.0"
+version = "0.1.1"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"


### PR DESCRIPTION
Release notes:

https://github.com/huacnlee/zed-autocorrect/releases/tag/v0.1.1