### PR TITLE
Add rest-client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3162,6 +3162,10 @@
 	path = extensions/rescript
 	url = https://github.com/rescript-lang/rescript-zed.git
 
+[submodule "extensions/rest-client"]
+	path = extensions/rest-client
+	url = https://github.com/TSC-Home/rest-client-zed.git
+
 [submodule "extensions/retrofit-theme"]
 	path = extensions/retrofit-theme
 	url = https://github.com/snapsnapturtle/retrofit-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3206,6 +3206,10 @@ version = "0.0.2"
 submodule = "extensions/rescript"
 version = "0.4.3"
 
+[rest-client]
+submodule = "extensions/rest-client"
+version = "0.1.0"
+
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Add `rest-client` extension v0.1.0

Adds **REST Client** — a lightweight HTTP client extension that lets users send requests directly from `.http` and `.rest` files inside Zed.

### What it does

- Provides syntax highlighting for `.http` / `.rest` files via [tree-sitter-http](https://github.com/rest-nvim/tree-sitter-http)
- Ships a native LSP server (`rest-cli`) that provides:
  - **Send HTTP requests** with a single click via runnables
  - **Hover** over `{{VAR}}` to see resolved environment variable values
  - **Diagnostics** for unresolved variables and invalid URLs
  - **Document & workspace symbols** for named requests (`# @name`)
- Supports `.env`, `.env.local`, and `.env.development` files for variable resolution
- Supports all standard HTTP methods: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, TRACE, CONNECT

### How the LSP binary is distributed

Pre-built binaries are published as GitHub Release assets for:
- `x86_64-unknown-linux-musl`
- `aarch64-unknown-linux-musl`
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`
- `x86_64-pc-windows-msvc`

The extension auto-downloads the correct binary on first use via `zed::latest_github_release` + `zed::download_file`.

### Checklist

- [x] Extension ID does not contain "zed"
- [x] `extension.toml` has all required fields
- [x] MIT license included
- [x] Repository is public
- [x] `pnpm sort-extensions` has been run
