### PR TITLE
prisma: Bump to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2102,7 +2102,7 @@ version = "0.3.0"
 
 [prisma]
 submodule = "extensions/prisma"
-version = "0.1.3"
+version = "0.1.4"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"


### PR DESCRIPTION
This PR bumps the version of the Prisma extension to 0.1.4.

Includes:
- https://github.com/zed-extensions/prisma/pull/16