### PR TITLE
Add Bio Pype LSP extension

### DIFF
--- a/extensions/bio-pype-lsp/Cargo.toml
+++ b/extensions/bio-pype-lsp/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bio-pype-lsp"
+version = "0.1.0"
+edition = "2021"
+description = "Bio Pype LSP support for Zed"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.7"
+serde_json = "1.0"

--- a/extensions/bio-pype-lsp/LICENSE
+++ b/extensions/bio-pype-lsp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Francesco Favero
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/extensions/bio-pype-lsp/README.md
+++ b/extensions/bio-pype-lsp/README.md
@@ -1,0 +1,56 @@
+# Bio Pype LSP Extension for Zed
+
+Language Server Protocol support for Bio Pype in Markdown and YAML files.
+
+## Installation
+
+Install bio-pype:
+```bash
+pip install --user bio-pype
+```
+
+Install this extension in Zed, then open a Markdown or YAML file.
+
+## Configuration
+
+### Automatic (Recommended)
+
+If `pype` is in your PATH, the extension works automatically with no configuration needed.
+
+### Custom Path
+
+For custom installations (e.g., virtual environments), add to your settings:
+
+```json
+{
+  "lsp": {
+    "bio-pype": {
+      "binary": {
+        "path": "/path/to/venv/bin/pype",
+        "arguments": ["validate", "lsp", "--stdio"]
+      }
+    }
+  }
+}
+```
+
+**Note:** When configuring a custom path, you must include both `path` and `arguments`.
+
+## Troubleshooting
+
+**LSP not starting?**
+
+Check that pype is installed and accessible:
+```bash
+pype --version
+pype validate lsp --stdio  # Should wait for input (Ctrl+C to exit)
+```
+
+## Links
+
+- [Bio Pype](https://bitbucket.org/ffavero/bio_pype)
+- [Extension Source](https://github.com/compute-bio/zed-pype-lsp)
+
+## License
+
+MIT License - see [LICENSE](LICENSE)

--- a/extensions/bio-pype-lsp/extension.toml
+++ b/extensions/bio-pype-lsp/extension.toml
@@ -1,0 +1,11 @@
+id = "bio-pype-lsp"
+name = "Bio Pype LSP"
+version = "0.1.0"
+schema_version = 1
+description = "Language Server Protocol support for Bio Pype in Markdown and YAML files"
+authors = ["Francesco Favero"]
+repository = "https://github.com/compute-bio/zed-pype-lsp"
+homepage = "https://github.com/compute-bio/zed-pype-lsp"
+
+[language_servers.bio-pype]
+languages = ["Markdown", "YAML"]

--- a/extensions/bio-pype-lsp/src/lib.rs
+++ b/extensions/bio-pype-lsp/src/lib.rs
@@ -1,0 +1,31 @@
+use zed_extension_api as zed;
+
+pub struct BioPypeExtension;
+
+impl zed::Extension for BioPypeExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> zed::Result<zed::Command> {
+        let pype_path = worktree
+            .which("pype")
+            .ok_or_else(|| "pype not found in PATH. Install with: pip install --user bio-pype".to_string())?;
+
+        Ok(zed::Command {
+            command: pype_path,
+            args: vec![
+                "validate".to_string(),
+                "lsp".to_string(),
+                "--stdio".to_string(),
+            ],
+            env: Default::default(),
+        })
+    }
+}
+
+zed::register_extension!(BioPypeExtension);


### PR DESCRIPTION
Bio_pype is a framework for building computing workflows, primarily used in bioinformatics. It consists of three core structural modules that connect and execute tasks:

Profiles: YAML definitions of reference files (genomes, annotations) and programs, specifying versions and execution contexts (Docker, Singularity, environment modules, etc.)
Snippets: Markdown files describing individual tasks, leveraging profiles to ensure correct environment setup and appropriate annotation file versions
Pipelines: YAML files defining a directed acyclic graph (DAG) that orchestrates snippet execution in the proper order

This Zed extension leverages bio_pype's internal validation framework and LSP server to provide IDE support for snippet markdown, pipeline, and profile YAML files. It includes:
Autocompletion

<img width="885" height="415" alt="image" src="https://github.com/user-attachments/assets/58459ffa-b841-4c70-97a8-b3909aba4b6a" />


Hover information

<img width="612" height="440" alt="image" src="https://github.com/user-attachments/assets/6c2321fb-c6a4-41ed-a391-21e9773533e2" />

<img width="826" height="412" alt="image" src="https://github.com/user-attachments/assets/efe30e03-1173-4ed2-adc5-5cb79579616a" />


Diagnostics feedback

<img width="805" height="459" alt="image" src="https://github.com/user-attachments/assets/dd303f88-502e-4a44-ae67-c6e0ad5e1c75" />

