### PR TITLE
Bump arturo 1.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -175,7 +175,7 @@ version = "0.2.0"
 
 [arturo]
 submodule = "extensions/arturo"
-version = "0.5.5"
+version = "1.0.1"
 
 [asciidoc]
 submodule = "extensions/asciidoc"

--- a/extensions.toml
+++ b/extensions.toml
@@ -187,7 +187,7 @@ version = "0.2.0"
 
 [arturo]
 submodule = "extensions/arturo"
-version = "1.0.1"
+version = "1.0.2"
 
 [asciidoc]
 submodule = "extensions/asciidoc"


### PR DESCRIPTION
# What's New 

## Bugfix release

### Fixed 

- "cannot find module '…/node_modules/arturo_lsp/server.js'" error that affected users whose project already had its own node_modules directory. The extension now builds an absolute path to the LSP server so Node.js always resolves it from the extension cache, not the open workspace.

### Improvements

- Synced highlights.scm with the tree-sitter grammar — interpolated strings (~"..."), | interpolation delimiters, and backtick unit literals (m, kg) are now correctly highlighted. - Label, assignment target, and dictionary key patterns also use more precise field selectors.
- Bumped tree-sitter-arturo grammar pin.
