### PR TITLE
Add nuxt extension

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2398,6 +2398,10 @@ version = "0.0.1"
 submodule = "extensions/nunjucks"
 version = "0.0.1"
 
+[nuxt]
+submodule = "extensions/nuxt"
+version = "0.1.0"
+
 [nvim-nightfox]
 submodule = "extensions/nvim-nightfox"
 version = "0.7.0"


### PR DESCRIPTION
   ## Summary
   
   Add Nuxt extension for Vue/Nuxt framework support.
   
   ## Repository
   
   https://github.com/vityapro/zed-nuxt
   
   ## Features
   
   - Nuxt 3/4 project auto-detection
   - Optimized Vue Language Server (Volar) configuration
   - Reduced completion noise
   - 15 Nuxt-specific snippets (npage, napi, nfetch, etc.)
   - MIT License
   
   ## Testing
   
   Tested locally with Zed dev extension installation.
   