### PR TITLE
Add vibrant-abyss theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3322,6 +3322,10 @@
 	path = extensions/vhs
 	url = https://github.com/eth0net/zed-vhs.git
 
+[submodule "extensions/vibrant-abyss"]
+	path = extensions/vibrant-abyss
+	url = https://github.com/noelhorvath/vibrant-abyss-zed.git
+
 [submodule "extensions/viewtree"]
 	path = extensions/viewtree
 	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3362,6 +3362,10 @@ version = "0.0.2"
 submodule = "extensions/vhs"
 version = "0.1.0"
 
+[vibrant-abyss]
+submodule = "extensions/vibrant-abyss"
+version = "0.1.0"
+
 [viewtree]
 submodule = "extensions/viewtree"
 version = "1.0.6"


### PR DESCRIPTION
[Vibrant Abyss for **Zed**](https://github.com/noelhorvath/vibrant-abyss-zed) is pitch-black, high-contrast theme based on the original [Vibrant Abyss for **Visual Studio Code**](https://github.com/noelhorvath/vibrant-abyss).