### PR TITLE
Add claude-code-cli language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/clarity
 	url = https://github.com/hirosystems/clarity-zed.git
 
+[submodule "extensions/claude-code-cli-ide"]
+	path = extensions/claude-code-cli-ide
+	url = https://github.com/beregcamlost/claude-code-cli-ide.git
+
 [submodule "extensions/claude-code-inspired-dark"]
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -562,6 +562,10 @@ version = "0.0.2"
 submodule = "extensions/clarity"
 version = "0.0.1"
 
+[claude-code-cli-ide]
+submodule = "extensions/claude-code-cli-ide"
+version = "0.1.1"
+
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -564,7 +564,7 @@ version = "0.0.1"
 
 [claude-code-cli-ide]
 submodule = "extensions/claude-code-cli-ide"
-version = "0.1.2"
+version = "0.1.3"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -564,7 +564,7 @@ version = "0.0.1"
 
 [claude-code-cli-ide]
 submodule = "extensions/claude-code-cli-ide"
-version = "0.1.1"
+version = "0.1.2"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"


### PR DESCRIPTION
## What this does

This extension bridges **Claude Code CLI** with **Zed**, giving Claude the same IDE context awareness it has in VS Code — knowing which file you're editing, reading your selected text, and understanding your workspace structure. Without it, Claude Code in the terminal is blind to what you're doing in your editor.

### How it works

The extension registers an LSP + WebSocket hybrid server for 65+ languages. When you open any file in Zed:

1. **Extension (WASM)** downloads a pre-built server binary from [GitHub Releases](https://github.com/beregcamlost/claude-code-cli-ide/releases) (or uses a local one if present on `$PATH`)
2. **Server binary** starts two channels:
   - **LSP** (stdio) — receives file open/close/change events, selections, and diagnostics from Zed
   - **WebSocket** (`ws://127.0.0.1:<port>`) — Claude Code CLI connects here to query editor state
3. **Claude Code CLI** connects via WebSocket and can:
   - See which file you have open and its contents
   - Read your current text selection
   - Know your workspace folders and project structure
   - Access diagnostics from Zed's language servers

This is the same integration model VS Code uses — Claude Code CLI detects the WebSocket server and automatically connects to get IDE context.

### Architecture

```
  Zed Editor
       │
       ├── LSP (stdio) ──► claude-code-server-zed ◄── WebSocket ── Claude Code CLI
       │                    (hybrid server binary)
       │
  Extension (WASM)
  Registers for 65+ languages
  Auto-downloads server binary
```

### MCP tools exposed to Claude Code

| Tool | Description |
|------|-------------|
| `getCurrentSelection` | Returns selected text, file path, and selection range |
| `getWorkspaceFolders` | Returns workspace folder names, URIs, and root path |
| `getDiagnostics` | Returns diagnostics from the workspace |

## Details

- **Repository**: https://github.com/beregcamlost/claude-code-cli-ide
- **License**: MIT
- **Zed API version**: 0.7.0
- **Extension version**: 0.1.2
- **Platforms**: macOS (Apple Silicon, Intel), Linux (x86_64, aarch64)
- **Server binary**: Auto-downloaded from GitHub Releases per platform — no manual build needed

### Changelog (v0.1.2)

- Server version strings now use `env!("CARGO_PKG_VERSION")` instead of hardcoded values — stays in sync automatically
- Fixed monitor daemon `kill_server()` hanging if server ignores SIGTERM (now has 3s timeout + SIGKILL fallback)
- Fixed stale README badge (zed_api v0.6.0 → v0.7.0)