### PR TITLE
Bump extension CLI version to `03d8e9a`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  ZED_EXTENSION_CLI_SHA: bb591f1e653a492c2d6c85353181e5151dbf8ac7
+  ZED_EXTENSION_CLI_SHA: 03d8e9aee95ea6117d75a48bcac2e19241f6e667
 
 jobs:
   package:


### PR DESCRIPTION
This PR bumps the extension CLI version to `zed-industries/zed@03d8e9aee95ea6117d75a48bcac2e19241f6e667`.

This adds better testing for snippets and extensions in general.