### PR TITLE
Add Phosphor theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/synthwave-theme"]
+	path = extensions/synthwave-theme
+	url = https://github.com/eneko-codes/synthwave-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,6 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/synthwave-theme"]
-	path = extensions/synthwave-theme
-	url = https://github.com/eneko-codes/synthwave-theme.git
+[submodule "extensions/phosphor-zed-theme"]
+	path = extensions/phosphor-zed-theme
+	url = https://github.com/eneko-codes/phosphor-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3761,6 +3761,10 @@ version = "0.0.1"
 submodule = "extensions/synthwave-alpha-theme"
 version = "0.1.1"
 
+[synthwave-theme]
+submodule = "extensions/synthwave-theme"
+version = "1.0.0"
+
 [synthwave84]
 submodule = "extensions/synthwave84"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2996,6 +2996,10 @@ version = "0.0.1"
 submodule = "extensions/phosphor-icons-theme"
 version = "0.0.2"
 
+[phosphor-zed-theme]
+submodule = "extensions/phosphor-zed-theme"
+version = "1.0.0"
+
 [php]
 submodule = "extensions/php"
 version = "0.4.10"
@@ -3780,10 +3784,6 @@ version = "0.0.1"
 [synthwave-alpha-theme]
 submodule = "extensions/synthwave-alpha-theme"
 version = "0.1.1"
-
-[synthwave-theme]
-submodule = "extensions/synthwave-theme"
-version = "1.0.0"
 
 [synthwave84]
 submodule = "extensions/synthwave84"


### PR DESCRIPTION
Adds **Phosphor**, a neon phosphor theme for Zed with dark and light variants.

- Repository: https://github.com/eneko-codes/phosphor-zed-theme
- License: MIT

![Dark](https://raw.githubusercontent.com/eneko-codes/phosphor-zed-theme/main/images/dark.png)
![Light](https://raw.githubusercontent.com/eneko-codes/phosphor-zed-theme/main/images/light.png)