### PR TITLE
material-icon-theme: Bump to v1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1369,7 +1369,7 @@ version = "0.0.3"
 
 [material-icon-theme]
 submodule = "extensions/material-icon-theme"
-version = "1.0.0"
+version = "1.1.0"
 
 [material-theme]
 submodule = "extensions/material-theme"


### PR DESCRIPTION
This PR updates the material-icon-theme extension to v1.1.0.