### PR TITLE
Add Puter MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2726,6 +2726,10 @@
 	path = extensions/purr
 	url = https://github.com/nemanjastanic/zed-purr.git
 
+[submodule "extensions/puter"]
+	path = extensions/puter
+	url = https://github.com/Mihai-Codes/zed-puter.git
+
 [submodule "extensions/pylsp"]
 	path = extensions/pylsp
 	url = https://github.com/rgbkrk/python-lsp-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2765,6 +2765,10 @@ version = "0.1.3"
 submodule = "extensions/purr"
 version = "0.0.4"
 
+[puter]
+submodule = "extensions/puter"
+version = "0.1.1"
+
 [pylsp]
 submodule = "extensions/pylsp"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2767,7 +2767,7 @@ version = "0.0.4"
 
 [puter]
 submodule = "extensions/puter"
-version = "0.1.1"
+version = "0.1.2"
 
 [pylsp]
 submodule = "extensions/pylsp"


### PR DESCRIPTION
Adds the `puter` extension.

Repository: https://github.com/Mihai-Codes/zed-puter

Description: Zed IDE extension for Puter.com AI models - Access Claude, GPT, Gemini & multiple other models via MCP.