### PR TITLE
Update Ruby to v0.13.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2259,7 +2259,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.13.2"
+version = "0.13.3"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This pull request updates the Ruby extension to v0.13.3. You can find the release notes [here](https://github.com/zed-extensions/ruby/releases/tag/v0.13.3). Thank you!