### PR TITLE
remove basedpyright

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -182,10 +182,6 @@
 	path = extensions/base16
 	url = https://github.com/bswinnerton/base16-zed.git
 
-[submodule "extensions/basedpyright"]
-	path = extensions/basedpyright
-	url = https://github.com/m1guer/basedpyright-zed.git
-
 [submodule "extensions/basher"]
 	path = extensions/basher
 	url = https://github.com/zed-extensions/bash.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -184,10 +184,6 @@ version = "1.3.1"
 submodule = "extensions/base16"
 version = "0.1.2"
 
-[basedpyright]
-submodule = "extensions/basedpyright"
-version = "0.1.3"
-
 [basher]
 submodule = "extensions/basher"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -126,7 +126,7 @@ version = "0.1.1"
 
 [basedpyright]
 submodule = "extensions/basedpyright"
-version = "0.1.2"
+version = "0.1.3"
 
 [basher]
 submodule = "extensions/basher"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1641,7 +1641,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "0.0.1"
+version = "0.0.2"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -126,7 +126,7 @@ version = "0.1.1"
 
 [basedpyright]
 submodule = "extensions/basedpyright"
-version = "0.1.1"
+version = "0.1.2"
 
 [basher]
 submodule = "extensions/basher"


### PR DESCRIPTION
Looks like the BasedPyright extension is no longer necessary, so I will remove it.