### PR TITLE
Add clang modulemap language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1938,6 +1938,10 @@
 	path = extensions/modest-dark
 	url = https://github.com/timcole/modest-dark.git
 
+[submodule "extensions/modulemap"]
+	path = extensions/modulemap
+	url = https://github.com/hokein/zed-modulemap.git
+
 [submodule "extensions/modus-themes"]
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1965,6 +1965,10 @@ version = "1.0.3"
 submodule = "extensions/modest-dark"
 version = "0.1.8"
 
+[modulemap]
+submodule = "extensions/modulemap"
+version = "0.0.1"
+
 [modus-themes]
 submodule = "extensions/modus-themes"
 version = "0.1.2"


### PR DESCRIPTION
This PR adds a new extension for supporting clang modulemap files (`.modulemap`).

This is the screenshot:

<img width="575" height="369" alt="image" src="https://github.com/user-attachments/assets/05c506c7-5f72-40e0-8bbd-5753fd9942aa" />
