### PR TITLE
Update browser-tools-context-server to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -437,7 +437,7 @@ version = "0.0.4"
 
 [browser-tools-context-server]
 submodule = "extensions/browser-tools-context-server"
-version = "0.0.2"
+version = "0.1.0"
 
 [bsl]
 submodule = "extensions/bsl"


### PR DESCRIPTION
## Summary

- **Fix context server timeout** (#11, #9, #10): Changed from launching `@agentdeskai/browser-tools-server` (HTTP middleware that doesn't speak MCP) to `@agentdeskai/browser-tools-mcp` (actual MCP server over stdio)
- **Fix MCP protocol corruption**: `browser-tools-mcp` writes debug/discovery messages to stdout, breaking JSON-RPC. Added stdout filtering via `grep --line-buffered` to pass only JSON lines
- **Fix PATH resolution**: GUI apps on macOS don't inherit shell PATH. Auto-detect user's `$SHELL` and source appropriate rc file (`~/.zshrc` or `~/.bashrc`) for node version managers (nvm, fnm, proto, volta)
- **Zed Agent integration** (#3): MCP tools (getConsoleLogs, takeScreenshot, runAccessibilityAudit, etc.) are now natively available in Zed Agent
- Update `zed_extension_api` 0.5.0 → 0.7.0
- Update `browser-tools-mcp` 1.2.0 → 1.2.1
- Code refactoring and cleanup

## Test plan

- [x] Verified MCP handshake works with filtered stdout (clean JSON-RPC response)
- [x] Tested with restricted PATH (`/usr/bin:/bin`) — shell detection resolves npx correctly
- [x] Tested as dev extension in Zed — all 14 MCP tools registered successfully
- [x] Release build compiles for `wasm32-wasip2`