### PR TITLE
Update extensions/just to 0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1436,7 +1436,7 @@
 
 [submodule "extensions/just"]
 	path = extensions/just
-	url = https://github.com/jackTabsCode/zed-just.git
+	url = https://github.com/mattrobenolt/zed-just.git
 
 [submodule "extensions/just-ls"]
 	path = extensions/just-ls

--- a/extensions.toml
+++ b/extensions.toml
@@ -1459,7 +1459,7 @@ version = "0.1.8"
 
 [just]
 submodule = "extensions/just"
-version = "0.1.4"
+version = "0.2.0"
 
 [just-ls]
 submodule = "extensions/just-ls"


### PR DESCRIPTION
Replace unmainted version with my fork.

Refs: https://github.com/jackTabsCode/zed-just/commit/b06fe9ca5e6e1cd846be271b38024b5ff71188c7

My fork also adds in LSP support, which was something I think should be bundled together in addition to syntax highlighting.

cc @jackTabsCode if you have any opinions or thoughts on this? I'm happy to take over.