### PR TITLE
danger: Use Danger Proxy running on Cloud

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -35,7 +35,7 @@ jobs:
           # This GitHub token is not used, but the value needs to be here to prevent
           # Danger from throwing an error.
           GITHUB_TOKEN: "not_a_real_token"
-          # All requests are instead proxied through an instance of
-          # https://github.com/maxdeviant/danger-proxy that allows Danger to securely
-          # authenticate with GitHub while still being able to run on PRs from forks.
-          DANGER_GITHUB_API_BASE_URL: "https://danger-proxy.fly.dev/github"
+          # All requests are instead proxied through a proxy that allows Danger
+          # to securely authenticate with GitHub while still being able to run
+          # on PRs from forks.
+          DANGER_GITHUB_API_BASE_URL: "https://danger-proxy.zed.dev/github"


### PR DESCRIPTION
This PR updates Danger to use the new Danger Proxy that is running on Cloud.

Part of CLO-45.