### PR TITLE
Add vscode-plus-icons icon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4122,6 +4122,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vs-code-plus-icons"]
+	path = extensions/vs-code-plus-icons
+	url = https://github.com/subhangadirli/vs-code-plus-icons-for-zed.git
+
 [submodule "extensions/vscode-classic-theme"]
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4224,6 +4224,7 @@ version = "0.0.2"
 [vscode-plus-icons]
 submodule = "extensions/vs-code-plus-icons"
 version = "1.0.0"
+path = "zed-extension"
 
 [vue]
 submodule = "extensions/vue"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4222,7 +4222,7 @@ submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"
 
 [vscode-plus-icons]
-submodule = "extensions/vs-code-plus-icons"
+submodule = "extensions/vscode-plus-icons"
 version = "1.0.0"
 path = "zed-extension"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -4221,6 +4221,10 @@ version = "0.1.0"
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"
 
+[vscode-plus-icons]
+submodule = "extensions/vs-code-plus-icons"
+version = "1.0.0"
+
 [vue]
 submodule = "extensions/vue"
 version = "0.3.2"


### PR DESCRIPTION
Adds the VSCode Plus Icons icon theme for Zed, ported from
https://github.com/yusifaliyevpro/vscode-icons.

800+ file and folder icons for the Zed editor.