### PR TITLE
snippets: Bump to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2306,7 +2306,7 @@ version = "0.1.0"
 [snippets]
 submodule = "extensions/zed"
 path = "extensions/snippets"
-version = "0.0.5"
+version = "0.0.6"
 
 [snow-fox-theme]
 submodule = "extensions/snow-fox-theme"


### PR DESCRIPTION
This PR updates the Snippets extension to v0.0.6.

See https://github.com/zed-industries/zed/pull/37567 for the changes in this version.