### PR TITLE
Add mcp-webshift extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4427,4 +4427,4 @@
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
 [submodule "extensions/mcp-webshift"]
 	path = extensions/mcp-webshift
-	url = https://github.com/annibale-x/webshift.git
+	url = https://github.com/x-monk/webshift.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4425,3 +4425,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-webshift"]
+	path = extensions/mcp-webshift
+	url = https://github.com/annibale-x/webshift.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4427,4 +4427,4 @@
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
 [submodule "extensions/mcp-webshift"]
 	path = extensions/mcp-webshift
-	url = https://github.com/x-monk/webshift.git
+	url = https://github.com/x-hannibal/webshift.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -16,7 +16,7 @@ version = "0.0.1"
 
 [abysswalker-theme]
 submodule = "extensions/abysswalker-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [actionscript]
 submodule = "extensions/actionscript"
@@ -74,7 +74,7 @@ version = "1.0.0"
 [air]
 submodule = "extensions/air"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.2.10"
 
 [aira]
 submodule = "extensions/aira"
@@ -82,7 +82,7 @@ version = "0.0.2"
 
 [aizen-theme]
 submodule = "extensions/aizen-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [alabaster]
 submodule = "extensions/alabaster"
@@ -138,7 +138,7 @@ version = "0.0.1"
 
 [apache-avro]
 submodule = "extensions/apache-avro"
-version = "0.1.0"
+version = "0.2.10"
 
 [apathy-theme]
 submodule = "extensions/apathy-theme"
@@ -163,7 +163,7 @@ version = "0.8.0"
 
 [arc-dark-theme]
 submodule = "extensions/arc-dark-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [arch-mcp]
 submodule = "extensions/arch-mcp"
@@ -175,7 +175,7 @@ version = "1.0.0"
 
 [arduino]
 submodule = "extensions/arduino"
-version = "0.1.0"
+version = "0.2.10"
 
 [ariake]
 submodule = "extensions/ariake"
@@ -211,11 +211,11 @@ version = "0.0.1"
 
 [assembly]
 submodule = "extensions/assembly"
-version = "0.1.0"
+version = "0.2.10"
 
 [ast-grep]
 submodule = "extensions/ast-grep"
-version = "0.1.0"
+version = "0.2.10"
 
 [asteroid]
 submodule = "extensions/asteroid"
@@ -227,7 +227,7 @@ version = "0.1.9"
 
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [atomize]
 submodule = "extensions/atomize"
@@ -235,7 +235,7 @@ version = "0.0.1"
 
 [atomizer-theme]
 submodule = "extensions/atomizer-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [auggie]
 submodule = "extensions/auggie"
@@ -304,11 +304,11 @@ version = "1.0.0"
 
 [azutiku-theme]
 submodule = "extensions/azutiku-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [bamboo-theme]
 submodule = "extensions/bamboo-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [baml]
 submodule = "extensions/baml"
@@ -372,7 +372,7 @@ version = "0.2.2"
 
 [bison]
 submodule = "extensions/bison"
-version = "0.1.0"
+version = "0.2.10"
 
 [bitbake]
 submodule = "extensions/bitbake"
@@ -412,15 +412,15 @@ version = "0.0.6"
 
 [blinds-theme]
 submodule = "extensions/blinds-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [blk-theme]
 submodule = "extensions/blk-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [bloc]
 submodule = "extensions/bloc"
-version = "0.1.0"
+version = "0.2.10"
 path = "extensions/zed"
 
 [blueforest-theme]
@@ -433,7 +433,7 @@ version = "0.4.0"
 
 [bluespec-systemverilog]
 submodule = "extensions/bluespec-systemverilog"
-version = "0.1.0"
+version = "0.2.10"
 
 [bluloco-theme]
 submodule = "extensions/bluloco-theme"
@@ -441,7 +441,7 @@ version = "1.0.0"
 
 [bookmark]
 submodule = "extensions/bookmark"
-version = "0.1.0"
+version = "0.2.10"
 
 [bqn]
 submodule = "extensions/bqn"
@@ -465,7 +465,7 @@ version = "0.0.1"
 
 [bubblegum]
 submodule = "extensions/bubblegum"
-version = "0.1.0"
+version = "0.2.10"
 
 [bun-docs-mcp]
 submodule = "extensions/bun-docs-mcp"
@@ -582,7 +582,7 @@ version = "0.5.0"
 
 [cherri]
 submodule = "extensions/cherri"
-version = "0.1.0"
+version = "0.2.10"
 
 [chocolate]
 submodule = "extensions/chocolate"
@@ -598,7 +598,7 @@ version = "1.0.0"
 
 [circom]
 submodule = "extensions/circom"
-version = "0.1.0"
+version = "0.2.10"
 
 [cisco-theme]
 submodule = "extensions/cisco-theme"
