### PR TITLE
Add REST Client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3182,6 +3182,10 @@
 	path = extensions/rescript
 	url = https://github.com/rescript-lang/rescript-zed.git
 
+[submodule "extensions/restclient"]
+	path = extensions/restclient
+	url = https://github.com/zed-ext/restclient.git
+
 [submodule "extensions/retrofit-theme"]
 	path = extensions/retrofit-theme
 	url = https://github.com/snapsnapturtle/retrofit-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3228,6 +3228,10 @@ version = "0.0.2"
 submodule = "extensions/rescript"
 version = "0.4.3"
 
+[restclient]
+submodule = "extensions/restclient"
+version = "0.1.0"
+
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"


### PR DESCRIPTION
  HTTP client for testing REST APIs with .http files directly in Zed.

  - Repository: https://github.com/zed-ext/restclient
  - License: MIT
  - Schema version: 1
  - Extension ID: `restclient`

 ## Demo
![demo](https://github.com/user-attachments/assets/66bdcb1c-3558-4357-b94a-223805421702)


## Features

- **▶ Send Request** — Execute HTTP requests with a single click, reusing the same terminal
- **⊕ Send in New Tab** — Open response in a dedicated terminal tab, titled with the request URL
- **📋 Generate cURL** — Copy any request as a cURL command to clipboard
- **Syntax Highlighting** — Full highlighting for `.http` and `.rest` files (methods, URLs, headers, JSON bodies, comments, variables, response handlers)
- **Autocompletion** — HTTP methods, 23 header names with default values, header value completions for 13 header types, auth schemes, and `{{variable}}` references
- **Document Symbols** — Navigate requests via the symbol outline (`Cmd+Shift+O`)
- **Colored JSON Response** — Syntax-highlighted JSON output (keys=magenta, strings=green, numbers=cyan, booleans=yellow, null=red)
- **Animated Spinner** — Color-cycling braille spinner with elapsed time counter while requests are in flight
- **Precise Timing** — `X.XXXs` for responses ≥1s (e.g., `3.315s`), `Xms` for <1s
- **Environment Variables** — JetBrains-compatible `http-client.env.json` + `http-client.private.env.json` with parent directory search
- **Environment Switching** — `activeEnv` key in `http-client.env.json` to swap between development/staging/production
- **Response Variable Capture** — JetBrains-compatible `> {% client.global.set("name", response.body.field) %}` syntax
- **File-Level Variables** — `@variable = value` declarations with `{{variable}}` substitution and nested resolution
- **Detailed Error Messages** — Full error source chain (DNS, connection refused, timeout, etc.)
- **Multiple Requests** — Use `###` separators for multiple requests per file

## Technical Details

- Rust WASM extension using `zed_extension_api` 0.7.0
- Custom LSP server (`http-lsp`) built with `tower-lsp` — provides completions, document symbols, and diagnostics
- Standalone CLI binary (`http-client`) built with `reqwest` — executes requests, handles response capture, colored output
- Tree-sitter grammar from [rest-nvim/tree-sitter-http](https://github.com/rest-nvim/tree-sitter-http)
- Custom HTTP file parser with line-number tracking and `###` block splitting
- Variable resolution: file-level → global (captured) → environment → system
- Task runner integration with `show_summary: false` and `show_command: false` for clean terminal output
- No build warnings, 47 tests passing

## Install

```bash
git clone https://github.com/zed-ext/restclient.git
cd restclient
./install_to_zed.sh
```

Then restart Zed and open any `.http` file.