### PR TITLE
Allow newline in a different spot in MIT license

### DIFF
--- a/src/lib/license.js
+++ b/src/lib/license.js
@@ -97,7 +97,7 @@ export function isGplV3License(licenseContent) {
 const MIT_REQUIRED_PATTERNS = [
   /Copyright/i,
   /Permission is hereby granted, free of charge, to any person obtaining a copy/i,
-  /The above copyright notice and this permission notice shall be included in all/i,
+  /The above copyright notice and this permission notice shall be included in[ \n]all/i,
   /THE SOFTWARE IS PROVIDED ["“]AS IS["”], WITHOUT WARRANTY OF ANY KIND, EXPRESS OR/i,
 ];
 


### PR DESCRIPTION
This PR updates the MIT license validation to account for a line being wrapped earlier.