### PR TITLE
ci: Make license checks line-insensitive

### DIFF
--- a/src/lib/license.js
+++ b/src/lib/license.js
@@ -1,6 +1,17 @@
 import path from "node:path";
 
 /**
+ * Normalizes whitespace in the given text by collapsing all sequences of
+ * whitespace characters (spaces, newlines, tabs, etc.) into a single space.
+ * This makes license matching insensitive to text wrapping.
+ * @param {string} text
+ * @returns {string}
+ */
+export function normalizeWhitespace(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/**
  * @param {string} fileName
  * @returns {boolean}
  */
@@ -45,12 +56,12 @@ const BSD_COMMON_PATTERNS = [
   /1\. Redistributions of source code must retain the above copyright/i,
   /2\. Redistributions in binary form must reproduce the above copyright/i,
   /THIS SOFTWARE IS PROVIDED BY THE (?:COPYRIGHT HOLDERS AND CONTRIBUTORS|AUTHOR AND CONTRIBUTORS) "AS IS"/i,
-  /IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE[ \n]ARE/i,
-  /DISCLAIMED\.[\s\S]{1,2}IN NO EVENT SHALL THE (?:COPYRIGHT HOLDER|AUTHOR) OR CONTRIBUTORS BE LIABLE/i,
+  /IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE/i,
+  /DISCLAIMED\. IN NO EVENT SHALL THE (?:COPYRIGHT HOLDER|AUTHOR) OR CONTRIBUTORS BE LIABLE/i,
 ];
 
 const BSD_3_CLAUSE_ONLY_PATTERN =
-  /3\. Neither the name of the copyright holder nor the names of its[\s\S]{1,4}contributors may[\s\S]{1,4}be used to endorse or promote products derived from/i;
+  /3\. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from/i;
 
 /**
  * @param {string} licenseContent
@@ -108,9 +119,9 @@ export function isGplV3License(licenseContent) {
 
 const MIT_REQUIRED_PATTERNS = [
   /Copyright/i,
-  /Permission is hereby granted, free of charge, to any[ \n]person obtaining a copy/i,
-  /The above copyright notice and this permission notice[ \n]shall be included in[ \n]all/i,
-  /THE SOFTWARE IS PROVIDED ["“]AS IS["”], WITHOUT WARRANTY OF[ \n]ANY KIND, EXPRESS OR/i,
+  /Permission is hereby granted, free of charge, to any person obtaining a copy/i,
+  /The above copyright notice and this permission notice shall be included in all/i,
+  /THE SOFTWARE IS PROVIDED ["“]AS IS["”], WITHOUT WARRANTY OF ANY KIND, EXPRESS OR/i,
 ];
 
 /**

--- a/src/lib/test-licenses/utilities.js
+++ b/src/lib/test-licenses/utilities.js
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
+import { normalizeWhitespace } from "../license.js";
 
 export function readApache2License() {
   return readLicenseFile("test-apache-2-license");
@@ -64,7 +65,9 @@ export function readLicenseFile(fileName) {
     return content;
   }
 
-  content = fs.readFileSync(path.join(__dirname, fileName), "utf-8");
+  content = normalizeWhitespace(
+    fs.readFileSync(path.join(__dirname, fileName), "utf-8"),
+  );
   licenseCache.set(fileName, content);
 
   return content;

--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -9,6 +9,7 @@ import {
   isMitLicense,
   isUnlicense,
   isZlibLicense,
+  normalizeWhitespace,
 } from "./license.js";
 
 const EXTENSION_ID_PATTERN = /^[a-z0-9\-]+$/;
@@ -184,16 +185,17 @@ export function validateLicense(licenseCandidates) {
   }
 
   for (const license_data of licenseCandidates) {
+    const content = normalizeWhitespace(license_data.content);
     const isValidLicense =
-      isApache2License(license_data.content) ||
-      isBsd2ClauseLicense(license_data.content) ||
-      isBsd3ClauseLicense(license_data.content) ||
-      isCcBy4License(license_data.content) ||
-      isGplV3License(license_data.content) ||
-      isLgplV3License(license_data.content) ||
-      isMitLicense(license_data.content) ||
-      isUnlicense(license_data.content) ||
-      isZlibLicense(license_data.content);
+      isApache2License(content) ||
+      isBsd2ClauseLicense(content) ||
+      isBsd3ClauseLicense(content) ||
+      isCcBy4License(content) ||
+      isGplV3License(content) ||
+      isLgplV3License(content) ||
+      isMitLicense(content) ||
+      isUnlicense(content) ||
+      isZlibLicense(content);
 
     if (isValidLicense) {
       return;


### PR DESCRIPTION
This should help us with valid licenses that we do not detect due to different line breaks, which happens rather frequently.