### PR TITLE
Update mcp-server-github to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1489,7 +1489,7 @@ version = "0.0.4"
 
 [mcp-server-github]
 submodule = "extensions/mcp-server-github"
-version = "0.0.4"
+version = "0.1.0"
 
 [mcp-server-gitlab]
 submodule = "extensions/mcp-server-gitlab"


### PR DESCRIPTION
Release notes:

https://github.com/LoamStudios/zed-mcp-server-github/releases/tag/v0.1.0