### PR TITLE
Add Relaxed theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4409,3 +4409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/relaxed-theme"]
+	path = extensions/relaxed-theme
+	url = https://github.com/stefanbc/relaxed-zed-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -3222,6 +3222,10 @@
 	path = extensions/rego
 	url = https://github.com/StyraInc/zed-rego.git
 
+[submodule "extensions/relaxed-theme"]
+	path = extensions/relaxed-theme
+	url = https://github.com/stefanbc/relaxed-zed-theme
+
 [submodule "extensions/relay"]
 	path = extensions/relay
 	url = https://github.com/XiNiHa/relay-zed
@@ -4409,6 +4413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/relaxed-theme"]
-	path = extensions/relaxed-theme
-	url = https://github.com/stefanbc/relaxed-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -3361,6 +3361,10 @@ version = "0.11.11"
 submodule = "extensions/rego"
 version = "0.0.2"
 
+[relaxed-theme]
+submodule = "extensions/relaxed-theme"
+version = "0.1.0"
+
 [relay]
 submodule = "extensions/relay"
 version = "0.0.5"


### PR DESCRIPTION
Adds the **Relaxed** theme — a port of the popular [Relaxed VSCode theme](https://github.com/Relaxed-Theme/vscode-theme-relaxed/).

A dark theme built around muted, warm tones on a deep grey background, designed for long coding sessions without eye strain.

<img width="2688" height="1554" alt="zed dev_theme-builder_ref=zed-themes com" src="https://github.com/user-attachments/assets/fecc243d-17f9-4552-b0b8-5a1b1b439ad2" />

---

**Checklist**
- [x] Extension repo is public on GitHub
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml`
- [x] `pnpm sort-extensions` run
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] Extension ID is suffixed with `-theme`
- [x] License file present at repo root (MIT)
- [x] Tested locally via Install Dev Extension