### PR TITLE
Add Gruvbox Material Dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1358,10 +1358,6 @@
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git
 
-[submodule "extensions/gruvbox-material-dark"]
-	path = extensions/gruvbox-material-dark
-	url = https://github.com/GaussianWonder/zed-gruvbox-material.git
-
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix
 	url = https://github.com/hyperdevstuff/zed-gruvbox-material.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1358,6 +1358,10 @@
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git
 
+[submodule "extensions/gruvbox-material-dark"]
+	path = extensions/gruvbox-material-dark
+	url = https://github.com/GaussianWonder/zed-gruvbox-material.git
+
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix
 	url = https://github.com/hyperdevstuff/zed-gruvbox-material.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1366,6 +1366,10 @@
 	path = extensions/gruvbox-material-neovim
 	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-neovim
 
+[submodule "extensions/gruvbox-material-port-theme"]
+	path = extensions/gruvbox-material-port-theme
+	url = https://github.com/GaussianWonder/zed-gruvbox-material.git
+
 [submodule "extensions/gruvchad"]
 	path = extensions/gruvchad
 	url = https://github.com/hey-ewan/zed-gruvchad.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1379,10 +1379,6 @@ version = "0.0.1"
 submodule = "extensions/gruvbox-material"
 version = "1.1.0"
 
-[gruvbox-material-dark]
-submodule = "extensions/gruvbox-material-dark"
-version = "0.0.1"
-
 [gruvbox-material-mix]
 submodule = "extensions/gruvbox-material-mix"
 version = "1.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1387,6 +1387,10 @@ version = "1.0.1"
 submodule = "extensions/gruvbox-material-neovim"
 version = "0.1.0"
 
+[gruvbox-material-port-theme]
+submodule = "extensions/gruvbox-material-port-theme"
+version = "0.1.0"
+
 [gruvchad]
 submodule = "extensions/gruvchad"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1379,6 +1379,10 @@ version = "0.0.1"
 submodule = "extensions/gruvbox-material"
 version = "1.1.0"
 
+[gruvbox-material-dark]
+submodule = "extensions/gruvbox-material-dark"
+version = "0.0.1"
+
 [gruvbox-material-mix]
 submodule = "extensions/gruvbox-material-mix"
 version = "1.0.1"


### PR DESCRIPTION
This is **yet another port of** [sainnhe's Gruvbox Material](https://github.com/sainnhe/gruvbox-material) VSCode theme.

## Features

- Lighter inlay hints
- [zed-comment](https://github.com/thedadams/zed-comment) support
- closer to the original