### PR TITLE
Add Helios theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1506,6 +1506,10 @@
 	path = extensions/helm
 	url = https://github.com/cabrinha/helm.zed.git
 
+[submodule "extensions/helios-zed-theme"]
+	path = extensions/helios-zed-theme
+	url = https://github.com/heliosgraphics/helios-zed.git
+
 [submodule "extensions/herzha-theme"]
 	path = extensions/herzha-theme
 	url = https://github.com/madhanmaaz/herzha-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1562,9 +1562,9 @@
 	path = extensions/hbuilderx-push-light
 	url = https://github.com/yuanzhhh/hbuilderx-theme-zed.git
 
-[submodule "extensions/helios-zed-theme"]
-	path = extensions/helios-zed-theme
-	url = https://github.com/heliosgraphics/helios-zed.git
+[submodule "extensions/helios-theme"]
+	path = extensions/helios-theme
+	url = https://github.com/heliosgraphics/helios-theme.git
 
 [submodule "extensions/helm"]
 	path = extensions/helm

--- a/.gitmodules
+++ b/.gitmodules
@@ -1502,13 +1502,13 @@
 	path = extensions/hbuilderx-push-light
 	url = https://github.com/yuanzhhh/hbuilderx-theme-zed.git
 
-[submodule "extensions/helm"]
-	path = extensions/helm
-	url = https://github.com/cabrinha/helm.zed.git
-
 [submodule "extensions/helios-zed-theme"]
 	path = extensions/helios-zed-theme
 	url = https://github.com/heliosgraphics/helios-zed.git
+
+[submodule "extensions/helm"]
+	path = extensions/helm
+	url = https://github.com/cabrinha/helm.zed.git
 
 [submodule "extensions/herzha-theme"]
 	path = extensions/herzha-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1528,6 +1528,10 @@ version = "0.1.0"
 submodule = "extensions/helm"
 version = "0.0.2"
 
+[helios-zed-theme]
+submodule = "extensions/helios-zed-theme"
+version = "0.0.5"
+
 [herzha-theme]
 submodule = "extensions/herzha-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1585,9 +1585,9 @@ version = "0.3.1"
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"
 
-[helios-zed-theme]
-submodule = "extensions/helios-zed-theme"
-version = "0.0.6"
+[helios-theme]
+submodule = "extensions/helios-theme"
+version = "0.0.7"
 
 [helm]
 submodule = "extensions/helm"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1530,7 +1530,7 @@ version = "0.0.2"
 
 [helios-zed-theme]
 submodule = "extensions/helios-zed-theme"
-version = "0.0.5"
+version = "0.0.6"
 
 [herzha-theme]
 submodule = "extensions/herzha-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1524,13 +1524,13 @@ version = "0.3.1"
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"
 
-[helm]
-submodule = "extensions/helm"
-version = "0.0.2"
-
 [helios-zed-theme]
 submodule = "extensions/helios-zed-theme"
 version = "0.0.6"
+
+[helm]
+submodule = "extensions/helm"
+version = "0.0.2"
 
 [herzha-theme]
 submodule = "extensions/herzha-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1587,7 +1587,7 @@ version = "0.1.0"
 
 [helios-theme]
 submodule = "extensions/helios-theme"
-version = "0.0.7"
+version = "0.0.8"
 
 [helm]
 submodule = "extensions/helm"


### PR DESCRIPTION
<img width="1400" height="920" alt="screenshot-0 0 5" src="https://github.com/user-attachments/assets/1c3fac56-c657-4b7f-bff8-8f81d938d525" />

### Summary

- Adds [Helios](https://github.com/heliosgraphics/helios-zed) theme
- Features a calming, classic OSX inspired dark syntax
- Version `0.0.7`

### Checklist

- [x] Extension has a license (MIT)
- [x] extension.toml is valid with all required fields
- [x] Version in `extensions.toml` matches `extension.toml`
- [x] Ran pnpm sort-extensions
