### PR TITLE
Add Obscion theme extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2143,6 +2143,10 @@ version = "0.0.4"
 submodule = "extensions/objectscript"
 version = "1.1.0"
 
+[obscion]
+version = "0.0.1"
+repository = "https://github.com/heyobscion/Obscion-for-Zed"
+
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"


### PR DESCRIPTION
   Adding Obscion - a collection of 10 warm, vibrant themes for Zed.
   
   Includes both dark and light variants with unique color palettes.
   
   Repository: https://github.com/heyobscion/Obscion-for-Zed