@@ -610,7 +610,7 @@ version = "0.0.2"
 
 [clarity]
 submodule = "extensions/clarity"
-version = "0.1.0"
+version = "0.2.10"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"
@@ -622,7 +622,7 @@ version = "0.1.1"
 
 [clice]
 submodule = "extensions/clice"
-version = "0.1.0"
+version = "0.2.10"
 path = "editors/zed"
 
 [clojure]
@@ -631,11 +631,11 @@ version = "0.2.2"
 
 [cloudformation-language-server]
 submodule = "extensions/cloudformation-language-server"
-version = "0.1.0"
+version = "0.2.10"
 
 [cobalt2]
 submodule = "extensions/cobalt2"
-version = "0.1.0"
+version = "0.2.10"
 
 [cobol]
 submodule = "extensions/cobol"
@@ -663,7 +663,7 @@ version = "0.0.1"
 
 [codeowners]
 submodule = "extensions/codeowners"
-version = "0.1.0"
+version = "0.2.10"
 
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
@@ -709,7 +709,7 @@ version = "1.0.1"
 [compline]
 submodule = "extensions/compline"
 path = "zed"
-version = "0.1.0"
+version = "0.2.10"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"
@@ -733,7 +733,7 @@ version = "0.0.1"
 
 [cpp2]
 submodule = "extensions/cpp2"
-version = "0.1.0"
+version = "0.2.10"
 
 [cql]
 submodule = "extensions/cql"
@@ -761,7 +761,7 @@ version = "1.0.4"
 
 [csharp-snippets]
 submodule = "extensions/csharp-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [csound]
 submodule = "extensions/csound"
@@ -778,7 +778,7 @@ path = "crates/zed"
 
 [css-variables]
 submodule = "extensions/css-variables"
-version = "0.1.0"
+version = "0.2.10"
 
 [csv]
 submodule = "extensions/csv"
@@ -874,7 +874,7 @@ version = "0.0.1"
 
 [dark-oled]
 submodule = "extensions/dark-oled"
-version = "0.1.0"
+version = "0.2.10"
 
 [dark-pop-ui]
 submodule = "extensions/dark-pop-ui"
@@ -910,7 +910,7 @@ version = "1.0.0"
 
 [deep-ocean-theme]
 submodule = "extensions/deep-ocean-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [defold]
 submodule = "extensions/defold"
@@ -945,7 +945,7 @@ version = "0.1.24"
 
 [desktop]
 submodule = "extensions/desktop"
-version = "0.1.0"
+version = "0.2.10"
 
 [dev-magic]
 submodule = "extensions/dev-magic"
@@ -969,7 +969,7 @@ version = "0.0.1"
 
 [docker-compose]
 submodule = "extensions/docker-compose"
-version = "0.1.0"
+version = "0.2.10"
 
 [dockerfile]
 submodule = "extensions/dockerfile"
@@ -985,7 +985,7 @@ version = "0.0.2"
 
 [doxygen]
 submodule = "extensions/doxygen"
-version = "0.1.0"
+version = "0.2.10"
 
 [dprint]
 submodule = "extensions/dprint"
@@ -1022,7 +1022,7 @@ version = "0.0.1"
 
 [dusty-theme]
 submodule = "extensions/dusty-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [dwp]
 submodule = "extensions/dwp"
@@ -1030,7 +1030,7 @@ version = "0.0.4"
 
 [earthfile]
 submodule = "extensions/earthfile"
-version = "0.1.0"
+version = "0.2.10"
 
 [earthsong-theme]
 submodule = "extensions/earthsong-theme"
@@ -1038,7 +1038,7 @@ version = "1.0.0"
 
 [eclat]
 submodule = "extensions/eclat"
-version = "0.1.0"
+version = "0.2.10"
 
 [edge]
 submodule = "extensions/edge"
@@ -1050,7 +1050,7 @@ version = "0.0.2"
 
 [editorconfig]
 submodule = "extensions/editorconfig"
-version = "0.1.0"
+version = "0.2.10"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
@@ -1062,11 +1062,11 @@ version = "0.0.1"
 
 [elderberry]
 submodule = "extensions/elderberry"
-version = "0.1.0"
+version = "0.2.10"
 
 [eldritch-theme]
 submodule = "extensions/eldritch-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [electron-vue-theme]
 submodule = "extensions/electron-vue-theme"
@@ -1082,7 +1082,7 @@ version = "0.4.2"
 
 [elixir-snippets]
 submodule = "extensions/elixir-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [elle]
 submodule = "extensions/elle"
@@ -1091,7 +1091,7 @@ version = "0.3.6"
 
 [ellsp]
 submodule = "extensions/ellsp"
-version = "0.1.0"
+version = "0.2.10"
 
 [elm]
 submodule = "extensions/elm"
