### PR TITLE
Improve detection of changed extensions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Package extensions
         run: pnpm package-extensions
         env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           SHOULD_PUBLISH: ${{ github.ref_name == 'main' }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
           S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}

--- a/src/package-extensions.js
+++ b/src/package-extensions.js
@@ -23,6 +23,7 @@ import {
 } from "./lib/validation.js";
 
 const {
+  BRANCH_HEAD_SHA,
   S3_ACCESS_KEY,
   S3_SECRET_KEY,
   S3_BUCKET,
@@ -48,6 +49,10 @@ ENVIRONMENT VARIABLES
   S3_BUCKET         Name of the bucket where extensions are published
   SHOULD_PUBLISH    Whether to publish packages to the blob store.
                     Set this to "true" to publish the packages.
+  BRANCH_HEAD_SHA   SHA of the branch head commit. This is used to
+                    determine the changed extensions. If this is not
+                    set, the changes will be determined based on the
+                    extensions.toml of the main branch.
 `;
 
 let selectedExtensionId;
@@ -97,7 +102,7 @@ try {
 
   const extensionIds = shouldPublish
     ? await unpublishedExtensionIds(extensionsToml)
-    : await changedExtensionIds(extensionsToml);
+    : await changedExtensionIds(extensionsToml, BRANCH_HEAD_SHA);
 
   for (const extensionId of extensionIds) {
     if (selectedExtensionId && extensionId !== selectedExtensionId) {
@@ -296,11 +301,14 @@ async function unpublishedExtensionIds(extensionsToml) {
 
 /**
  * @param {Record<string, any>} extensionsToml
+ * @param {string | undefined} compareSha
  */
-async function changedExtensionIds(extensionsToml) {
+async function changedExtensionIds(extensionsToml, compareSha) {
   const { stdout: extensionsContents } = await exec("git", [
     "show",
-    "origin/main:extensions.toml",
+    compareSha
+      ? `${compareSha}:extensions.toml`
+      : "origin/main:extensions.toml",
   ]);
   /** @type {any} */
   const mainExtensionsToml = toml.parse(extensionsContents);


### PR DESCRIPTION
This improves the detection of changed extensions for a given PR and reduces the rate of false negatives on PRs due to changes present on main. 

With this, merging main into PRs will not be needed anymore (hopefully). This will also improve CI-times, as we will only package actually changed extensions. 