### PR TITLE
Add DevGlobe extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4401,3 +4401,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "zed-devglobe"]
+	path = zed-devglobe
+	url = https://github.com/CaadriFR/zed-devglobe.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -947,6 +947,10 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
+[devglobe]
+submodule = "extensions/devglobe"
+version = "0.1.0"
+
 [devicetree]
 submodule = "extensions/devicetree"
 version = "0.0.1"


### PR DESCRIPTION

  ## DevGlobe — Live coding presence on a 3D globe

  [DevGlobe](https://devglobe.xyz) shows developers coding in real time on
  an interactive world map. This extension brings DevGlobe tracking to Zed.

  ### How it works

  - A lightweight Language Server receives `didOpen`/`didChange`/`didSave`
  events
  - Sends a heartbeat every 30 seconds while the developer is actively
  coding
  - Pauses automatically after 1 minute of inactivity
  - Detects programming language, git repository, and city-level location

  ### Features

  - 80+ languages supported
  - Anonymous mode (random city in your country)
  - Repository sharing (opt-in)
  - Status message
  - Offline detection with auto-recovery
  - Configuration via `~/.devglobe/api_key` and `~/.devglobe/config.json`

  ### Requirements

  - Node.js 18+
  - A DevGlobe API key from [devglobe.xyz](https://devglobe.xyz)

  ### Privacy

  No source code, file contents, or keystrokes are sent. Only language
  name, city-level location, and editor name. [Full privacy policy](https://github.com/Nako0/devglobe-extension/blob/main/PRIVACY.md).

  **Repository:** https://github.com/CaadriFR/zed-devglobe
  **License:** MIT