### PR TITLE
Update VS Code Icons repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3036,7 +3036,7 @@
 
 [submodule "extensions/vscode-icons"]
 	path = extensions/vscode-icons
-	url = https://github.com/vscode-icons/vcode-icons-zed.git
+	url = https://github.com/vscode-icons/vscode-icons-zed.git
 
 [submodule "extensions/vscode-light-plus"]
 	path = extensions/vscode-light-plus


### PR DESCRIPTION
I realized the URL of the repo was wrong. It's working because Github keeps the redirection. In any case, I think it is better to correct it.