@@ -1099,7 +1099,7 @@ version = "0.2.2"
 
 [ember]
 submodule = "extensions/ember"
-version = "0.1.0"
+version = "0.2.10"
 
 [ember-theme]
 submodule = "extensions/ember-theme"
@@ -1127,7 +1127,7 @@ version = "0.0.1"
 
 [erb-snippets]
 submodule = "extensions/erb-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [erlang]
 submodule = "extensions/erlang"
@@ -1135,7 +1135,7 @@ version = "0.2.1"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [everforest]
 submodule = "extensions/everforest"
@@ -1143,7 +1143,7 @@ version = "0.1.1"
 
 [everforest-blurred]
 submodule = "extensions/everforest-blurred"
-version = "0.1.0"
+version = "0.2.10"
 
 [everforest-theme]
 submodule = "extensions/everforest-theme"
@@ -1196,7 +1196,7 @@ version = "0.0.11"
 
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
@@ -1212,7 +1212,7 @@ version = "0.1.1"
 
 [firrtl-source-locator]
 submodule = "extensions/firrtl-source-locator"
-version = "0.1.0"
+version = "0.2.10"
 
 [fish]
 submodule = "extensions/fish"
@@ -1273,7 +1273,7 @@ version = "1.0.0"
 
 [forest-night]
 submodule = "extensions/forest-night"
-version = "0.1.0"
+version = "0.2.10"
 
 [formosa-theme]
 submodule = "extensions/formosa-theme"
@@ -1297,7 +1297,7 @@ version = "0.0.1"
 
 [freemarker]
 submodule = "extensions/freemarker"
-version = "0.1.0"
+version = "0.2.10"
 
 [freezed-dart-flutter-snippets]
 submodule = "extensions/freezed-dart-flutter-snippets"
@@ -1358,7 +1358,7 @@ version = "1.2.2"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [ghostty]
 submodule = "extensions/ghostty"
@@ -1418,7 +1418,7 @@ version = "0.6.0"
 
 [gleam-snippets]
 submodule = "extensions/gleam-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [gleam-theme]
 submodule = "extensions/gleam-theme"
@@ -1467,19 +1467,19 @@ version = "0.1.3"
 
 [gren]
 submodule = "extensions/gren"
-version = "0.1.0"
+version = "0.2.10"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.0"
+version = "0.2.10"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"
-version = "0.1.0"
+version = "0.2.10"
 
 [grit]
 submodule = "extensions/grit"
@@ -1523,11 +1523,11 @@ version = "1.0.1"
 
 [gruvbox-material-neovim]
 submodule = "extensions/gruvbox-material-neovim"
-version = "0.1.0"
+version = "0.2.10"
 
 [gruvchad]
 submodule = "extensions/gruvchad"
-version = "0.1.0"
+version = "0.2.10"
 
 [hackatime]
 submodule = "extensions/hackatime"
@@ -1575,7 +1575,7 @@ version = "0.3.1"
 
 [hbuilderx-push-light]
 submodule = "extensions/hbuilderx-push-light"
-version = "0.1.0"
+version = "0.2.10"
 
 [helm]
 submodule = "extensions/helm"
@@ -1592,7 +1592,7 @@ version = "0.0.4"
 
 [hexpeek]
 submodule = "extensions/hexpeek"
-version = "0.1.0"
+version = "0.2.10"
 
 [hilleer-v-theme]
 submodule = "extensions/hilleer-v-theme"
@@ -1645,11 +1645,11 @@ version = "0.3.1"
 
 [html-jinja]
 submodule = "extensions/html-jinja"
-version = "0.1.0"
+version = "0.2.10"
 
 [html-snippets]
 submodule = "extensions/html-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [htmx-lsp]
 submodule = "extensions/htmx-lsp"
@@ -1669,7 +1669,7 @@ version = "0.0.1"
 
 [hurl]
 submodule = "extensions/hurl"
-version = "0.1.0"
+version = "0.2.10"
 
 [hyprlang]
 submodule = "extensions/hyprlang"
@@ -1681,7 +1681,7 @@ version = "1.0.0"
 
 [ical]
 submodule = "extensions/ical"
-version = "0.1.0"
+version = "0.2.10"
 
 [iceberg]
 submodule = "extensions/iceberg"
@@ -1721,11 +1721,11 @@ version = "0.0.2"
 
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [intl-lens]
 submodule = "extensions/intl-lens"
@@ -1746,7 +1746,7 @@ version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [isle]
 submodule = "extensions/isle"
@@ -1754,7 +1754,7 @@ version = "0.0.1"
 
 [iterm2-default-theme]
 submodule = "extensions/iterm2-default-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [iwe]
 submodule = "extensions/iwe"
@@ -1783,7 +1783,7 @@ version = "0.2.5"
 
 [javascript-snippets]
 submodule = "extensions/javascript-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [jdl]
 submodule = "extensions/jdl"
