### PR TITLE
Add DAML language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -830,6 +830,10 @@
 	path = extensions/dafny
 	url = https://github.com/WeetHet/dafny-zed.git
 
+[submodule "extensions/daml"]
+	path = extensions/daml
+	url = https://github.com/DLC-link/zed-daml-lsp.git
+
 [submodule "extensions/dang"]
 	path = extensions/dang
 	url = https://codeberg.org/vito/zed-dang.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -840,6 +840,10 @@ version = "0.2.1"
 submodule = "extensions/dafny"
 version = "0.0.1"
 
+[daml]
+submodule = "extensions/daml"
+version = "0.1.0"
+
 [dang]
 submodule = "extensions/dang"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

- Adds DAML smart contract language support for Zed
- Syntax highlighting via tree-sitter-haskell grammar with DAML keyword extensions
- Language server integration (`damlc ide` / `damlc multi-ide`)
- Auto-detects `dpm` and `daml` SDK commands
- Multi-package project support (automatic `multi-ide` for SDK >= 2.9.0)
- Document outline, code completion labels, text object selections

## Links

- Extension repo: https://github.com/DLC-link/zed-daml-lsp
- DAML docs: https://docs.daml.com