### PR TITLE
Add Laravel extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3593,3 +3593,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/laravel"]
+	path = extensions/laravel
+	url = https://github.com/GeneaLabs/zed-laravel.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1542,6 +1542,10 @@
 	path = extensions/kvs-cyberpunk-2077
 	url = https://github.com/notKvS/2077-zed.git
 
+[submodule "extensions/laravel"]
+	path = extensions/laravel
+	url = https://github.com/GeneaLabs/zed-laravel.git
+
 [submodule "extensions/latex"]
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git
@@ -3593,6 +3597,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/laravel"]
-	path = extensions/laravel
-	url = https://github.com/GeneaLabs/zed-laravel.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1568,7 +1568,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.5"
+version = "0.1.7"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1568,7 +1568,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.0"
+version = "0.1.2"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1572,7 +1572,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.11"
+version = "0.1.12"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1566,6 +1566,10 @@ version = "1.0.0"
 submodule = "extensions/kvs-cyberpunk-2077"
 version = "0.0.2"
 
+[laravel]
+submodule = "extensions/laravel"
+version = "0.1.0"
+
 [latex]
 submodule = "extensions/latex"
 version = "0.2.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1572,7 +1572,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.10"
+version = "0.1.11"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1568,7 +1568,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.7"
+version = "0.1.8"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1568,7 +1568,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.8"
+version = "0.1.10"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1568,7 +1568,7 @@ version = "0.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.2"
+version = "0.1.5"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1688,7 +1688,7 @@ version = "1.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.12"
+version = "0.1.13"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1688,7 +1688,7 @@ version = "1.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.13"
+version = "0.1.14"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1688,7 +1688,7 @@ version = "1.0.2"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.14"
+version = "0.1.15"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
## Laravel Extension

  Hey Zed team! 👋

  This PR adds Laravel support to Zed—something the Laravel community has been eager for as more developers discover Zed.

###  What it does

  The extension provides go-to-definition and diagnostics for Laravel's conventions. Click on a view name, Blade component, route, config key, or translation—and jump straight to the file. Get inline warnings when something's missing or misconfigured.

  Essentially, it makes Zed understand Laravel projects the way Laravel developers think about them.

###  Why it matters

  Laravel is the most widely-used PHP framework, powering millions of applications. PHP developers evaluating Zed often ask "does it support Laravel?" before making the switch. This extension removes that barrier.

  Many Laravel developers are currently tied to VS Code or PhpStorm specifically because of Laravel tooling. Giving them a native Zed option opens the door for a large, enthusiastic community to join the Zed ecosystem.

###  About the extension

  - Written in Rust with a custom LSP
  - Uses tree-sitter for fast, accurate parsing
  - Zero configuration—auto-discovers project structure
  - Cross-platform binaries included for all supported architectures

###  Links

  - Repository: https://github.com/GeneaLabs/zed-laravel
  - Full feature documentation in the README

  Happy to address any feedback. Thanks for considering!