@@ -1827,7 +1827,7 @@ version = "0.0.1"
 
 [jj-lsp]
 submodule = "extensions/jj-lsp"
-version = "0.1.0"
+version = "0.2.10"
 
 [jq]
 submodule = "extensions/jq"
@@ -1835,7 +1835,7 @@ version = "0.0.2"
 
 [json5]
 submodule = "extensions/json5"
-version = "0.1.0"
+version = "0.2.10"
 
 [jsonl]
 submodule = "extensions/jsonl"
@@ -1883,11 +1883,11 @@ version = "0.0.1"
 
 [kconfig]
 submodule = "extensions/kconfig"
-version = "0.1.0"
+version = "0.2.10"
 
 [kde-breeze-dark-theme]
 submodule = "extensions/kde-breeze-dark-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [kdl]
 submodule = "extensions/kdl"
@@ -1943,11 +1943,11 @@ version = "0.2.3"
 
 [latte]
 submodule = "extensions/latte"
-version = "0.1.0"
+version = "0.2.10"
 
 [lean4]
 submodule = "extensions/lean4"
-version = "0.1.0"
+version = "0.2.10"
 
 [leblackque]
 submodule = "extensions/leblackque"
@@ -1959,11 +1959,11 @@ version = "0.2.0"
 
 [leptos]
 submodule = "extensions/leptos"
-version = "0.1.0"
+version = "0.2.10"
 
 [less]
 submodule = "extensions/less"
-version = "0.1.0"
+version = "0.2.10"
 
 [libsql-context-server]
 submodule = "extensions/libsql-context-server"
@@ -1979,7 +1979,7 @@ version = "0.0.9"
 
 [linkerscript]
 submodule = "extensions/linkerscript"
-version = "0.1.0"
+version = "0.2.10"
 
 [liquid]
 submodule = "extensions/liquid"
@@ -1991,7 +1991,7 @@ version = "0.0.2"
 
 [liquidsoap]
 submodule = "extensions/liquidsoap"
-version = "0.1.0"
+version = "0.2.10"
 
 [live-server]
 submodule = "extensions/live-server"
@@ -2028,7 +2028,7 @@ path = "zed"
 
 [lotus-theme]
 submodule = "extensions/lotus-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [lox]
 submodule = "extensions/lox"
@@ -2060,7 +2060,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.1.0"
+version = "0.2.10"
 
 [macos-classic]
 submodule = "extensions/macos-classic"
@@ -2088,7 +2088,7 @@ version = "0.1.9"
 
 [marathon-theme]
 submodule = "extensions/marathon-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [marble]
 submodule = "extensions/marble"
@@ -2165,7 +2165,7 @@ version = "0.4.5"
 [maybe-material]
 submodule = "extensions/maybe-material"
 path = "extension/"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcfunction]
 submodule = "extensions/mcfunction"
@@ -2205,7 +2205,7 @@ version = "0.0.3"
 
 [mcp-server-code-runner]
 submodule = "extensions/mcp-server-code-runner"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-container-use]
 submodule = "extensions/mcp-server-container-use"
@@ -2217,11 +2217,11 @@ version = "0.0.5"
 
 [mcp-server-digitalocean]
 submodule = "extensions/mcp-server-digitalocean"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-exa-search]
 submodule = "extensions/mcp-server-exa-search"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-figma]
 submodule = "extensions/mcp-server-figma"
@@ -2233,7 +2233,7 @@ version = "0.0.4"
 
 [mcp-server-github]
 submodule = "extensions/mcp-server-github"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-gitlab]
 submodule = "extensions/mcp-server-gitlab"
@@ -2269,11 +2269,11 @@ version = "0.0.10"
 
 [mcp-server-nextjs]
 submodule = "extensions/mcp-server-nextjs"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-notion]
 submodule = "extensions/mcp-server-notion"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-playwright]
 submodule = "extensions/mcp-server-playwright"
@@ -2293,19 +2293,19 @@ version = "0.2.0"
 
 [mcp-server-repomix]
 submodule = "extensions/mcp-server-repomix"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-resend]
 submodule = "extensions/mcp-server-resend"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-sequential-thinking]
 submodule = "extensions/mcp-server-sequential-thinking"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-shopify-dev]
 submodule = "extensions/mcp-server-shopify-dev"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-shortcut]
 submodule = "extensions/mcp-server-shortcut"
@@ -2329,7 +2329,7 @@ version = "0.0.2"
 
 [mcp-server-threadbridge]
 submodule = "extensions/mcp-server-threadbridge"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-server-weave]
 submodule = "extensions/mcp-server-weave"
@@ -2337,12 +2337,12 @@ version = "0.0.2"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
-version = "0.1.0"
+version = "0.2.10"
 
 [mcp-webshift]
 submodule = "extensions/mcp-webshift"
 path = "integrations/zed"
