### PR TITLE
Add ChipKit extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -518,6 +518,10 @@
 	path = extensions/cherri
 	url = https://github.com/videah/zed-cherri.git
 
+[submodule "extensions/chipkit"]
+	path = extensions/chipkit
+	url = https://github.com/Leonui/zed-chipkit.git
+
 [submodule "extensions/chocolate"]
 	path = extensions/chocolate
 	url = https://github.com/brunozalc/zed-chocolate

--- a/extensions.toml
+++ b/extensions.toml
@@ -522,6 +522,10 @@ version = "0.5.0"
 submodule = "extensions/cherri"
 version = "0.1.0"
 
+[chipkit]
+submodule = "extensions/chipkit"
+version = "0.1.0"
+
 [chocolate]
 submodule = "extensions/chocolate"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -524,7 +524,7 @@ version = "0.1.0"
 
 [chipkit]
 submodule = "extensions/chipkit"
-version = "0.1.0"
+version = "0.1.1"
 
 [chocolate]
 submodule = "extensions/chocolate"


### PR DESCRIPTION
Zed extension providing file associations and syntax highlighting, currently supporting:

- Verilog (.v)
- SystemVerilog (.sv, .svh, .vh)
- Tcl (.tcl)
- SDC (.sdc)
- UPF (.upf)
- CPF (.cpf)
- SKILL (.il, .ils, .sk)
- 