### PR TITLE
Update mcp-server-linear to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1501,7 +1501,7 @@ version = "0.1.1"
 
 [mcp-server-linear]
 submodule = "extensions/mcp-server-linear"
-version = "0.0.1"
+version = "0.1.0"
 
 [mcp-server-markitdown]
 submodule = "extensions/mcp-server-markitdown"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-linear/releases/tag/v0.1.0