### PR TITLE
Update Stylelint to v1.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2486,7 +2486,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "1.0.1"
+version = "1.0.2"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"


### PR DESCRIPTION
Now that `0.205.4` is stable, I've merged the PR that bumps the `zed_extension_api` to improve Windows compatibility.

This version only contains this change:
https://github.com/florian-sanders/zed-stylelint/releases/tag/1.0.2