### PR TITLE
Add mypy language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2462,6 +2462,10 @@
 	path = extensions/muted
 	url = https://github.com/arifzeeshan/Muted.git
 
+[submodule "extensions/mypy"]
+	path = extensions/mypy
+	url = https://github.com/Zenor27/zed-mypy.git
+
 [submodule "extensions/naive-ui-intellisense"]
 	path = extensions/naive-ui-intellisense
 	url = https://github.com/tu6ge/zed-naive-ui.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2497,6 +2497,10 @@ version = "0.0.1"
 submodule = "extensions/muted"
 version = "0.0.1"
 
+[mypy]
+submodule = "extensions/mypy"
+version = "0.0.1"
+
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"


### PR DESCRIPTION
Add `mypy` typechecker extension for Zed.

- Uses [pygls](https://github.com/openlawlibrary/pygls/) as a simple LSP (since mypy doesn't have one)
- Highlight errors in Zed
- Does not support dmypy (yet)

This is a first version of the extension, and my first extension for Zed.

https://github.com/Zenor27/zed-mypy