### PR TITLE
Add go-profile language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1398,6 +1398,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/go-profile"]
+	path = extensions/go-profile
+	url = https://github.com/lukasbash7/zed-go-profile.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1421,6 +1421,11 @@ submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.2"
 
+[go-profile]
+submodule = "extensions/go-profile"
+path = "extension"
+version = "0.0.1"
+
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

Adds the **Go Profile** extension, which provides inline Go pprof profiling annotations via an LSP server.

### Features
- **Inlay hints**: Inline cost annotations (flat/cumulative time and percentages) on profiled lines, with severity indicators
- **Code lenses**: Function-level hotspot summaries showing rank, flat cost, and cumulative cost
- **Diagnostics**: Configurable diagnostics for profiled lines above a threshold (appears in Diagnostics panel)
- **Auto-reload**: Watches profile files for changes and refreshes annotations automatically

### Architecture
- Thin Zed WASM extension that registers a secondary LSP for Go files
- Standalone Rust LSP server (`go-profile-lsp`) that parses pprof protobuf profiles and serves hints/lenses/diagnostics
- 86 tests, zero clippy warnings

### Repository
https://github.com/lukasbash7/zed-go-profile

### License
MIT