### PR TITLE
Add Isabelle language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1550,6 +1550,10 @@
 	path = extensions/ir-black
 	url = https://github.com/sametaylak/ir-black-zed-theme
 
+[submodule "extensions/isabelle"]
+	path = extensions/isabelle
+	url = https://github.com/MCB-SMART-BOY/isabelle-zed.git
+
 [submodule "extensions/isle"]
 	path = extensions/isle
 	url = https://github.com/eagr/zed-isle.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1578,6 +1578,11 @@ version = "0.1.2"
 submodule = "extensions/ir-black"
 version = "0.0.1"
 
+[isabelle]
+submodule = "extensions/isabelle"
+path = "zed-extension"
+version = "0.2.0"
+
 [isle]
 submodule = "extensions/isle"
 version = "0.0.1"


### PR DESCRIPTION
## Summary
Add a new Isabelle extension entry to the Zed official extensions registry.

## Included changes
- Add submodule: `extensions/isabelle` -> `https://github.com/MCB-SMART-BOY/isabelle-zed.git`
- Add `extensions.toml` entry:
  - `submodule = "extensions/isabelle"`
  - `path = "zed-extension"`
  - `version = "0.2.0"`

## Notes
- Extension repo: https://github.com/MCB-SMART-BOY/isabelle-zed
- Extension id: `isabelle`
- Default runtime mode uses Isabelle native `vscode_server` integration.
