### PR TITLE
Defer license validation until after other validations

### DIFF
--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -140,9 +140,6 @@ async function packageExtension(
   extensionVersion,
   shouldPublish,
 ) {
-  const extensionFiles = await readExtensionFiles(extensionPath);
-  validateLicense(extensionFiles);
-
   const outputDir = "output";
 
   const SCRATCH_DIR = "./scratch";
@@ -169,6 +166,9 @@ async function packageExtension(
       );
     }
   }
+
+  const extensionFiles = await readExtensionFiles(extensionPath);
+  validateLicense(extensionFiles);
 
   const zedExtensionOutput = await exec(
     "./zed-extension",


### PR DESCRIPTION
This PR defers the license validation added in #3460 until after we've validated the other parts of the extension.