### PR TITLE
Update mcp-server-webflow to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1561,7 +1561,7 @@ version = "1.0.1"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
-version = "0.0.2"
+version = "0.1.0"
 
 [mdx]
 submodule = "extensions/mdx"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-webflow/releases/tag/v0.1.0