### PR TITLE
Add MJML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2354,6 +2354,10 @@
 	path = extensions/mistral-vibe
 	url = https://github.com/mistralai/mistral-vibe.git
 
+[submodule "extensions/mjml"]
+	path = extensions/mjml
+	url = https://github.com/jaredlyvers/zed-mjml.git
+
 [submodule "extensions/mnemonic"]
 	path = extensions/mnemonic
 	url = https://github.com/mnemonic-theme/zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2389,6 +2389,10 @@ submodule = "extensions/mistral-vibe"
 version = "2.5.0"
 path = "distribution/zed"
 
+[mjml]
+submodule = "extensions/mjml"
+version = "0.1.3"
+
 [mnemonic]
 submodule = "extensions/mnemonic"
 version = "0.0.1"


### PR DESCRIPTION
  - Adds MJML language support for Zed
  - Repo: https://github.com/jaredlyvers/zed-mjml
  - Initial published version: 0.1.3
  - Includes bundled Node language-server runtime and registered HTML grammar dependency