### PR TITLE
Update markdownlint version to v0.6.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1657,7 +1657,7 @@ version = "0.0.5"
 
 [markdownlint]
 submodule = "extensions/markdownlint"
-version = "0.4.0"
+version = "0.6.0"
 
 [marksman]
 submodule = "extensions/marksman"


### PR DESCRIPTION
https://github.com/vitallium/markdownlint-lsp/releases/tag/v0.6.0