### PR TITLE
Update mcp-server-shopify-dev to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1533,7 +1533,7 @@ version = "0.0.3"
 
 [mcp-server-shopify-dev]
 submodule = "extensions/mcp-server-shopify-dev"
-version = "0.0.1"
+version = "0.1.0"
 
 [mcp-server-shortcut]
 submodule = "extensions/mcp-server-shortcut"


### PR DESCRIPTION
Release notes:

https://github.com/TheBeyondGroup/zed-mcp-server-shopify-dev/releases/tag/v0.1.0