### PR TITLE
Update extension CLI sha to get Agent Servers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: 332626e5825564e97afc969292c90d9b0fb40b6d
+  ZED_EXTENSION_CLI_SHA: 7cfce605704d41ca247e3f84804bf323f6c6caaf
 
 jobs:
   package:


### PR DESCRIPTION
The previous CLI did not have access to the new Agent Servers stuff, which means that https://github.com/zed-industries/extensions/pull/3716 got published with all that metadata getting stripped out - leading to the behavior that the local dev extension works, but the official one does not. 😅 

To fix that, after landing this PR we'll need to ask the Opencode folks to bump that extension to 0.1.1 just to trigger a fresh publish with the updated CLI.