### PR TITLE
Add skopio language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3326,6 +3326,10 @@
 	path = extensions/sitruuna
 	url = https://github.com/menduz/sitruuna-zed.git
 
+[submodule "extensions/skopio"]
+	path = extensions/skopio
+	url = https://github.com/Skopio-app/skopio-zed.git
+
 [submodule "extensions/sl4y-theme"]
 	path = extensions/sl4y-theme
 	url = https://github.com/berkantay/zed-theme-sl4y.git


### PR DESCRIPTION
## :book: Description

Adds the `skopio` extension to the Zed extension registry.

This is the initial publication of [`Skopio-app/skopio-zed`](https://github.com/Skopio-app/skopio-zed) and registers version `0.1.0`.