### PR TITLE
Add Path Server language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2834,6 +2834,10 @@
 	path = extensions/path-of-exile
 	url = https://github.com/egibs/poe.zed.git
 
+[submodule "extensions/path-server"]
+	path = extensions/path-server
+	url = https://github.com/kunlinglio/path-server.git
+
 [submodule "extensions/pathy"]
 	path = extensions/pathy
 	url = https://github.com/gokulp01/pathy.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2834,8 +2834,8 @@
 	path = extensions/path-of-exile
 	url = https://github.com/egibs/poe.zed.git
 
-[submodule "extensions/path-server"]
-	path = extensions/path-server
+[submodule "extensions/path-server-lsp"]
+	path = extensions/path-server-lsp
 	url = https://github.com/kunlinglio/path-server.git
 
 [submodule "extensions/pathy"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2871,10 +2871,10 @@ version = "0.1.0"
 submodule = "extensions/path-of-exile"
 version = "0.0.1"
 
-[path-server]
-submodule = "extensions/path-server"
+[path-server-lsp]
+submodule = "extensions/path-server-lsp"
 path = "extensions/zed"
-version = "0.2.0"
+version = "1.1.2"
 
 [pathy]
 submodule = "extensions/pathy"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2871,6 +2871,11 @@ version = "0.1.0"
 submodule = "extensions/path-of-exile"
 version = "0.0.1"
 
+[path-server]
+submodule = "extensions/path-server"
+path = "extensions/zed"
+version = "0.2.0"
+
 [pathy]
 submodule = "extensions/pathy"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **Path Server** extension, which is a `Path Intellisense` like extension for zed, provides fast, real-time file path auto-completion regardless of the programming language provided by a language server.

![Timeline 1](https://github.com/user-attachments/assets/a8329f63-de09-422f-b1e7-d98017467ef4)

### Features
- **Path Completion**: Provides real-time suggestions for both relative and absolute paths.
- **Fast and Lightweight**: Native-level response speed and consume only ~5MB memory with very low cpu usage.
- **Language Compatibility**: Support all text files discarding programming languages.

### Repository
[Path Server](https://github.com/kunlinglio/path-server)
[v0.2.0 Release](https://github.com/kunlinglio/path-server/releases/tag/v0.2.0)

### License
Apache-2.0