### PR TITLE
php: Bump to v0.4.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1950,7 +1950,7 @@ version = "0.0.2"
 
 [php]
 submodule = "extensions/php"
-version = "0.4.1"
+version = "0.4.2"
 
 [phpcs]
 submodule = "extensions/phpcs"


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/37683

This PR updates the PHP extension to v0.4.2.

Includes:

- https://github.com/zed-extensions/php/pull/40
- https://github.com/zed-extensions/php/pull/48
- https://github.com/zed-extensions/php/pull/49
