### PR TITLE
Add cursor-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -770,6 +770,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/cursor-theme"]
+	path = extensions/cursor-theme
+	url = https://github.com/eugenebokhan/zed-cursor-theme.git
+
 [submodule "extensions/cyan-light-theme"]
 	path = extensions/cyan-light-theme
 	url = https://github.com/biaqat/cyan-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -779,6 +779,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[cursor-theme]
+submodule = "extensions/cursor-theme"
+version = "0.1.0"
+
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"


### PR DESCRIPTION
Adds the Cursor-inspired theme for Zed.

- **Extension ID**: `cursor-theme`
- **Repository**: https://github.com/eugenebokhan/zed-cursor-theme
- **Version**: 0.1.0
- Includes both light and dark variants: **Cursor Light** and **Cursor Dark**