### PR TITLE
Add Djot language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4381,3 +4381,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/djot"]
+	path = extensions/djot
+	url = https://github.com/nzoschke/zed-djot.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -946,6 +946,10 @@
 	path = extensions/django-snippets
 	url = https://github.com/bencres/zed-django-snippets.git
 
+[submodule "extensions/djot"]
+	path = extensions/djot
+	url = https://github.com/nzoschke/zed-djot.git
+
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose
 	url = https://github.com/eth0net/zed-docker-compose.git
@@ -4381,6 +4385,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/djot"]
-	path = extensions/djot
-	url = https://github.com/nzoschke/zed-djot.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -959,6 +959,10 @@ version = "0.2.2"
 submodule = "extensions/django-snippets"
 version = "0.0.1"
 
+[djot]
+submodule = "extensions/djot"
+version = "0.1.0"
+
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"


### PR DESCRIPTION
- Adds [Djot](https://djot.net/) markup language support for Zed
- Syntax highlighting, bracket matching, indentation, outline, and language injection for code blocks
- Uses [tree-sitter-djot](https://github.com/nzoschke/tree-sitter-djot) (fork with WASI-compatible scanner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)