### PR TITLE
Update Ruby to v0.13.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2279,7 +2279,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.13.4"
+version = "0.13.5"
 
 [ruff]
 submodule = "extensions/zed"


### PR DESCRIPTION
Hi! This pull request updates the Ruby extension to v0.13.5. You can find release notes on [the release page](https://github.com/zed-extensions/ruby/releases/tag/v0.13.5). Thank you!