### PR TITLE
Add Monokai Pro Spectrum theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1534,6 +1534,10 @@
 	path = extensions/monokai-og
 	url = https://github.com/sidwachche/monokai-og-zed.git
 
+[submodule "extensions/zed-monokai-pro-spectrum"]
+	path = extensions/zed-monokai-pro-spectrum
+	url = https://github.com/nh4tl4/zed-monokai-pro-spectrum.git
+
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1555,6 +1555,10 @@ version = "0.2.2"
 submodule = "extensions/monokai-og"
 version = "0.1.0"
 
+[monokai-pro-spectrum]
+submodule = "extensions/zed-monokai-pro-spectrum"
+version = "0.1.0"
+
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

This PR adds the Monokai Pro Spectrum theme extension to the Zed extensions registry.

## Extension Details

- **Name**: Monokai Pro Spectrum
- **ID**: monokai-pro-spectrum
- **Version**: 0.1.0
- **Repository**: https://github.com/nh4tl4/zed-monokai-pro-spectrum
- **Author**: nh4tl4

## Description

A beautiful dark theme with vibrant colors optimized for coding, featuring a JetBrains-style color scheme. This extension provides:

- Monokai Pro Spectrum theme variant
- Monokai Pro Classic theme variant
- High contrast and readability
- Vibrant syntax highlighting
- Optimized for long coding sessions

## Theme Preview

The theme provides excellent syntax highlighting for various programming languages with carefully chosen colors that reduce eye strain while maintaining good contrast and readability.
![8BE2B990-3CC3-4BC8-8710-C3C436338FCB](https://github.com/user-attachments/assets/b6d3d50c-83b6-4c0f-a1d0-67735ea62182)


## Files Changed

- `extensions.toml`: Added extension entry
- `.gitmodules`: Added submodule reference
- `extensions/zed-monokai-pro-spectrum`: Added as git submodule

## Checklist

- [x] Extension follows Zed extension guidelines
- [x] Repository is public and accessible
- [x] Extension has proper `extension.toml` configuration
- [x] Themes are properly formatted JSON files
- [x] Added to extensions registry in alphabetical order