### PR TITLE
Add PostCrawl MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1986,6 +1986,10 @@
 	path = extensions/pollinations-mcp
 	url = https://github.com/FrancoStino/pollinations-mcp.git
 
+[submodule "extensions/postcrawl-mcp"]
+	path = extensions/postcrawl-mcp
+	url = https://github.com/post-crawl/mcp-zed.git
+
 [submodule "extensions/postgres-context-server"]
 	path = extensions/postgres-context-server
 	url = https://github.com/zed-extensions/postgres-context-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2008,6 +2008,10 @@ version = "0.8.1"
 submodule = "extensions/pollinations-mcp"
 version = "1.0.4"
 
+[postcrawl-mcp]
+submodule = "extensions/postcrawl-mcp"
+version = "0.0.1"
+
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
 version = "0.0.4"


### PR DESCRIPTION
## Summary
- Adds the PostCrawl MCP extension as a Git submodule
- Updates extensions.toml with the new extension entry
- Extension provides Reddit & TikTok content extraction tools

## Extension Details
- **ID**: `postcrawl-mcp`
- **Name**: PostCrawl MCP Server - Reddit & TikTok
- **Version**: 0.0.1
- **Repository**: https://github.com/post-crawl/mcp-zed
- **Description**: Model Context Protocol Server for PostCrawl - Reddit & TikTok Content Extraction

This extension enables Zed users to leverage PostCrawl's content extraction capabilities for Reddit and TikTok through the Model Context Protocol.

## Features
- **search**: Search for posts across Reddit and TikTok
- **search_and_extract**: Search and extract content in a single operation
- **extract**: Extract content from specific Reddit and TikTok URLs
- **check_health**: Check PostCrawl API health status

## Links
- Extension: https://github.com/post-crawl/mcp-zed
- MCP Server: https://postcrawl.com/mcp
- Documentation: https://edge.postcrawl.com/api-reference