### PR TITLE
astro: Bump to v0.1.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -121,7 +121,7 @@ version = "0.0.1"
 
 [astro]
 submodule = "extensions/astro"
-version = "0.1.7"
+version = "0.1.8"
 
 [atomize]
 submodule = "extensions/atomize"


### PR DESCRIPTION
This PR bumps the version of the Astro extension to 0.1.8.

Includes: 
- https://github.com/zed-extensions/astro/pull/13
- https://github.com/zed-extensions/astro/pull/15
