### PR TITLE
Add coverage-lsp language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -818,6 +818,10 @@
 	path = extensions/cosmos
 	url = https://github.com/nauvalazhar/cosmos.git
 
+[submodule "extensions/coverage-lsp"]
+	path = extensions/coverage-lsp
+	url = https://github.com/fargies/coverage-lsp.git
+
 [submodule "extensions/cpp2"]
 	path = extensions/cpp2
 	url = https://github.com/tsoj/zed-cpp2.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -830,6 +830,11 @@ version = "0.4.2"
 submodule = "extensions/cosmos"
 version = "0.0.1"
 
+[coverage-lsp]
+submodule = "extensions/coverage-lsp"
+version = "1.0.1"
+path = "zed-coverage-lsp"
+
 [cpp2]
 submodule = "extensions/cpp2"
 version = "0.1.0"


### PR DESCRIPTION
Adds code-coverage language-server for Zed.

This project implements a Code Coverage [Language Server](https://microsoft.github.io/language-server-protocol/) that reads [LCOV](https://lcov.readthedocs.io/) coverage reports and exposes the results through the Language Server Protocol.

Coverage information is surfaced using the [textDocument/documentColor](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentColor) request, allowing editors to visually highlight covered and uncovered lines.

Project is crawled for "*.info" (file-path may also be configured), re-loading the file on changes, colors may also be customized.

Here's an example configuration:
```json
{
  "lsp": {
    "coverage-lsp": {
      "settings": {
        "hit": null,
        "miss": "#FFAA0020",
        "interval": "20s",
        "lcov_file": "./build/lcov.info"
      }
    }
  }
}
```

Inspired from [color-lsp](https://github.com/huacnlee/color-lsp), pre-built language-server binaries are hosted on GitHub and downloaded from latest release.

This extension is really simple on purpose, still it felt like a missing piece in Zed.

Repository: https://github.com/fargies/coverage-lsp (hosting language-server and extension)

<img width="946" height="1022" alt="Screenshot" src="https://github.com/user-attachments/assets/3e6ac62e-606e-4ab2-92cb-6ea60f7f337e" />
