### PR TITLE
Add Vesper Black theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4413,3 +4413,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/vesper-black"]
+	path = extensions/vesper-black
+	url = https://github.com/michaljach/vesper-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4121,6 +4121,10 @@ version = "0.0.2"
 submodule = "extensions/vesper-blur"
 version = "0.1.1"
 
+[vesper-black-theme]
+submodule = "extensions/vesper-black"
+version = "0.0.1"
+
 [vhdl]
 submodule = "extensions/vhdl"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds the **Vesper Black** theme — a minimal dark theme with a pure black background and warm peach accents (`#ffc799`), ported from the [VSCode Vesper Black](https://github.com/michaljach/vesper-black) theme.

- Extension id: `vesper-black-theme`
- Version: `0.0.1`
- Source repo: https://github.com/michaljach/vesper-zed
- Appearance: dark
- License: MIT