-version = "0.1.0"
+version = "0.2.10"
 
 [mdx]
 submodule = "extensions/mdx"
@@ -2358,7 +2358,7 @@ version = "0.0.1"
 
 [mermaid]
 submodule = "extensions/mermaid"
-version = "0.1.0"
+version = "0.2.10"
 
 [meson]
 submodule = "extensions/meson"
@@ -2387,7 +2387,7 @@ version = "1.0.0"
 
 [minizinc]
 submodule = "extensions/minizinc"
-version = "0.1.0"
+version = "0.2.10"
 
 [mint-theme]
 submodule = "extensions/mint-theme"
@@ -2436,7 +2436,7 @@ version = "0.2.2"
 
 [monokai-og]
 submodule = "extensions/monokai-og"
-version = "0.1.0"
+version = "0.2.10"
 
 [monokai-pro-ce]
 submodule = "extensions/monokai-pro-ce"
@@ -2516,7 +2516,7 @@ version = "0.1.2"
 
 [nanowise]
 submodule = "extensions/nanowise"
-version = "0.1.0"
+version = "0.2.10"
 
 [napalm]
 submodule = "extensions/napalm"
@@ -2536,7 +2536,7 @@ version = "0.0.6"
 
 [neo-brutalism]
 submodule = "extensions/neo-brutalism"
-version = "0.1.0"
+version = "0.2.10"
 
 [neocmake]
 submodule = "extensions/neocmake"
@@ -2544,7 +2544,7 @@ version = "0.1.1"
 
 [neon-comfy-soft-themes]
 submodule = "extensions/neon-comfy-soft-themes"
-version = "0.1.0"
+version = "0.2.10"
 
 [neon-cyberpunk]
 submodule = "extensions/neon-cyberpunk"
@@ -2568,7 +2568,7 @@ version = "0.1.4"
 
 [netlinx]
 submodule = "extensions/netlinx"
-version = "0.1.0"
+version = "0.2.10"
 
 [neutral-theme]
 submodule = "extensions/neutral-theme"
@@ -2580,7 +2580,7 @@ version = "1.0.9"
 
 [nextjs-react-snippets]
 submodule = "extensions/nextjs-react-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [nginx]
 submodule = "extensions/nginx"
@@ -2637,7 +2637,7 @@ version = "0.0.1"
 
 [noctis-port]
 submodule = "extensions/noctis-port"
-version = "0.1.0"
+version = "0.2.10"
 
 [noir]
 submodule = "extensions/noir"
@@ -2681,11 +2681,11 @@ version = "0.0.1"
 
 [not-too-shabby]
 submodule = "extensions/not-too-shabby"
-version = "0.1.0"
+version = "0.2.10"
 
 [nova-theme]
 submodule = "extensions/nova-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [npm-package-json-checker]
 submodule = "extensions/npm-package-json-checker"
@@ -2802,7 +2802,7 @@ version = "1.0.1"
 
 [one-dark-ocean]
 submodule = "extensions/one-dark-ocean"
-version = "0.1.0"
+version = "0.2.10"
 
 [one-dark-pro]
 submodule = "extensions/one-dark-pro"
@@ -2822,7 +2822,7 @@ version = "0.1.1"
 
 [one-dark-pro-vivid-theme]
 submodule = "extensions/one-dark-pro-vivid-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [one-hunter]
 submodule = "extensions/one-hunter"
@@ -2830,7 +2830,7 @@ version = "0.0.4"
 
 [onurb]
 submodule = "extensions/onurb"
-version = "0.1.0"
+version = "0.2.10"
 
 [oolong]
 submodule = "extensions/oolong"
@@ -2838,7 +2838,7 @@ version = "0.1.1"
 
 [opaline-theme]
 submodule = "extensions/opaline-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [opencode]
 submodule = "extensions/opencode"
@@ -2899,7 +2899,7 @@ version = "0.0.1"
 
 [pace-pro-theme]
 submodule = "extensions/pace-pro-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"
@@ -2935,7 +2935,7 @@ version = "1.0.2"
 
 [pascal]
 submodule = "extensions/pascal"
-version = "0.1.0"
+version = "0.2.10"
 
 [path-of-exile]
 submodule = "extensions/path-of-exile"
@@ -2943,7 +2943,7 @@ version = "0.0.1"
 
 [pathy]
 submodule = "extensions/pathy"
-version = "0.1.0"
+version = "0.2.10"
 
 [pbxproj]
 submodule = "extensions/pbxproj"
@@ -2995,7 +2995,7 @@ version = "0.4.10"
 
 [php-snippets]
 submodule = "extensions/php-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [phpcs]
 submodule = "extensions/phpcs"
