### PR TITLE
Add codeowners language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -590,6 +590,10 @@
 	path = extensions/codeowners
 	url = https://github.com/lukasmalkmus/codeowners-zed.git
 
+[submodule "extensions/codeowners-lsp"]
+	path = extensions/codeowners-lsp
+	url = https://github.com/radiosilence/codeowners-zed.git
+
 [submodule "extensions/codesandbox-theme"]
 	path = extensions/codesandbox-theme
 	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -595,6 +595,10 @@ version = "0.0.1"
 submodule = "extensions/codeowners"
 version = "0.1.0"
 
+[codeowners-lsp]
+submodule = "extensions/codeowners-lsp"
+version = "0.1.0"
+
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Adds **codeowners-lsp** - an LSP-powered extension for GitHub CODEOWNERS files.

## Why a separate extension?

There is already an existing `codeowners` extension (by @lukasmalkmus) that provides tree-sitter syntax highlighting. This new extension is published separately rather than replacing/updating that one because:

1. **User choice** - Some users just want lightweight syntax highlighting without downloading an LSP binary. The base extension serves that use case perfectly.

2. **No forced downloads** - This extension auto-downloads the LSP binary from GitHub releases. Users who prefer not to have extensions downloading binaries can stick with the base extension.

3. **Different scope** - The LSP adds significant functionality (linting, formatting, ownership display, go-to-definition, completions, code actions) that goes well beyond syntax highlighting.

Users can choose:
- **codeowners** - Syntax highlighting only (no binary download)
- **codeowners-lsp** - Full LSP features (auto-downloads binary)

## Features

- Ownership display via inlay hints and hover
- Go-to-definition from any file to matching CODEOWNERS rule  
- Linting (shadowed rules, invalid patterns, duplicate owners, etc.)
- Quick fixes and code actions
- Formatting
- Path and owner completions
- Document symbols, find references, rename, workspace symbols, code lens

## Links

- Extension repo: https://github.com/radiosilence/codeowners-zed
- LSP repo: https://github.com/radiosilence/codeowners-lsp
- Base extension: https://github.com/lukasmalkmus/codeowners-zed