### PR TITLE
Cache test license content for subsequent test runs

### DIFF
--- a/src/lib/test-licenses/utilities.js
+++ b/src/lib/test-licenses/utilities.js
@@ -2,20 +2,38 @@ import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
 
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 export function readMitLicense() {
-  return fs.readFileSync(path.join(__dirname, "test-mit-license"), "utf-8");
+  return readLicenseFile("test-mit-license");
 }
 
 export function readApache2License() {
-  return fs.readFileSync(
-    path.join(__dirname, "test-apache-2-license"),
-    "utf-8",
-  );
+  return readLicenseFile("test-apache-2-license");
 }
 
 export function readGplV3License() {
-  return fs.readFileSync(path.join(__dirname, "test-gpl-v3-license"), "utf-8");
+  return readLicenseFile("test-gpl-v3-license");
+}
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/** @type {Map<string, string>} */
+const licenseCache = new Map();
+
+/**
+ * Reads a license file from the current directory, using a cache to avoid redundant reads.
+ * @param {string} fileName - The name of the license file to read
+ * @returns {string} The content of the license file
+ */
+function readLicenseFile(fileName) {
+  let content = licenseCache.get(fileName);
+
+  if (content) {
+    return content;
+  }
+
+  content = fs.readFileSync(path.join(__dirname, fileName), "utf-8");
+  licenseCache.set(fileName, content);
+
+  return content;
 }


### PR DESCRIPTION
This is likely not that big of a deal, but I wanted to cache this test license content so that subsequent tests within the same test module wouldn't need to open and read from these files again.

We could inline these sample licenses, but mixing that large of content into source code feels bad, so I used separate files.