@@ -3003,7 +3003,7 @@ version = "0.4.1"
 
 [phpmd]
 submodule = "extensions/phpmd"
-version = "0.1.0"
+version = "0.2.10"
 
 [pica200]
 submodule = "extensions/pica200"
@@ -3016,7 +3016,7 @@ version = "0.0.23"
 
 [pigs-in-space]
 submodule = "extensions/pigs-in-space"
-version = "0.1.0"
+version = "0.2.10"
 
 [pinata-theme]
 submodule = "extensions/pinata-theme"
@@ -3032,11 +3032,11 @@ version = "0.3.0"
 
 [plaintasks]
 submodule = "extensions/plaintasks"
-version = "0.1.0"
+version = "0.2.10"
 
 [plantuml]
 submodule = "extensions/plantuml"
-version = "0.1.0"
+version = "0.2.10"
 
 [plastic-theme]
 submodule = "extensions/plastic-theme"
@@ -3056,7 +3056,7 @@ version = "0.1.2"
 
 [po]
 submodule = "extensions/po"
-version = "0.1.0"
+version = "0.2.10"
 
 [poimandres]
 submodule = "extensions/poimandres"
@@ -3088,7 +3088,7 @@ version = "0.0.5"
 
 [postgres-language-server]
 submodule = "extensions/postgres-language-server"
-version = "0.1.0"
+version = "0.2.10"
 
 [powershell]
 submodule = "extensions/powershell"
@@ -3178,7 +3178,7 @@ version = "0.1.1"
 
 [qlik]
 submodule = "extensions/qlik"
-version = "0.1.0"
+version = "0.2.10"
 
 [qml]
 submodule = "extensions/qml"
@@ -3207,7 +3207,7 @@ version = "0.0.1"
 
 [qubik-theme]
 submodule = "extensions/qubik-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [quiet-light-theme]
 submodule = "extensions/quiet-light-theme"
@@ -3231,7 +3231,7 @@ version = "1.0.1"
 
 [railscast]
 submodule = "extensions/railscast"
-version = "0.1.0"
+version = "0.2.10"
 
 [rainbow]
 submodule = "extensions/rainbow"
@@ -3304,7 +3304,7 @@ version = "0.0.1"
 [rewrite-theme]
 submodule = "extensions/rewrite-theme"
 path = "zed"
-version = "0.1.0"
+version = "0.2.10"
 
 [rhai]
 submodule = "extensions/rhai"
@@ -3340,15 +3340,15 @@ version = "1.3.2"
 
 [rosevin]
 submodule = "extensions/rosevin"
-version = "0.1.0"
+version = "0.2.10"
 
 [roto]
 submodule = "extensions/roto"
-version = "0.1.0"
+version = "0.2.10"
 
 [rover]
 submodule = "extensions/rover"
-version = "0.1.0"
+version = "0.2.10"
 
 [rpmspec]
 submodule = "extensions/rpmspec"
@@ -3388,7 +3388,7 @@ version = "1.0.3"
 
 [sagemath]
 submodule = "extensions/sagemath"
-version = "0.1.0"
+version = "0.2.10"
 
 [scala]
 submodule = "extensions/scala"
@@ -3448,11 +3448,11 @@ version = "0.1.1"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"
-version = "0.1.0"
+version = "0.2.10"
 
 [shader-ls]
 submodule = "extensions/shader-ls"
-version = "0.1.0"
+version = "0.2.10"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
@@ -3496,7 +3496,7 @@ version = "0.0.12"
 
 [sitruuna]
 submodule = "extensions/sitruuna"
-version = "0.1.0"
+version = "0.2.10"
 
 [sl4y-theme]
 submodule = "extensions/sl4y-theme"
@@ -3521,7 +3521,7 @@ version = "1.15.1"
 
 [smalisp]
 submodule = "extensions/smalisp"
-version = "0.1.0"
+version = "0.2.10"
 path = "extensions/zed"
 
 [smithy]
@@ -3530,7 +3530,7 @@ version = "0.0.1"
 
 [sml]
 submodule = "extensions/sml"
-version = "0.1.0"
+version = "0.2.10"
 
 [smooth]
 submodule = "extensions/smooth"
@@ -3538,7 +3538,7 @@ version = "1.1.1"
 
 [snakemake]
 submodule = "extensions/snakemake"
-version = "0.1.0"
+version = "0.2.10"
 
 [snazzy]
 submodule = "extensions/snazzy"
@@ -3546,7 +3546,7 @@ version = "0.1.3"
 
 [snazzy-light]
 submodule = "extensions/snazzy-light"
-version = "0.1.0"
+version = "0.2.10"
 
 [snippet-iwonder]
 submodule = "extensions/snippet-iwonder"
@@ -3574,7 +3574,7 @@ version = "0.0.1"
 
 [solid-typescript-snippets]
 submodule = "extensions/solid-typescript-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [solidity]
 submodule = "extensions/solidity"
