### PR TITLE
Update markdownlint to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1397,7 +1397,7 @@ version = "0.0.4"
 
 [markdownlint]
 submodule = "extensions/markdownlint"
-version = "0.1.2"
+version = "0.3.0"
 
 [marksman]
 submodule = "extensions/marksman"


### PR DESCRIPTION
Hi! This pull request updates the `markdownlint` extension to v0.3.0. You can find the release notes [here](https://github.com/vitallium/zed-markdownlint/releases/tag/v0.3.0). Thanks!