### PR TITLE
Update catppuccin-icons to v1.22.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -334,7 +334,7 @@ version = "0.1.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
-version = "1.21.0"
+version = "1.22.0"
 
 [cedar]
 submodule = "extensions/cedar"


### PR DESCRIPTION
Release notes:

https://github.com/catppuccin/zed-icons/releases/tag/v1.22.0