### PR TITLE
tally: v0.41.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4689,3 +4689,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/tally"]
+	path = extensions/tally
+	url = https://github.com/wharflab/tally.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4749,3 +4749,8 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[tally]
+submodule = "extensions/tally"
+path = "_integrations/zed-tally"
+version = "0.41.0"


### PR DESCRIPTION
Publishing version v0.41.0 of the [tally](https://github.com/wharflab/tally) extension.

Tally is a Dockerfile linter and formatter written in Go, promoting modern container syntax and helping avoid common pitfalls.

[Changelog](https://github.com/wharflab/tally/releases/tag/v0.41.0)
