### PR TITLE
Add 42header language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/42header"]
+	path = extensions/42header
+	url = https://github.com/MazeWave/42-header-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[42header]
+submodule = "extensions/42header"
+version = "0.2.0"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary
- Adds the **42 Header** extension (`42header`) for Zed
- Inserts and auto-updates [42 school](https://42.fr) headers via an LSP-based code action
- Supports 37+ languages with correct comment delimiters
- Configuration via `~/.config/42header/config.toml` or Zed LSP settings

## Extension details
- **Repository:** https://github.com/MazeWave/42-header-zed
- **License:** MIT
- **Version:** 0.2.0