### PR TITLE
Update liquid to v0.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1321,7 +1321,7 @@ version = "0.0.9"
 
 [liquid]
 submodule = "extensions/liquid"
-version = "0.4.0"
+version = "0.5.0"
 
 [liquid-snippets]
 submodule = "extensions/liquid-snippets"


### PR DESCRIPTION
Release notes:

https://github.com/TheBeyondGroup/zed-shopify-liquid/releases/tag/v0.5.0