### PR TITLE
Update vscode-modern to 0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4215,7 +4215,7 @@ version = "0.0.2"
 
 [vscode-modern]
 submodule = "extensions/vscode-modern"
-version = "0.1.1"
+version = "0.1.2"
 
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"


### PR DESCRIPTION
What's changed:
* fix: color fixes for light theme by @kiyutink in https://github.com/fabrialberio/zed-vscode-modern-theme/pull/2

**Full Changelog**: https://github.com/fabrialberio/zed-vscode-modern-theme/compare/v0.1.1...v0.1.2
