### PR TITLE
Add todo-highlight language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3362,6 +3362,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todo-highlight"]
+	path = extensions/todo-highlight
+	url = https://github.com/placintaalexandru/zed-todo-highlighter.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3405,6 +3405,11 @@ version = "0.0.1"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todo-highlight]
+submodule = "extensions/todo-highlight"
+version = "0.1.1"
+path = "todo_highlight"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"


### PR DESCRIPTION
This extension allows background highlights for comments containing special keywords defined by the user.

The user can configure which keywords they want (by default only `TODO` is searched for) and also the keyword's color.