### PR TITLE
Add Stata language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3066,6 +3066,10 @@
 	path = extensions/sieve
 	url = https://github.com/aRustyDev/zed-sieve.git
 
+[submodule "extensions/sight"]
+	path = extensions/sight
+	url = https://github.com/jbearak/zed-stata.git
+
 [submodule "extensions/simple-darker"]
 	path = extensions/simple-darker
 	url = https://github.com/DP19/zed-theme-simple-darker.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3066,10 +3066,6 @@
 	path = extensions/sieve
 	url = https://github.com/aRustyDev/zed-sieve.git
 
-[submodule "extensions/sight"]
-	path = extensions/sight
-	url = https://github.com/jbearak/zed-stata.git
-
 [submodule "extensions/simple-darker"]
 	path = extensions/simple-darker
 	url = https://github.com/DP19/zed-theme-simple-darker.git
@@ -3965,3 +3961,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/stata"]
+	path = extensions/stata
+	url = https://github.com/jbearak/zed-stata.git
+	branch = main

--- a/extensions.toml
+++ b/extensions.toml
@@ -3108,6 +3108,10 @@ version = "2.2.0"
 submodule = "extensions/sieve"
 version = "0.1.7"
 
+[sight]
+submodule = "extensions/sight"
+version = "0.1.24"
+
 [simple-darker]
 submodule = "extensions/simple-darker"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3108,8 +3108,8 @@ version = "2.2.0"
 submodule = "extensions/sieve"
 version = "0.1.7"
 
-[sight]
-submodule = "extensions/sight"
+[stata]
+submodule = "extensions/stata"
 version = "0.1.24"
 
 [simple-darker]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3142,7 +3142,7 @@ version = "0.1.7"
 
 [stata]
 submodule = "extensions/stata"
-version = "0.1.24"
+version = "0.5.0"
 
 [simple-darker]
 submodule = "extensions/simple-darker"


### PR DESCRIPTION
Fresh submission after rewriting the extension repo history with `git-filter-repo`.

Adds the `stata` extension to the Zed extension registry:
- Adds submodule `extensions/stata` pointing to `https://github.com/jbearak/zed-stata.git`
- Pins the submodule to the current `v0.5.0` release commit
- Adds a `[stata]` entry to `extensions.toml` with version `0.5.0`

The extension provides Stata language support for Zed, including syntax highlighting, tasks, and Sight-based language server integration. The platform-specific install scripts are only for optional send-to-Stata and Jupyter kernel workflows; the extension itself works out of the box for editor and LSP features.