### PR TITLE
Update Superior Green theme to v0.0.20

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3694,7 +3694,7 @@ version = "0.1.0"
 
 [superior-green-theme]
 submodule = "extensions/superior-green-theme"
-version = "0.0.10"
+version = "0.0.20"
 
 [supertheme4]
 submodule = "extensions/supertheme4"


### PR DESCRIPTION
- Set keyword styling to the new green accent (#50C878) in both theme variants
- Refresh the preview image to match current visuals
- Fix an extension.toml typo and bump version to 0.0.20