### PR TITLE
Add 42-tools language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/42-tools"]
+	path = extensions/42-tools
+	url = https://github.com/EdizKeskin/42-tools-zed.git
+
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[42-tools]
+submodule = "extensions/42-tools"
+version = "0.1.5"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the `42-tools` Zed extension.

Repository:
- https://github.com/EdizKeskin/42-tools-zed

Version:
- `0.1.5`

Release:
- `v0.1.5`

## What It Does

- Inserts 42 headers for `.c` and `.h` files
- Updates the `Updated` line on save
- Runs 42 C formatting on save