### PR TITLE
Add high contrast themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1566,8 +1566,8 @@
 	path = extensions/hexpeek
 	url = https://github.com/A-23187/zed-hexpeek.git
 
-[submodule "extensions/high-contrast-zed"]
-	path = extensions/high-contrast-zed
+[submodule "extensions/high-contrast-themes"]
+	path = extensions/high-contrast-themes
 	url = https://github.com/rakshit087/high-contrast-zed.git
 
 [submodule "extensions/hilleer-v-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1546,6 +1546,10 @@
 	path = extensions/hexpeek
 	url = https://github.com/A-23187/zed-hexpeek.git
 
+[submodule "extensions/high-contrast-zed"]
+	path = extensions/high-contrast-zed
+	url = https://github.com/rakshit087/high-contrast-zed.git
+
 [submodule "extensions/hilleer-v-theme"]
 	path = extensions/hilleer-v-theme
 	url = https://github.com/hilleer/zed-v-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1570,6 +1570,10 @@ version = "0.0.4"
 submodule = "extensions/hexpeek"
 version = "0.1.0"
 
+[high-contrast-theme]
+submodule = "extensions/high-contrast-zed"
+version = "0.1.0"
+
 [hilleer-v-theme]
 submodule = "extensions/hilleer-v-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1591,7 +1591,7 @@ submodule = "extensions/hexpeek"
 version = "0.1.0"
 
 [high-contrast-theme]
-submodule = "extensions/high-contrast-zed"
+submodule = "extensions/high-contrast-themes"
 version = "0.1.0"
 
 [hilleer-v-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1590,7 +1590,7 @@ version = "0.0.4"
 submodule = "extensions/hexpeek"
 version = "0.1.0"
 
-[high-contrast-theme]
+[high-contrast-themes]
 submodule = "extensions/high-contrast-themes"
 version = "0.1.0"
 


### PR DESCRIPTION
Adds 10 high contrast theme variants of popular dark themes for Zed — designed for maximum readability and reduced eye strain.

| Theme | Base |
|---|---|
| High Contrast Ayu | [Ayu](https://github.com/ayu-theme/ayu-colors) |
| High Contrast VSCode | VSCode Dark+ |
| High Contrast One Dark | [One Dark](https://github.com/atom/one-dark-ui) |
| High Contrast Catppuccin Mocha | [Catppuccin Mocha](https://github.com/catppuccin/catppuccin) |
| High Contrast Gruvbox | [Gruvbox](https://github.com/morhetz/gruvbox) |
| High Contrast Tokyo Night | [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) |
| High Contrast Dracula | [Dracula](https://draculatheme.com/) |
| High Contrast Nord | [Nord](https://www.nordtheme.com/) |
| High Contrast Monokai | [Monokai](https://monokai.pro/) |
| High Contrast Solarized Dark | [Solarized](https://ethanschoonover.com/solarized/) |

