### PR TITLE
Allow smart quotes in MIT licenses

### DIFF
--- a/src/lib/license.js
+++ b/src/lib/license.js
@@ -99,7 +99,7 @@ const MIT_REQUIRED_PATTERNS = [
   /Copyright/i,
   /Permission is hereby granted, free of charge, to any person obtaining a copy/i,
   /The above copyright notice and this permission notice shall be included in all/i,
-  /THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR/i,
+  /THE SOFTWARE IS PROVIDED ["“]AS IS["”], WITHOUT WARRANTY OF ANY KIND, EXPRESS OR/i,
 ];
 
 /**

--- a/src/lib/license.test.js
+++ b/src/lib/license.test.js
@@ -10,6 +10,7 @@ import {
   readApache2License,
   readBsd3ClauseLicense,
   readGplV3License,
+  readLicenseFile,
   readMitLicense,
   readOtherLicense,
 } from "./test-licenses/utilities.js";
@@ -134,6 +135,12 @@ describe("isGPLv3License", () => {
 describe("isMitLicense", () => {
   it("returns true for valid MIT license text", () => {
     expect(isMitLicense(readMitLicense())).toBe(true);
+  });
+
+  it("returns true for valid MIT license text using smart quotes", () => {
+    expect(
+      isMitLicense(readLicenseFile("test-mit-license-with-smart-quotes")),
+    ).toBe(true);
   });
 
   it("returns false for Apache 2.0 license text", () => {

--- a/src/lib/test-licenses/test-mit-license-with-smart-quotes
+++ b/src/lib/test-licenses/test-mit-license-with-smart-quotes
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Joseph Lyons <joseph@zed.dev>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/lib/test-licenses/utilities.js
+++ b/src/lib/test-licenses/utilities.js
@@ -33,7 +33,7 @@ const licenseCache = new Map();
  * @param {string} fileName - The name of the license file to read
  * @returns {string} The content of the license file
  */
-function readLicenseFile(fileName) {
+export function readLicenseFile(fileName) {
   let content = licenseCache.get(fileName);
 
   if (content) {


### PR DESCRIPTION
This PR makes it so we accept MIT licenses with smart quotes in them.