### PR TITLE
Add npm-manager language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2554,6 +2554,10 @@
 	path = extensions/nova-theme
 	url = https://github.com/overstarry/zed-nova.git
 
+[submodule "extensions/npm-manager"]
+	path = extensions/npm-manager
+	url = https://github.com/cth-latest/zed-npm-manager.git
+
 [submodule "extensions/npm-package-json-checker"]
 	path = extensions/npm-package-json-checker
 	url = https://github.com/e-simpson/zed-npm-update-checker.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2589,6 +2589,10 @@ version = "0.1.0"
 submodule = "extensions/nova-theme"
 version = "0.1.0"
 
+[npm-manager]
+submodule = "extensions/npm-manager"
+version = "1.0.0"
+
 [npm-package-json-checker]
 submodule = "extensions/npm-package-json-checker"
 version = "1.0.4"


### PR DESCRIPTION
## Summary

Adds the **NPM Manager** extension, which shows npm/pnpm package version status inline in `package.json` and `pnpm-workspace.yaml` files.

### Features
- Inline version indicators via inlay hints (up-to-date, outdated, invalid, not found)
- Hover details with version info and npmjs.com link
- Diagnostics for outdated/invalid packages
- Lock file awareness (package-lock.json, pnpm-lock.yaml, yarn.lock, bun.lock)
- Supports all dependency sections including bun/pnpm catalogs

### Repository
https://github.com/cth-latest/zed-npm-manager

### License
MIT