### PR TITLE
Add aoe2-rms extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,6 +134,10 @@
 	path = extensions/anysphere-theme
 	url = https://github.com/stpn48/anysphere-zed-theme
 
+[submodule "extensions/aoe2-rms"]
+	path = extensions/aoe2-rms
+	url = https://github.com/twestura/zed-aoe2-rms.git
+
 [submodule "extensions/apache-avro"]
 	path = extensions/apache-avro
 	url = https://github.com/victorhqc/zed-apache-avro.git


### PR DESCRIPTION
Adds syntax highlighting for Age of Empires II random map scripts (.rms), using [tree-sitter-aoe2-rms](https://github.com/twestura/tree-sitter-aoe2-rms).