### PR TITLE
ci: Add merge queue trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - "main"


### PR DESCRIPTION
This PR adds a merge queue trigger to the CI workflow in order to support merge queues.