### PR TITLE
prisma: Bump to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2098,7 +2098,7 @@ version = "0.3.0"
 
 [prisma]
 submodule = "extensions/prisma"
-version = "0.1.2"
+version = "0.1.3"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"


### PR DESCRIPTION
This PR bumps the version of the Prisma extension to 0.1.3.

Includes: 

- https://github.com/zed-extensions/prisma/pull/14