### PR TITLE
Update Zoegi theme to v0.4.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2937,7 +2937,7 @@ version = "0.0.1"
 
 [zoegi-theme]
 submodule = "extensions/zoegi-theme"
-version = "0.4.2"
+version = "0.4.3"
 
 [zwirn]
 submodule = "extensions/zwirn"


### PR DESCRIPTION
- Changed `background` to an opaque color to fix the issue with startup screen on Windows
- Changed all color values to `#rrggbbaa` format (easier to notice opaque colors by `ff` at the end, + consistent with default Zed themes)
- Added `background.appearance: "opaque"`