### PR TITLE
Update toml to v0.1.5 and deprecate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2510,6 +2510,10 @@
 	path = extensions/tombi
 	url = https://github.com/tombi-toml/tombi.git
 
+[submodule "extensions/toml"]
+	path = extensions/toml
+	url = https://github.com/tyranron/toml-zed-extension
+
 [submodule "extensions/tomorrow-min-theme"]
 	path = extensions/tomorrow-min-theme
 	url = https://github.com/biaqat/tomorrow-min-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2551,9 +2551,8 @@ path = "editors/zed"
 version = "0.1.9"
 
 [toml]
-submodule = "extensions/zed"
-path = "extensions/toml"
-version = "0.1.4"
+submodule = "extensions/toml"
+version = "0.1.5"
 
 [tomorrow-min-theme]
 submodule = "extensions/tomorrow-min-theme"


### PR DESCRIPTION
Part of zed-industries/zed#36766


## Context

In https://github.com/zed-industries/zed/issues/36766#issuecomment-3250365614 discussion, it was decided to deprecate the official `toml` extension by moving it into a separate archived repository and update its description.

> given that Taplo is unmaintained, and there is a well-maintained Tombi extension out there already, the course of actions seems to be the following:
> 1. PR to `zed-industries/zed` with changing [the suggested extension for TOML](https://github.com/zed-industries/zed/blob/v0.202.6/crates/extensions_ui/src/extension_suggest.rs#L73) to `tombi` and updating [the doc](https://github.com/zed-industries/zed/blob/v0.202.6/docs/src/languages/toml.md) properly.
> 2. PR to `zed-industries/zed` with marking `toml` extension as deprecated and bumping its version.
> 3. PR to `zed-industries/extensions` updating `toml` extension.
>  4. Eventually, PR to `zed-industries/extensions` removing `toml` extension.
>  5. PR to `zed-industries/zed` removing `toml` extension's crate and sources.

> I'd start by moving that way from `/zed` into `/extensions` repo first; adding a clear indication that it's deprecated along the way would be nice too.

> We can do something like https://github.com/zed-extensions/perplexity but for that, we need to create some repo first.
> I do not want to do this task myself, but happy to fork your repository that has all the bits extracted (if you do not want to keep that deemed-to-be-stale repo under your profile) or just link to yours.


## Solution

This is the first step, moving the [official Zed extension for TOML](https://github.com/zed-industries/zed/tree/05fc0c432c024596e68ac5223c556d2a642ff135/extensions/toml) to the https://github.com/tyranron/toml-zed-extension repository.

Once it's reviewed and this PR is merged, the https://github.com/tyranron/toml-zed-extension repository will be archived.