### PR TITLE
Add NetCoreDbg (.NET Core debugger) extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2506,6 +2506,10 @@
 	path = extensions/nestjs-snippets
 	url = https://github.com/ayberkgezer/nestjs-snippets.git
 
+[submodule "extensions/netcoredbg"]
+	path = extensions/netcoredbg
+	url = https://github.com/NeverGET/netcoredbg-zed.git
+
 [submodule "extensions/netlinx"]
 	path = extensions/netlinx
 	url = https://github.com/Norgate-AV/zed-netlinx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2541,6 +2541,10 @@ version = "0.3.0"
 submodule = "extensions/nestjs-snippets"
 version = "0.1.4"
 
+[netcoredbg]
+submodule = "extensions/netcoredbg"
+version = "0.1.0"
+
 [netlinx]
 submodule = "extensions/netlinx"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds a **netcoredbg** extension that provides .NET Core debugging support via Samsung's [netcoredbg](https://github.com/Samsung/netcoredbg) DAP debugger.

- **Auto-downloads** netcoredbg from Samsung's GitHub releases (no manual install required)
- Supports **launch** and **attach** debug scenarios
- Full DAP configuration via `.zed/debug.json` (program, args, cwd, env, stopAtEntry, processId)
- Falls back to system-installed binary or user-configured path

### Platform Support

| Platform | Asset | Status |
|----------|-------|--------|
| Linux x64 | `netcoredbg-linux-amd64.tar.gz` | Full support |
| Linux ARM64 | `netcoredbg-linux-arm64.tar.gz` | Full support |
| macOS x64 | `netcoredbg-osx-amd64.tar.gz` | Full support |
| macOS ARM64 | `netcoredbg-osx-amd64.tar.gz` | Via Rosetta 2 |
| Windows x64 | `netcoredbg-win64.zip` | Full support |

### Extension Repo

https://github.com/NeverGET/netcoredbg-zed