### PR TITLE
Update `prisma-mcp` to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2106,7 +2106,7 @@ version = "0.1.3"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"
-version = "0.1.0"
+version = "0.2.0"
 
 [probe-rs]
 submodule = "extensions/probe-rs"


### PR DESCRIPTION
Update `prisma-mcp` to v0.2.0 for Windows support.

Release notes: https://github.com/aqrln/prisma-mcp-zed/releases/tag/v0.2.0

Ref: https://github.com/zed-industries/extensions/issues/3350
