### PR TITLE
Update Julia to v0.1.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1181,7 +1181,7 @@ version = "0.1.0"
 
 [julia]
 submodule = "extensions/julia"
-version = "0.1.7"
+version = "0.1.8"
 
 [just]
 submodule = "extensions/just"


### PR DESCRIPTION
Fix docstring highlighting for Zed 0.204+

Use `markdown-inline` instead of `markdown` for docstring injection.