### PR TITLE
Add Veliora theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
-	url = https://github.com/szymkab/a-touch-of-lilac-theme
+	url = https://github.com/szymkab/a-touch-of-lilac-theme.git
 
 [submodule "extensions/abysswalker-theme"]
 	path = extensions/abysswalker-theme
@@ -4064,7 +4064,7 @@
 
 [submodule "extensions/vhdl"]
 	path = extensions/vhdl
-	url = https://github.com/rapgenic/zed-vhdl
+	url = https://github.com/rapgenic/zed-vhdl.git
 
 [submodule "extensions/vhs"]
 	path = extensions/vhs
@@ -4072,7 +4072,7 @@
 
 [submodule "extensions/vhs80-theme"]
 	path = extensions/vhs80-theme
-	url = https://github.com/tahayvr/vhs80-zed
+	url = https://github.com/tahayvr/vhs80-zed.git
 
 [submodule "extensions/vibescript"]
 	path = extensions/vibescript
@@ -4092,7 +4092,7 @@
 
 [submodule "extensions/vintergata"]
 	path = extensions/vintergata
-	url = https://github.com/webhooked/vintergata-zed
+	url = https://github.com/webhooked/vintergata-zed.git
 
 [submodule "extensions/veliora-theme-zed"]
 	path = extensions/veliora-theme-zed
@@ -4108,11 +4108,11 @@
 
 [submodule "extensions/vitesse-theme-refined"]
 	path = extensions/vitesse-theme-refined
-	url = https://github.com/colinlienard/zed-vitesse-theme-refined
+	url = https://github.com/colinlienard/zed-vitesse-theme-refined.git
 
 [submodule "extensions/vitest-snippets"]
 	path = extensions/vitest-snippets
-	url = https://github.com/jwerre/vitest-snippets
+	url = https://github.com/jwerre/vitest-snippets.git
 
 [submodule "extensions/vrl"]
 	path = extensions/vrl

--- a/.gitmodules
+++ b/.gitmodules
@@ -4094,6 +4094,10 @@
 	path = extensions/vintergata
 	url = https://github.com/webhooked/vintergata-zed
 
+[submodule "extensions/veliora-theme-zed"]
+	path = extensions/veliora-theme-zed
+	url = https://github.com/franzgollhammer/veliora-theme-zed.git
+
 [submodule "extensions/visual-assist-dark"]
 	path = extensions/visual-assist-dark
 	url = https://github.com/trojanfoe/visual-assist-dark.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4149,6 +4149,10 @@ version = "0.5.1"
 submodule = "extensions/vintergata"
 version = "0.0.1"
 
+[veliora-theme-zed]
+submodule = "extensions/veliora-theme-zed"
+version = "0.1.0"
+
 [visual-assist-dark]
 submodule = "extensions/visual-assist-dark"
 version = "0.0.5"


### PR DESCRIPTION
## Summary
- add the Veliora Zed theme extension registry entry
- add the Veliora repository as a submodule
- publish version 0.1.0 from franzgollhammer/veliora-theme-zed

## Extension
https://github.com/franzgollhammer/veliora-theme-zed