### PR TITLE
ci: Add repository guard for actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   actionlint:
     runs-on: namespace-profile-2x4-ubuntu-2404
+    if: github.repository_owner == 'zed-industries'
     env:
       SHA: 03d0035246f3e81f36aed592ffb4bebf33a03106
       VERSION: 1.7.7


### PR DESCRIPTION
This prevents this from unintentionally running on forks.