### PR TITLE
Add effect-language-service-tsgo language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1030,6 +1030,10 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/effect-tsgo"]
+	path = extensions/effect-tsgo
+	url = https://github.com/RATIU5/zed-effect-tsgo.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -4409,6 +4413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/effect-tsgo"]
-	path = extensions/effect-tsgo
-	url = https://github.com/RATIU5/zed-effect-tsgo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1058,10 +1058,6 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
-[submodule "extensions/effect-tsgo"]
-	path = extensions/effect-tsgo
-	url = https://github.com/RATIU5/zed-effect-tsgo.git
-
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -4589,3 +4585,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/effect-language-service-tsgo"]
+	path = extensions/effect-language-service-tsgo
+	url = https://github.com/RATIU5/zed-effect-tsgo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4409,3 +4409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/effect-tsgo"]
+	path = extensions/effect-tsgo
+	url = https://github.com/RATIU5/zed-effect-tsgo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1106,6 +1106,10 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/effect-language-service-tsgo"]
+	path = extensions/effect-language-service-tsgo
+	url = https://github.com/RATIU5/zed-effect-tsgo.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -4713,6 +4717,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/effect-language-service-tsgo"]
-	path = extensions/effect-language-service-tsgo
-	url = https://github.com/RATIU5/zed-effect-tsgo.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1073,9 +1073,9 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
-[effect-tsgo]
-submodule = "extensions/effect-tsgo"
-version = "0.0.2"
+[effect-language-service-tsgo]
+submodule = "extensions/effect-language-service-tsgo"
+version = "0.0.3"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,6 +1044,10 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
+[effect-tsgo]
+submodule = "extensions/effect-tsgo"
+version = "0.0.1"
+
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1058,7 +1058,7 @@ version = "0.1.0"
 
 [effect-tsgo]
 submodule = "extensions/effect-tsgo"
-version = "0.0.1"
+version = "0.0.2"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1169,7 +1169,7 @@ version = "0.1.0"
 
 [effect-language-service-tsgo]
 submodule = "extensions/effect-language-service-tsgo"
-version = "0.0.3"
+version = "0.0.4"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"


### PR DESCRIPTION
Building on top of [tsgo](https://github.com/zed-extensions/tsgo), this extension replaces the upstream tsgo binary with Effect's fork ([https://github.com/Effect-TS/tsgo](https://github.com/Effect-TS/tsgo))which adds Effect-TS-specific diagnostics and quick fixes to the native TypeScript language server. This allows Effect developers to use the Effect Language Service directly within Zed.  

Attributions  

This extension is a derivative of https://github.com/zed-extensions/tsgo by Zed Industries, Inc., licensed under Apache 2.0. 

The following changes were made: 
- Replaced the @typescript/native-preview binary target with @effect/tsgo 
- Updated binary resolution to use the @effect/tsgo platform-specific packages 
- Updated extension metadata (name, description, authors, repository)  

Both copyright notices are retained in the LICENSE file per Apache  2.0 Section 4(c).