### PR TITLE
Add tokyoppuccin theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3874,6 +3874,10 @@
 	path = extensions/tokyo-night-dark
 	url = https://github.com/pyncz/zed-tokyo-night-dark-theme.git
 
+[submodule "extensions/tokyoppuccin-theme"]
+	path = extensions/tokyoppuccin-theme
+	url = https://github.com/EmmanuelVernet/zed-tokyoppuccin.git
+
 [submodule "extensions/tombi"]
 	path = extensions/tombi
 	url = https://github.com/tombi-toml/tombi.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3928,6 +3928,10 @@ version = "0.7.0"
 submodule = "extensions/tokyo-night-dark"
 version = "0.1.0"
 
+[tokyoppuccin-theme]
+submodule = "extensions/tokyoppuccin-theme"
+version = "0.1.0"
+
 [tombi]
 submodule = "extensions/tombi"
 path = "editors/zed"


### PR DESCRIPTION
Hello,

For my first time contribution attempt to open source, I've worked on this theme for Zed.

It's a blend of Tokyo Night and Catppuccin themes with a minimalist flavor, currently available with a Storm, Frappé and Latte styles.

I hope you like it 😃 

Tokyoppuccin Storm

<img width="1795" height="1062" alt="Screenshot 2026-01-16 at 21 08 38" src="https://github.com/user-attachments/assets/15383547-3c17-49fc-9ca9-dc66aace6ec4" />

Tokyoppuccin Frappé

<img width="1795" height="1062" alt="Screenshot 2026-01-16 at 21 08 46" src="https://github.com/user-attachments/assets/0ddcea3b-1b1b-498e-84b0-5b1cbbaff9dd" />

Tokyoppuccin Latte

<img width="1795" height="1062" alt="Screenshot 2026-01-16 at 21 08 59" src="https://github.com/user-attachments/assets/bc120cc7-2c08-4ffd-92a5-4f403bea8cb1" />
