### PR TITLE
Add universal ctags lsp support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -498,6 +498,10 @@
 	path = extensions/csv
 	url = https://github.com/huacnlee/zed-csv.git
 
+[submodule "extensions/ctags"]
+	path = extensions/ctags
+	url = https://github.com/mazurel/zed-ctags.git
+
 [submodule "extensions/cucumber"]
 	path = extensions/cucumber
 	url = https://github.com/thlcodes/zed-extension-cucumber

--- a/extensions.toml
+++ b/extensions.toml
@@ -503,6 +503,10 @@ path = "crates/zed"
 submodule = "extensions/csv"
 version = "0.0.3"
 
+[ctags]
+submodule = "extensions/ctags"
+version = "0.0.1"
+
 [cucumber]
 submodule = "extensions/cucumber"
 version = "0.0.2"


### PR DESCRIPTION
This extension adds `ctags-lsp` language server to the Zed editor. User can override any language and set it as a language server, to use it. It can be useful on big, especially legacy, projects :)

It was also requested in #2819

- Extension: https://github.com/Mazurel/zed-ctags
- Ctags LSP: https://github.com/netmute/ctags-lsp
- Ctags: https://github.com/universal-ctags/ctags