### PR TITLE
Update mcp-server-sequential-thinking to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1529,7 +1529,7 @@ version = "0.1.0"
 
 [mcp-server-sequential-thinking]
 submodule = "extensions/mcp-server-sequential-thinking"
-version = "0.0.3"
+version = "0.1.0"
 
 [mcp-server-shopify-dev]
 submodule = "extensions/mcp-server-shopify-dev"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-sequential-thinking/releases/tag/v0.1.0