### PR TITLE
Update marksman to v0.1.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1409,7 +1409,7 @@ version = "0.1.2"
 
 [marksman]
 submodule = "extensions/marksman"
-version = "0.0.6"
+version = "0.1.6"
 
 [martianized]
 submodule = "extensions/martianized"


### PR DESCRIPTION
Release notes:

https://github.com/vitallium/zed-marksman/releases/tag/v0.1.6