### PR TITLE
Add cmake extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/clojure
 	url = https://github.com/zed-extensions/clojure.git
 
+[submodule "extensions/cmake"]
+	path = extensions/cmake
+	url = https://github.com/NikitolProject/zed-cmake.git
+
 [submodule "extensions/cobalt2"]
 	path = extensions/cobalt2
 	url = https://github.com/wesbos/cobalt2-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -563,6 +563,10 @@ path = "editors/zed"
 submodule = "extensions/clojure"
 version = "0.2.2"
 
+[cmake]
+submodule = "extensions/cmake"
+version = "0.2.0"
+
 [cobalt2]
 submodule = "extensions/cobalt2"
 version = "0.1.0"


### PR DESCRIPTION
Adds full CMake language support for Zed.

## Features

### Syntax Highlighting
Full syntax highlighting for CMakeLists.txt and .cmake files using [tree-sitter-cmake](https://github.com/uyha/tree-sitter-cmake).

### Language Server
Integrates [neocmakelsp-fast](https://github.com/NikitolProject/neocmakelsp-fast) LSP with:
- Autocompletion for commands, variables, and paths
- Path completions with directory caching
- Hover documentation
- Go-to-definition
- Signature help for CMake commands
- Diagnostics and linting
- Code formatting

The LSP binary is automatically downloaded from GitHub Releases on first use.

### Editor Features
- **Outline panel** — navigate project(), add_executable(), add_library(), functions, macros
- **Auto-indentation** — proper indentation for if/else/endif, foreach, function blocks
- **Bracket matching** — parentheses and command blocks
- **Text objects** — select inside/around functions and macros

### Build Tasks
Run directly from Command Palette or inline on targets:
- Configure (Debug/Release)
- Build All / Build Target
- Run Executable
- Run Test / Run All Tests
- Clean
- Install
- Reconfigure

## Repository
https://github.com/NikitolProject/zed-cmake

## License
MIT