### PR TITLE
Add Xcode MCP bundle extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4130,6 +4130,10 @@
 	path = extensions/wxml
 	url = https://github.com/BlockLune/zed-wxml.git
 
+[submodule "extensions/xcode-mcp-bundle"]
+	path = extensions/xcode-mcp-bundle
+	url = https://github.com/tommyming/zed-xcode-mcp-bundle.git
+
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes
 	url = https://github.com/skarline/zed-xcode-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4183,6 +4183,10 @@ version = "0.0.1"
 submodule = "extensions/wxml"
 version = "0.1.0"
 
+[xcode-mcp-bundle]
+submodule = "extensions/xcode-mcp-bundle"
+version = "0.1.1"
+
 [xcode-themes]
 submodule = "extensions/xcode-themes"
 version = "2.0.1"


### PR DESCRIPTION
This extension contains 2 MCP Servers:

1. XCodeBuildMCP
2. Apple's Xcode MCP Server (available since Xcode 26.3)

Will provide installed display photos when available.

- [x] Test XCodeBuildMCP 
- [ ] Test Xcode MCP Server