@@ -3614,7 +3614,7 @@ version = "0.0.1"
 
 [spinel-theme]
 submodule = "extensions/spinel-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [sql]
 submodule = "extensions/sql"
@@ -3630,11 +3630,11 @@ version = "0.1.4"
 
 [sqruff]
 submodule = "extensions/sqruff"
-version = "0.1.0"
+version = "0.2.10"
 
 [squirrel]
 submodule = "extensions/squirrel"
-version = "0.1.0"
+version = "0.2.10"
 
 [srcery]
 submodule = "extensions/srcery"
@@ -3642,7 +3642,7 @@ version = "0.0.3"
 
 [ssh-config]
 submodule = "extensions/ssh-config"
-version = "0.1.0"
+version = "0.2.10"
 
 [stakpak]
 submodule = "extensions/stakpak"
@@ -3658,7 +3658,7 @@ version = "0.4.1"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
-version = "0.1.0"
+version = "0.2.10"
 
 [stimulus]
 submodule = "extensions/stimulus"
@@ -3683,7 +3683,7 @@ version = "2.0.2"
 [styx]
 submodule = "extensions/styx"
 path = "editors/zed-styx"
-version = "0.1.0"
+version = "0.2.10"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
@@ -3703,7 +3703,7 @@ version = "1.0.1"
 
 [supaglass]
 submodule = "extensions/supaglass"
-version = "0.1.0"
+version = "0.2.10"
 
 [supergreatmonokai]
 submodule = "extensions/supergreatmonokai"
@@ -3711,7 +3711,7 @@ version = "0.0.4"
 
 [superhtml]
 submodule = "extensions/superhtml"
-version = "0.1.0"
+version = "0.2.10"
 
 [superior-green-theme]
 submodule = "extensions/superior-green-theme"
@@ -3743,11 +3743,11 @@ version = "0.0.9"
 
 [sway]
 submodule = "extensions/sway"
-version = "0.1.0"
+version = "0.2.10"
 
 [sweet-dracula]
 submodule = "extensions/sweet-dracula"
-version = "0.1.0"
+version = "0.2.10"
 
 [swift]
 submodule = "extensions/swift"
@@ -3801,7 +3801,7 @@ version = "0.6.0"
 
 [tamarin]
 submodule = "extensions/tamarin"
-version = "0.1.0"
+version = "0.2.10"
 
 [tanuki]
 submodule = "extensions/tanuki"
@@ -3849,11 +3849,11 @@ version = "0.0.3"
 
 [textproto]
 submodule = "extensions/textproto"
-version = "0.1.0"
+version = "0.2.10"
 
 [tflint]
 submodule = "extensions/tflint"
-version = "0.1.0"
+version = "0.2.10"
 
 [the-best-theme]
 submodule = "extensions/the-best-theme"
@@ -3873,7 +3873,7 @@ version = "0.0.1"
 
 [thorn-theme]
 submodule = "extensions/thorn-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [thrift]
 submodule = "extensions/thrift"
@@ -3910,7 +3910,7 @@ version = "0.7.0"
 
 [tokyo-night-dark]
 submodule = "extensions/tokyo-night-dark"
-version = "0.1.0"
+version = "0.2.10"
 
 [tombi]
 submodule = "extensions/tombi"
@@ -3971,7 +3971,7 @@ version = "0.0.4"
 
 [turtle]
 submodule = "extensions/turtle"
-version = "0.1.0"
+version = "0.2.10"
 
 [twig]
 submodule = "extensions/twig"
@@ -3979,11 +3979,11 @@ version = "0.3.0"
 
 [twilight]
 submodule = "extensions/twilight"
-version = "0.1.0"
+version = "0.2.10"
 
 [txtar]
 submodule = "extensions/txtar"
-version = "0.1.0"
+version = "0.2.10"
 
 [ty]
 submodule = "extensions/ty"
@@ -3991,7 +3991,7 @@ version = "0.0.3"
 
 [typescript-snippets]
 submodule = "extensions/typescript-snippets"
-version = "0.1.0"
+version = "0.2.10"
 
 [typespec]
 submodule = "extensions/typespec"
@@ -4015,7 +4015,7 @@ version = "0.0.2"
 
 [ultimate-dark-neo]
 submodule = "extensions/ultimate-dark-neo"
-version = "0.1.0"
+version = "0.2.10"
 
 [ultralytics-snippets]
 submodule = "extensions/ultralytics-snippets"
@@ -4023,7 +4023,7 @@ version = "0.0.2"
 
 [umbralkai]
 submodule = "extensions/umbralkai"
-version = "0.1.0"
+version = "0.2.10"
 
 [umka]
 submodule = "extensions/umka"
@@ -4063,11 +4063,11 @@ version = "0.1.4"
 
 [usd]
 submodule = "extensions/usd"
