### PR TITLE
Add WooCommerce snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4238,6 +4238,10 @@
 	path = extensions/witchesbrew-theme
 	url = https://github.com/shoenot/witchesbrew.zed
 
+[submodule "extensions/woocommerce-snippets"]
+	path = extensions/woocommerce-snippets
+	url = https://github.com/renzojohnson/woocommerce-snippets.git
+
 [submodule "extensions/wow-toc"]
 	path = extensions/wow-toc
 	url = https://github.com/Alexayy/zed-wow-toc.git
@@ -4409,6 +4413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/woocommerce-snippets"]
-	path = extensions/woocommerce-snippets
-	url = https://github.com/renzojohnson/woocommerce-snippets.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4409,3 +4409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/woocommerce-snippets"]
+	path = extensions/woocommerce-snippets
+	url = https://github.com/renzojohnson/woocommerce-snippets.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4295,6 +4295,10 @@ version = "0.4.0"
 submodule = "extensions/witchesbrew-theme"
 version = "1.0.0"
 
+[woocommerce-snippets]
+submodule = "extensions/woocommerce-snippets"
+version = "0.1.0"
+
 [wow-toc]
 submodule = "extensions/wow-toc"
 version = "0.0.1"


### PR DESCRIPTION
Adds **WooCommerce Snippets** — 180 curated PHP snippets for WooCommerce development.

## Features

- **180 snippets** across 17 categories: hooks, CRUD, HPOS, Block Checkout, REST API, checkout, cart, admin, emails, shipping, queries, conditionals, templates, Action Scheduler, security, notices/logging, utilities
- **25 choice dropdowns** for HTTP methods, capabilities, field types, order statuses, product types, log levels
- **31 linked placeholders** — type once, auto-fills everywhere (textdomains, callbacks, slugs)
- **Smart defaults** — every snippet produces complete, runnable PHP code

## Extension info

- **ID:** `woocommerce-snippets`
- **Type:** Snippet-only (no Rust/WASM)
- **Repository:** https://github.com/renzojohnson/woocommerce-snippets
- **License:** MIT