### PR TITLE
Add Noe theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4411,4 +4411,4 @@
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
 [submodule "extensions/noe-theme"]
 	path = extensions/noe-theme
-	url = https://github.com/devmoran/zed-theme-now
+	url = https://github.com/devmoran/zed-theme-noe

--- a/.gitmodules
+++ b/.gitmodules
@@ -4409,3 +4409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/noe-theme"]
+	path = extensions/noe-theme
+	url = https://github.com/devmoran/zed-theme-now

--- a/extensions.toml
+++ b/extensions.toml
@@ -2702,6 +2702,10 @@ version = "0.0.1"
 submodule = "extensions/nvim-nightfox"
 version = "0.7.0"
 
+[noe-theme]
+submodule = "extensions/noe-theme"
+version = "1.0.0"
+
 [nyxvamp-theme]
 submodule = "extensions/nyxvamp-theme"
 version = "0.3.0"


### PR DESCRIPTION
Adds the Noe theme extension — a dark and light theme ported from the [Noe Dark VSCode extension](https://github.com/devmoran/theme-noe-dark).

- Noe Dark
- Noe Light

Repository: https://github.com/devmoran/zed-theme-now