-version = "0.1.0"
+version = "0.2.10"
 
 [utl]
 submodule = "extensions/utl"
-version = "0.1.0"
+version = "0.2.10"
 
 [v]
 submodule = "extensions/v"
@@ -4115,7 +4115,7 @@ version = "1.0.0"
 
 [vercel-carbon-theme]
 submodule = "extensions/vercel-carbon-theme"
-version = "0.1.0"
+version = "0.2.10"
 
 [vercel-theme]
 submodule = "extensions/vercel-theme"
@@ -4144,7 +4144,7 @@ version = "0.0.2"
 
 [vhs]
 submodule = "extensions/vhs"
-version = "0.1.0"
+version = "0.2.10"
 
 [vhs80-theme]
 submodule = "extensions/vhs80-theme"
@@ -4188,7 +4188,7 @@ version = "1.0.0"
 
 [vrl]
 submodule = "extensions/vrl"
-version = "0.1.0"
+version = "0.2.10"
 
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
@@ -4302,7 +4302,7 @@ version = "0.0.2"
 
 [whkd]
 submodule = "extensions/whkd"
-version = "0.1.0"
+version = "0.2.10"
 
 [wikitext]
 submodule = "extensions/wikitext"
@@ -4331,7 +4331,7 @@ version = "0.0.1"
 
 [wxml]
 submodule = "extensions/wxml"
-version = "0.1.0"
+version = "0.2.10"
 
 [xcode-themes]
 submodule = "extensions/xcode-themes"
@@ -4343,11 +4343,11 @@ version = "0.0.2"
 
 [xmake]
 submodule = "extensions/xmake"
-version = "0.1.0"
+version = "0.2.10"
 
 [xml]
 submodule = "extensions/xml"
-version = "0.1.0"
+version = "0.2.10"
 
 [xonsh]
 submodule = "extensions/xonsh"
@@ -4387,7 +4387,7 @@ version = "1.1.0"
 
 [yuck]
 submodule = "extensions/yuck"
-version = "0.1.0"
+version = "0.2.10"
 
 [yue-theme]
 submodule = "extensions/yue-theme"
@@ -4415,7 +4415,7 @@ version = "0.0.3"
 
 [zedburn]
 submodule = "extensions/zedburn"
-version = "0.1.0"
+version = "0.2.10"
 
 [zedokai]
 submodule = "extensions/zedokai"
@@ -4467,7 +4467,7 @@ version = "0.4.3"
 
 [zokrates]
 submodule = "extensions/zokrates"
-version = "0.1.0"
+version = "0.2.10"
 
 [zomorrod-theme]
 submodule = "extensions/zomorrod-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2339,6 +2339,11 @@ version = "0.0.2"
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"
 
+[mcp-webshift]
+submodule = "extensions/mcp-webshift"
+path = "integrations/zed"
+version = "0.1.0"
+
 [mdx]
 submodule = "extensions/mdx"
 version = "0.3.0"


### PR DESCRIPTION
## Summary

Add the `mcp-webshift` extension to the Zed Extension Marketplace.

**mcp-webshift** is a Zed context server extension that provides denoised web search and single-page fetch via the Model Context Protocol (MCP). It downloads the correct native binary for the user's platform automatically from GitHub Releases — no runtime, no PATH setup required.

## Extension Details

- **ID:** `mcp-webshift`
- **Name:** mcp-webshift
- **Version:** `0.2.10`
- **Repository:** https://github.com/x-hannibal/webshift
- **License:** MIT ✅
- **Extension path in repo:** `integrations/zed`

## How it works

The extension is a pure-Rust WASM binary compiled with `zed_extension_api = "0.7"`. On first use it downloads the platform-native `mcp-webshift` binary from the latest GitHub release (5 targets: Linux x86_64/aarch64, macOS x86_64/aarch64, Windows x86_64). The binary is a single static Rust executable with zero system dependencies.

Configuration is exposed through Zed's **Configure Server** modal. Keys are CLI flags (e.g. `--default-backend`, `--brave-api-key`) passed directly to the binary at launch — one isolated config per Zed instance, no conflict with other running instances.

## MCP tools exposed

| Tool | Description |
|------|-------------|
| `webshift_query` | Full search pipeline: search + fetch + clean + rerank |
| `webshift_fetch` | Single page fetch and clean |
| `webshift_onboarding` | Returns an operational guide for the agent |

## Checklist

- [x] Extension ID does not contain "zed"
- [x] MIT license present in repo root
- [x] `extension.toml` is valid and present at `integrations/zed/extension.toml`
- [x] `extensions.toml` entry added with correct `path = "integrations/zed"`
- [x] `.gitmodules` updated
- [x] Submodule points to v0.2.10
- [x] Tested on Windows, macOS, and Linux