### PR TITLE
Update monospace-icon-theme to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1637,7 +1637,7 @@ version = "0.1.3"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [monospace-theme]
 submodule = "extensions/monospace-theme"


### PR DESCRIPTION
Release notes:

https://github.com/irmhonde/monospace-icon-theme/releases/tag/v0.1.4