### PR TITLE
Add `cucumber-syntax` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4413,3 +4413,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/cucumber-syntax"]
+	path = extensions/cucumber-syntax
+	url = https://github.com/moretti/zed-cucumber.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -788,6 +788,10 @@ version = "0.0.2"
 submodule = "extensions/cucumber"
 version = "0.0.2"
 
+[cucumber-syntax]
+submodule = "extensions/cucumber-syntax"
+version = "0.0.1"
+
 [cue]
 submodule = "extensions/cue"
 version = "0.0.4"


### PR DESCRIPTION
Add Cucumber/Gherkin syntax highlighting extension

- Uses [binhtran432k/tree-sitter-gherkin](https://github.com/binhtran432k/tree-sitter-gherkin) grammar with proper keyword parsing and i18n support
- Highlights Given/When/Then with distinct colors to visually distinguish BDD phases
- Supports tags, data tables, doc strings with language injection, and step parameters

https://github.com/moretti/zed-cucumber
