### PR TITLE
elixir: Bump to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -667,7 +667,7 @@ version = "0.0.4"
 
 [elixir]
 submodule = "extensions/elixir"
-version = "0.2.1"
+version = "0.2.2"
 
 [elle]
 submodule = "extensions/elle"


### PR DESCRIPTION
This PR updates the Elixir extension to v0.2.2.

Includes:

- https://github.com/zed-extensions/elixir/pull/19
- https://github.com/zed-extensions/elixir/pull/34