### PR TITLE
Update vibe-code-guardian to v0.10.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4129,6 +4129,10 @@ version = "0.1.0"
 submodule = "extensions/vhs80-theme"
 version = "1.0.0"
 
+[vibe-code-guardian]
+submodule = "extensions/vibe-code-guardian"
+version = "0.10.0"
+
 [vibescript]
 submodule = "extensions/vibescript"
 version = "0.0.1"


### PR DESCRIPTION
## Update Vibe Code Guardian Extension

**Extension ID:** `vibe-code-guardian`
**Version:** `0.10.0`
**Repository:** https://github.com/aresnasa/vibe-code-guardian-zed
**License:** MIT

### Description

A game-like checkpoint/save system for AI-assisted coding (vibe coding).

### Changes

- Updated extension to v0.10.0
- Submodule pointer updated to latest commit

### Checklist

- [x] Extension repository uses HTTPS URL
- [x] `extension.toml` has required fields
- [x] MIT license included
- [x] Extension compiles to wasm32-wasip1
- [x] `extensions.toml` version matches `extension.toml`
- [x] Extension ID does not contain "zed"