### PR TITLE
Update CQL Extension to v1.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -460,7 +460,7 @@ version = "0.1.0"
 
 [cql]
 submodule = "extensions/cql"
-version = "1.0.1"
+version = "1.0.2"
 
 [crates-lsp]
 submodule = "extensions/crates-lsp"


### PR DESCRIPTION
### PR Summary 

- Added some compiler optimizations to reduce wasm binary size (opt-level 3 | 223312 -> 173915)
- Changed extension version from 1.0.1 to 1.0.2

| opt-level | Binary Size |
|:-----------:|:---------------:|
|  none   |   223312     |
|  3   |    173915    |
|  s   |   158275     |