### PR TITLE
Add Markdoc language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1986,6 +1986,10 @@
 	path = extensions/marine-dark
 	url = https://github.com/MarineDark/marine-dark.zed.git
 
+[submodule "extensions/markdoc"]
+	path = extensions/markdoc
+	url = https://github.com/louiss0/zed-markdoc-extension.git
+
 [submodule "extensions/markdown-oxide"]
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2017,6 +2017,10 @@ version = "0.9.1"
 submodule = "extensions/marine-dark"
 version = "1.0.0"
 
+[markdoc]
+submodule = "extensions/markdoc"
+version = "0.1.0"
+
 [markdown-oxide]
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"


### PR DESCRIPTION
## Summary
- add `louiss0/zed-markdoc-extension` as the `extensions/markdoc` git submodule
- register `[markdoc]` in `extensions.toml` with version `0.1.0`
- run `pnpm sort-extensions` to keep `.gitmodules` and `extensions.toml` sorted

## Extension repo
- https://github.com/louiss0/zed-markdoc-extension