### PR TITLE
Add Headroom extension — context compression for AI agents

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4409,3 +4409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/headroom"]
+	path = extensions/headroom
+	url = https://github.com/chopratejas/headroom-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1565,6 +1565,10 @@ version = "0.2.1"
 submodule = "extensions/haxe"
 version = "0.3.1"
 
+[headroom]
+submodule = "extensions/headroom"
+version = "0.1.0"
+
 [hbuilderx-push-light]
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"


### PR DESCRIPTION
Adds [Headroom](https://github.com/chopratejas/headroom) as an MCP context server extension.

## What it does

Registers Headroom's MCP server with Zed, giving the AI agent three tools:

- **headroom_compress** — Compress large content on demand (50-90% token savings on tool outputs, JSON, code, logs)
- **headroom_retrieve** — Retrieve original uncompressed content by hash (lossless)
- **headroom_stats** — Session compression statistics

## Details

- WASM binary: 130KB
- Requires `headroom` CLI in PATH (`pip install "headroom-ai[mcp]"`)
- Apache 2.0 licensed
- Extension repo: https://github.com/chopratejas/headroom-zed