### PR TITLE
Add memory MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2162,6 +2162,10 @@
 	path = extensions/mcp-server-master-go
 	url = https://github.com/aizigao/zed-mcp-server-master-go.git
 
+[submodule "extensions/mcp-server-memory"]
+	path = extensions/mcp-server-memory
+	url = https://github.com/robin-afro/zed-mcp-memory
+
 [submodule "extensions/mcp-server-miaoduo"]
 	path = extensions/mcp-server-miaoduo
 	url = https://github.com/benmooo/zed-mcp-server-miaoduo.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2195,6 +2195,10 @@ version = "0.0.1"
 submodule = "extensions/mcp-server-master-go"
 version = "0.0.1"
 
+[mcp-server-memory]
+submodule = "extensions/mcp-server-memory"
+version = "0.1.0"
+
 [mcp-server-miaoduo]
 submodule = "extensions/mcp-server-miaoduo"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds an MCP server for agent memories, wrapping the official [`@modelcontextprotocol/server-memory`](https://www.npmjs.com/package/@modelcontextprotocol/server-memory) package.