### PR TITLE
Add ZX extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3505,3 +3505,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/zx"]
+	path = extensions/zx
+	url = https://github.com/nurulhudaapon/zx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3574,4 +3574,4 @@ version = "0.1.0"
 [zx]
 submodule = "extensions/zx"
 path = "editors/zed"
-version = "0.1.0-dev.364"
+version = "0.1.0-dev.366"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3555,4 +3555,4 @@ version = "0.1.0"
 [zx]
 submodule = "extensions/zx"
 path = "editors/zed"
-version = "0.0.1-dev.289"
+version = "0.1.0-dev.364"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3551,3 +3551,8 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.1.0"
+
+[zx]
+submodule = "extensions/zx"
+path = "editors/zed"
+version = "0.0.1-dev.289"


### PR DESCRIPTION
This extension add support for `.zx` file. `.zx` file is an extension to Zig language file with support for HTML like syntax. The extension currently provides syntax highlighting and LSP support using ZLS.

Repository: https://github.com/nurulhudaapon/zx

<img width="1329" height="866" alt="image" src="https://github.com/user-attachments/assets/39066059-ff1c-4b18-8e3e-93ca3e5548dc" />
