### PR TITLE
Add Razor extension for ASP.NET Razor Pages and Blazor

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2918,7 +2918,7 @@ version = "1.1.0"
 
 [razor]
 submodule = "extensions/razor"
-version = "0.2.0"
+version = "0.3.0"
 
 [rcl]
 submodule = "extensions/rcl"


### PR DESCRIPTION
## Summary

- Adds the **Razor** extension for ASP.NET Razor Pages and Blazor support (.cshtml, .razor files)
- Provides full C# syntax highlighting via [tree-sitter-razor](https://github.com/tris203/tree-sitter-razor)
- Includes XML-based syntax highlighting for .NET project files (.csproj, .slnx, .sln) via [tree-sitter-xml](https://github.com/tree-sitter-grammars/tree-sitter-xml)
- Source: https://github.com/noundry/zed-razor (v0.3.0)

## Companion extension

For .NET debugging support in Zed, see [noundry/zed-netcoredbg](https://github.com/noundry/zed-netcoredbg) — a netcoredbg adapter extension that enables easy debugging of ASP.NET and Blazor projects.

## Test plan

- [x] Extension builds and grammar compiles to WASM
- [x] Syntax highlighting works for .cshtml and .razor files
- [x] C# code blocks within Razor markup are properly highlighted
- [x] .csproj and .slnx files receive full XML highlighting
- [x] .sln files open with best-effort XML highlighting