### PR TITLE
Update jetbrains-themes to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1185,7 +1185,7 @@ version = "0.0.2"
 
 [jetbrains-themes]
 submodule = "extensions/jetbrains-themes"
-version = "0.1.0"
+version = "0.1.1"
 
 [jinja2]
 submodule = "extensions/jinja2"


### PR DESCRIPTION
Fix inlay hints using status theming instead of syntax theming:
https://github.com/zed-industries/zed/pull/36219

Since using Zed: v0.207.0 (Zed Nightly bcc8149), the hint color is incorrect

https://github.com/artemevsevev/zed-theme-jetbrains/pull/5

