### PR TITLE
Don't require a header for MIT licenses

### DIFF
--- a/src/lib/license.js
+++ b/src/lib/license.js
@@ -95,7 +95,6 @@ export function isGplV3License(licenseContent) {
 }
 
 const MIT_REQUIRED_PATTERNS = [
-  /MIT License/i,
   /Copyright/i,
   /Permission is hereby granted, free of charge, to any person obtaining a copy/i,
   /The above copyright notice and this permission notice shall be included in all/i,


### PR DESCRIPTION
This PR removes the requirement of having the `MIT License` header for MIT licenses.

This doesn't appear to be mandatory based on https://opensource.org/license/mit.