### PR TITLE
Add an extension to include zuban as a python language server.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2902,6 +2902,10 @@
 	path = extensions/zoegi-theme
 	url = https://github.com/nikitapashinsky/zoegi-theme.git
 
+[submodule "extensions/zuban"]
+	path = extensions/zuban
+	url = https://github.com/CMLL/zed_zuban.git
+
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2939,6 +2939,10 @@ version = "0.0.1"
 submodule = "extensions/zoegi-theme"
 version = "0.4.2"
 
+[zuban]
+submodule = "extensions/zuban"
+version = "0.0.1"
+
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.1.0"


### PR DESCRIPTION
Adds support for Zuban as a language server for Python. https://zubanls.com/