### PR TITLE
Add jinja-universal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1606,6 +1606,10 @@
 	path = extensions/jetbrains-themes
 	url = https://github.com/artemevsevev/zed-theme-jetbrains.git
 
+[submodule "extensions/jinja-universal"]
+	path = extensions/jinja-universal
+	url = https://github.com/Else00/zed-jinja-universal.git
+
 [submodule "extensions/jinja2"]
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1635,6 +1635,10 @@ version = "0.0.2"
 submodule = "extensions/jetbrains-themes"
 version = "0.3.1"
 
+[jinja-universal]
+submodule = "extensions/jinja-universal"
+version = "1.0.0"
+
 [jinja2]
 submodule = "extensions/jinja2"
 version = "0.0.1"


### PR DESCRIPTION
Adds `jinja-universal` to the Zed extension registry at version `1.0.0`.

## Why this extension

`jinja-universal` provides Jinja2 syntax highlighting with host-language injection across a large set of Zed-supported languages (currently 353 in the published default set), including examples like:

- `.yaml.jinja`, `.toml.jinja`, `.sql.jinja`, `.md.jinja`
- filename-based templates like `Justfile.jinja`

## How it differs from existing Jinja extensions

This is complementary to the existing Jinja entries:

- `html-jinja` (`0.1.0`): HTML-first approach (`grammar = "html"`), focused on HTML/Jinja templates.
- `jinja2` (`0.0.1`): single Jinja2 language config with generic `.jinja/.jinja2/.j2` detection and HTML-oriented injection.

`jinja-universal` instead ships generated per-language Jinja variants, so host-language highlighting is preserved across many non-HTML template targets as well.
