### PR TITLE
Add Umple language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3994,6 +3994,10 @@
 	path = extensions/umka
 	url = https://github.com/michabay05/zed-umka.git
 
+[submodule "extensions/umple"]
+	path = extensions/umple
+	url = https://github.com/umple/umple.zed.git
+
 [submodule "extensions/underground-theme"]
 	path = extensions/underground-theme
 	url = https://github.com/i-amdroid/zed-underground-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4051,7 +4051,7 @@ version = "0.0.1"
 
 [umple]
 submodule = "extensions/umple"
-version = "0.0.1"
+version = "0.1.0"
 
 [underground-theme]
 submodule = "extensions/underground-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4049,6 +4049,10 @@ version = "0.1.0"
 submodule = "extensions/umka"
 version = "0.0.1"
 
+[umple]
+submodule = "extensions/umple"
+version = "0.0.1"
+
 [underground-theme]
 submodule = "extensions/underground-theme"
 version = "1.0.0"


### PR DESCRIPTION
  Adds [Umple](https://www.umple.org) language support (syntax highlighting, diagnostics, completion, go-to-definition).

  - Extension repo: https://github.com/umple/umple.zed
  - LSP server: [`umple-lsp-server`](https://www.npmjs.com/package/umple-lsp-server) (auto-downloaded from npm)
  - Tree-sitter grammar: https://github.com/umple/umple-lsp/tree/master/packages/tree-sitter-umple
  - License: MIT