### PR TITLE
Bump extension CLI version to `7cfce60`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: 7cfce605704d41ca247e3f84804bf323f6c6caaf
+  ZED_EXTENSION_CLI_SHA: bb591f1e653a492c2d6c85353181e5151dbf8ac7
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to https://github.com/zed-industries/zed/commit/bb591f1e653a492c2d6c85353181e5151dbf8ac7.

This fixes snippets files not being bundled with extensions in some more cases.