### PR TITLE
Add modern-vesper extension to extensions.toml

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2514,6 +2514,10 @@ version = "0.0.1"
 submodule = "extensions/rich-vesper"
 version = "0.0.5"
 
+[modern-vesper]
+submodule = "extensions/modern-vesper"
+version = "1.0.4"
+
 [risor]
 submodule = "extensions/risor"
 version = "0.0.2"


### PR DESCRIPTION
This pull request adds a new extension entry to the `extensions.toml` configuration file.

Extension configuration update:

* Added a new `[modern-vesper]` section with `submodule = "extensions/modern-vesper"` and `version = "1.0.4"` to the `extensions.toml` file.