### PR TITLE
Update catppuccin-blur to v0.3.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -326,7 +326,7 @@ version = "0.2.23"
 
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"
-version = "0.3.1"
+version = "0.3.2"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"


### PR DESCRIPTION
Release notes:

https://github.com/jenslys/zed-catppuccin-blur/releases/tag/v0.3.2