### PR TITLE
Add Aztec-Noir (prev. 'Zoir') extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3970,6 +3970,10 @@
 	path = extensions/zoegi-theme
 	url = https://github.com/nikitapashinsky/zoegi-theme.git
 
+[submodule "extensions/zoir"]
+	path = extensions/zoir
+	url = https://github.com/Hydepwns/zoir.git
+
 [submodule "extensions/zokrates"]
 	path = extensions/zokrates
 	url = https://github.com/threonyl/zed-zokrates.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -306,6 +306,10 @@
 	path = extensions/ayu-themes-glass
 	url = https://github.com/jansol/zed-ayu-glass.git
 
+[submodule "extensions/aztec-noir"]
+	path = extensions/aztec-noir
+	url = https://github.com/DROOdotFOO/aztec-noir.git
+
 [submodule "extensions/azure-context-server"]
 	path = extensions/azure-context-server
 	url = https://github.com/oWretch/zed-extension-azure-mcp
@@ -4665,10 +4669,6 @@
 [submodule "extensions/zoegi-theme"]
 	path = extensions/zoegi-theme
 	url = https://github.com/nikitapashinsky/zoegi-theme.git
-
-[submodule "extensions/zoir"]
-	path = extensions/zoir
-	url = https://github.com/Hydepwns/zoir.git
 
 [submodule "extensions/zokrates"]
 	path = extensions/zokrates

--- a/extensions.toml
+++ b/extensions.toml
@@ -4017,6 +4017,10 @@ version = "0.0.1"
 submodule = "extensions/zoegi-theme"
 version = "0.4.3"
 
+[zoir]
+submodule = "extensions/zoir"
+version = "0.1.3"
+
 [zokrates]
 submodule = "extensions/zokrates"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -310,6 +310,10 @@ version = "1.1.2"
 submodule = "extensions/ayu-themes-glass"
 version = "1.0.0"
 
+[aztec-noir]
+submodule = "extensions/aztec-noir"
+version = "0.3.0"
+
 [azure-context-server]
 submodule = "extensions/azure-context-server"
 version = "1.0.0"
@@ -4725,10 +4729,6 @@ version = "0.0.1"
 [zoegi-theme]
 submodule = "extensions/zoegi-theme"
 version = "0.4.3"
-
-[zoir]
-submodule = "extensions/zoir"
-version = "0.1.3"
 
 [zokrates]
 submodule = "extensions/zokrates"


### PR DESCRIPTION
## Summary
- Adds Aztec-Noir (prev. 'Zoir') extension v0.3.0

### Features:
- Noir zero-knowledge language support for Zed, focused around the Aztec Network
- Tree-sitter grammar for syntax highlighting
- nargo language server integration

### Repositories:
- Extension: https://github.com/DROOdotFOO/aztec-noir
- Tree-sitter grammar: https://github.com/DROOdotFOO/tree-sitter-noir