### PR TITLE
Add LikeC4 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/likec4"]
+	path = extensions/likec4
+	url = https://github.com/Lenivvenil/zed-likec4.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1950,6 +1950,10 @@
 	path = extensions/lights-out
 	url = https://github.com/Ajiva-D/lights-out-theme-zed.git
 
+[submodule "extensions/likec4"]
+	path = extensions/likec4
+	url = https://github.com/Lenivvenil/zed-likec4.git
+
 [submodule "extensions/lilypond"]
 	path = extensions/lilypond
 	url = https://github.com/nwhetsell/lilypond-zed-extension
@@ -4453,6 +4457,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/likec4"]
-	path = extensions/likec4
-	url = https://github.com/Lenivvenil/zed-likec4.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1981,6 +1981,10 @@ version = "0.0.1"
 submodule = "extensions/lights-out"
 version = "0.0.1"
 
+[likec4]
+submodule = "extensions/likec4"
+version = "0.0.1"
+
 [lilypond]
 submodule = "extensions/lilypond"
 version = "0.0.9"


### PR DESCRIPTION
## Summary

Adds [LikeC4](https://likec4.dev) architecture-as-code language support for Zed:

- **Tree-sitter grammar** — syntax highlighting, bracket matching, auto-indentation, code outline
- **LSP integration** — official [@likec4/language-server](https://www.npmjs.com/package/@likec4/language-server) providing completions, diagnostics, hover, go-to-definition, find references, and rename
- **File detection** — `.likec4` and `.c4` extensions

**Extension repo:** https://github.com/Lenivvenil/zed-likec4
**Grammar repo:** https://github.com/Lenivvenil/tree-sitter-likec4