### PR TITLE
Add mcp-memento extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2138,6 +2138,10 @@
 	path = extensions/mcfunction
 	url = https://github.com/bcheidemann/zed-mcfunction.git
 
+[submodule "extensions/mcp-memento"]
+	path = extensions/mcp-memento
+	url = https://github.com/annibale-x/mcp-memento.git
+
 [submodule "extensions/mcp-planetscale"]
 	path = extensions/mcp-planetscale
 	url = https://github.com/hunterjsb/zed-planetscale-mcp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2140,7 +2140,7 @@
 
 [submodule "extensions/mcp-memento"]
 	path = extensions/mcp-memento
-	url = https://github.com/annibale-x/mcp-memento.git
+	url = https://github.com/x-monk/mcp-memento.git
 
 [submodule "extensions/mcp-planetscale"]
 	path = extensions/mcp-planetscale

--- a/.gitmodules
+++ b/.gitmodules
@@ -2140,7 +2140,7 @@
 
 [submodule "extensions/mcp-memento"]
 	path = extensions/mcp-memento
-	url = https://github.com/x-monk/mcp-memento.git
+	url = https://github.com/x-hannibal/mcp-memento.git
 
 [submodule "extensions/mcp-planetscale"]
 	path = extensions/mcp-planetscale

--- a/extensions.toml
+++ b/extensions.toml
@@ -2171,6 +2171,11 @@ version = "0.1.0"
 submodule = "extensions/mcfunction"
 version = "0.0.1"
 
+[mcp-memento]
+submodule = "extensions/mcp-memento"
+path = "integrations/zed"
+version = "0.2.29"
+
 [mcp-planetscale]
 submodule = "extensions/mcp-planetscale"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2174,7 +2174,7 @@ version = "0.0.1"
 [mcp-memento]
 submodule = "extensions/mcp-memento"
 path = "integrations/zed"
-version = "0.2.29"
+version = "0.2.37"
 
 [mcp-planetscale]
 submodule = "extensions/mcp-planetscale"


### PR DESCRIPTION
## Summary

Add the `mcp-memento` extension to the Zed Extension Marketplace.

**mcp-memento** is a Zed context server extension that provides persistent, cross-session memory for AI agents via the Model Context Protocol (MCP). It allows AI assistants in Zed to store and retrieve structured knowledge across sessions using a local SQLite database.

## Extension Details

- **ID:** `mcp-memento`
- **Name:** Memento MCP Server
- **Version:** `0.2.37`
- **Repository:** https://github.com/x-hannibal/mcp-memento
- **License:** MIT ✅
- **Extension path in repo:** `integrations/zed`

## How it works

The extension ships a native stub binary (pre-compiled for Windows, macOS arm64/x86_64, Linux arm64/x86_64) that Zed downloads from the GitHub release. The stub locates the system Python, sets up a virtual environment, installs `mcp-memento` from PyPI, and launches it as a context server.

## Checklist

- [x] Extension ID does not contain "zed"
- [x] MIT license present in repo root
- [x] `extension.toml` is valid and present at `integrations/zed/extension.toml`
- [x] `extensions.toml` entry added with correct `path = "integrations/zed"`
- [x] `pnpm sort-extensions` run successfully
- [x] `.gitmodules` updated
- [x] Submodule points to v0.2.37
- [x] Tested on Windows, macOS, and Linux