### PR TITLE
Add MJML language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2434,6 +2434,10 @@
 	path = extensions/mistral-vibe
 	url = https://github.com/mistralai/mistral-vibe.git
 
+[submodule "extensions/mjml"]
+	path = extensions/mjml
+	url = https://github.com/pataruco/zed-mjml.git
+
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen
 	url = https://github.com/feichai0017/mlir-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2472,6 +2472,10 @@ submodule = "extensions/mistral-vibe"
 version = "2.7.5"
 path = "distribution/zed"
 
+[mjml]
+submodule = "extensions/mjml"
+version = "0.1.0"
+
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
 version = "0.2.1"


### PR DESCRIPTION
Adds [MJML](https://mjml.io) email markup language support to Zed.

## Features: 

- Syntax highlighting with MJML-specific tag differentiation (reuses tree-sitter-html)
- Built-in LSP with real-time diagnostics: nesting validation, required attributes, unknown tag detection with typo suggestions, and singleton enforcement
- Bracket matching, auto-indentation, document outline, CSS injection for `<mj-style>` blocks
- Word-aware navigation for hyphenated tag names like `mj-section`

Repository:  https://github.com/pataruco/zed-mjml

