### PR TITLE
Add night-owlify-dark-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4329,3 +4329,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/night-owlify-dark"]
+	path = extensions/night-owlify-dark
+	url = https://github.com/muhrusdi/zed-night-owlify-dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[night-owlify-dark]
+submodule = "extensions/night-owlify-dark"
+version = "0.0.1"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,6 +1,6 @@
 [night-owlify-dark]
 submodule = "extensions/night-owlify-dark"
-version = "0.0.1"
+version = "0.0.2"
 
 [0x96f]
 submodule = "extensions/0x96f"


### PR DESCRIPTION
# Night Owlify Dark
A Zed theme extending the beloved Night Owl Darkness, crafted to bring that iconic, eye-friendly deep dark aesthetic to your Zed editor. Perfect for late-night coding sessions, it offers a harmonious balance of vibrant accents against a comforting dark backdrop.