### PR TITLE
Add update-versions language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3990,9 +3990,9 @@
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
 
-[submodule "extensions/update-versions"]
-	path = extensions/update-versions
-	url = https://github.com/christophehurpeau/zed-update-versions.git
+[submodule "extensions/update-versions-lsp"]
+	path = extensions/update-versions-lsp
+	url = https://github.com/christophehurpeau/zed-update-versions-lsp.git
 
 [submodule "extensions/usd"]
 	path = extensions/usd

--- a/.gitmodules
+++ b/.gitmodules
@@ -3922,6 +3922,10 @@
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
 
+[submodule "extensions/update-versions"]
+	path = extensions/update-versions
+	url = https://github.com/christophehurpeau/zed-update-versions.git
+
 [submodule "extensions/usd"]
 	path = extensions/usd
 	url = https://github.com/elkraneo/zed-usd.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3975,6 +3975,11 @@ version = "0.0.5"
 submodule = "extensions/unoflat"
 version = "0.1.4"
 
+[update-versions]
+submodule = "extensions/update-versions"
+path = "extension"
+version = "0.1.0"
+
 [usd]
 submodule = "extensions/usd"
 version = "0.1.0"


### PR DESCRIPTION
Adds the [update-versions](https://github.com/christophehurpeau/zed-update-versions) extension.

This extension shows inline inlay hints with the latest available version for each dependency in supported manifest files, via a native LSP server.

- Extension id: `update-versions-lsp`
- Version: `0.2.0`
- License: MIT
- Supported manifests: npm / Node.js (package.json), Rust / Cargo (Cargo.toml), Python / PyPI (requirements.txt, pyproject.toml), Ruby / Bundler (Gemfile), Composer (composer.json), Deno (deno.json, import_map.json).