### PR TITLE
Add thrift next

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3342,6 +3342,10 @@
 	path = extensions/thrift
 	url = https://github.com/likaihua/zed-thrift.git
 
+[submodule "extensions/thrift-next"]
+	path = extensions/thrift-next
+	url = https://github.com/HusuSama/zed-thrift-next.git
+
 [submodule "extensions/tm-twilight"]
 	path = extensions/tm-twilight
 	url = https://github.com/waldirbertazzijr/zed-twilight

--- a/extensions.toml
+++ b/extensions.toml
@@ -3385,6 +3385,10 @@ version = "0.1.0"
 submodule = "extensions/thrift"
 version = "0.0.1"
 
+[thrift-next]
+submodule = "extensions/thrift-next"
+version = "0.0.1"
+
 [tm-twilight]
 submodule = "extensions/tm-twilight"
 version = "0.0.1"


### PR DESCRIPTION
Added Thrift support. Why create a separate extension?

1. The `zed-thrift` extension only provides basic syntax highlighting. Its integrated LSP service hasn't been properly tested and doesn't work as expected.
2. `zed-thrift` doesn't automatically download the required binary, and its documentation offers no guidance on how users can obtain the correct binary themselves.
3. Due to incorrect LSP parameters resulting from insufficient testing, `zed-thrift` fails to launch—even after trying multiple Thrift LSP servers.
4. Attempts to contact the original author via GitHub issues and email—either to collaborate on improvements or request repository ownership—received no response.

Features of this extension (`zed-thrift-next`):

1. Automatically downloads the required binary upon installation and cleans up outdated versions. It leaves manual installations or configurations untouched.
2. Compatible with both `thriftls` and the original Thrift binary naming conventions.
3. Provides full functionality, including syntax highlighting, auto-completion, go-to-definition, and code formatting.
4. Includes comprehensive documentation and troubleshooting guidance for potential failure scenarios.

This extension will be actively maintained long-term.

repo: https://github.com/HusuSama/zed-thrift-next