### PR TITLE
java: Bump to v6.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1161,7 +1161,7 @@ version = "0.0.1"
 
 [java]
 submodule = "extensions/java"
-version = "6.4.1"
+version = "6.5.0"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"


### PR DESCRIPTION
This PR bump the version of the Java extension to 6.5.0.

Includes: 

- https://github.com/zed-extensions/java/pull/79
- https://github.com/zed-extensions/java/pull/84
- https://github.com/zed-extensions/java/pull/85
- https://github.com/zed-extensions/java/pull/87