### PR TITLE
ocaml: Bump to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1854,7 +1854,7 @@ version = "1.1.0"
 
 [ocaml]
 submodule = "extensions/ocaml"
-version = "0.1.4"
+version = "0.1.5"
 
 [ocean-dark-motifs]
 submodule = "extensions/ocean-dark-motifs"


### PR DESCRIPTION
This PR bumps the version of the Ocaml extension to 0.1.5.

Includes: 
- https://github.com/zed-extensions/ocaml/pull/14
- https://github.com/zed-extensions/ocaml/pull/12