### PR TITLE
Add vscode-classics themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4286,6 +4286,10 @@
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed
 
+[submodule "extensions/vscode-classics"]
+	path = extensions/vscode-classics
+	url = https://github.com/alanisme/vscode-themes-for-zed
+
 [submodule "extensions/vscode-dark-high-contrast"]
 	path = extensions/vscode-dark-high-contrast
 	url = https://github.com/nick-myrick/vscode-dark-high-contrast.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4394,6 +4394,10 @@
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed
 
+[submodule "extensions/vscode-classics"]
+	path = extensions/vscode-classics
+	url = https://github.com/alanisme/vscode-themes-for-zed
+
 [submodule "extensions/vscode-dark-high-contrast"]
 	path = extensions/vscode-dark-high-contrast
 	url = https://github.com/nick-myrick/vscode-dark-high-contrast.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4394,8 +4394,8 @@
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed
 
-[submodule "extensions/vscode-classics-theme"]
-	path = extensions/vscode-classics-theme
+[submodule "extensions/vscode-classic-themes"]
+	path = extensions/vscode-classic-themes
 	url = https://github.com/alanisme/vscode-themes-for-zed
 
 [submodule "extensions/vscode-dark-high-contrast"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4394,8 +4394,8 @@
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed
 
-[submodule "extensions/vscode-classics"]
-	path = extensions/vscode-classics
+[submodule "extensions/vscode-classics-theme"]
+	path = extensions/vscode-classics-theme
 	url = https://github.com/alanisme/vscode-themes-for-zed
 
 [submodule "extensions/vscode-dark-high-contrast"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4346,6 +4346,10 @@ version = "0.1.0"
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"
 
+[vscode-classics]
+submodule = "extensions/vscode-classics"
+version = "0.1.0"
+
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4348,7 +4348,7 @@ version = "0.0.1"
 
 [vscode-classics]
 submodule = "extensions/vscode-classics"
-version = "0.2.0"
+version = "0.3.0"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4348,7 +4348,7 @@ version = "0.0.1"
 
 [vscode-classics]
 submodule = "extensions/vscode-classics"
-version = "0.1.0"
+version = "0.2.0"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4457,7 +4457,7 @@ version = "0.0.1"
 
 [vscode-classics]
 submodule = "extensions/vscode-classics"
-version = "0.1.0"
+version = "0.2.0"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4457,7 +4457,7 @@ version = "0.0.1"
 
 [vscode-classics]
 submodule = "extensions/vscode-classics"
-version = "0.2.0"
+version = "0.3.0"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4455,6 +4455,10 @@ version = "0.1.0"
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"
 
+[vscode-classics]
+submodule = "extensions/vscode-classics"
+version = "0.1.0"
+
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4457,7 +4457,7 @@ version = "0.0.1"
 
 [vscode-classics]
 submodule = "extensions/vscode-classics"
-version = "0.3.0"
+version = "0.4.0"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4455,8 +4455,8 @@ version = "0.1.0"
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"
 
-[vscode-classics-theme]
-submodule = "extensions/vscode-classics-theme"
+[vscode-classic-themes]
+submodule = "extensions/vscode-classic-themes"
 version = "0.4.0"
 
 [vscode-dark-high-contrast]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4455,8 +4455,8 @@ version = "0.1.0"
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"
 
-[vscode-classics]
-submodule = "extensions/vscode-classics"
+[vscode-classics-theme]
+submodule = "extensions/vscode-classics-theme"
 version = "0.4.0"
 
 [vscode-dark-high-contrast]


### PR DESCRIPTION
All 17 built-in Visual Studio Code color themes, ported to Zed.                                                                                                                       
                                                                                                                                                                                        
  - Converts directly from VS Code source (pinned to v1.96.4)                                                                                                                           
  - Includes all dark, light, and high-contrast variants
  - UI colors, syntax highlighting, and terminal palettes                                                                                                                               
                                                            
Repository: https://github.com/alanisme/vscode-themes-for-zed 