### PR TITLE
Add rosewood-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/rosewood-theme"]
+	path = extensions/rosewood-theme
+	url = https://github.com/ayush-porwal/zed-rosewood-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3306,6 +3306,10 @@
 	path = extensions/rosevin
 	url = https://github.com/anson-ryea/rosevin-zed.git
 
+[submodule "extensions/rosewood-theme"]
+	path = extensions/rosewood-theme
+	url = https://github.com/ayush-porwal/zed-rosewood-theme.git
+
 [submodule "extensions/roto"]
 	path = extensions/roto
 	url = https://github.com/tertsdiepraam/zed-extension-roto.git
@@ -4453,6 +4457,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/rosewood-theme"]
-	path = extensions/rosewood-theme
-	url = https://github.com/ayush-porwal/zed-rosewood-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4471,3 +4471,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[rosewood-theme]
+submodule = "extensions/rosewood-theme"
+version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3329,6 +3329,10 @@ version = "0.0.1"
 submodule = "extensions/rose-pine-theme"
 version = "1.3.2"
 
+[rosewood-theme]
+submodule = "extensions/rosewood-theme"
+version = "0.0.1"
+
 [rosevin]
 submodule = "extensions/rosevin"
 version = "0.1.0"
@@ -4471,7 +4475,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[rosewood-theme]
-submodule = "extensions/rosewood-theme"
-version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3349,13 +3349,13 @@ version = "0.0.1"
 submodule = "extensions/rose-pine-theme"
 version = "1.3.2"
 
-[rosewood-theme]
-submodule = "extensions/rosewood-theme"
-version = "0.0.1"
-
 [rosevin]
 submodule = "extensions/rosevin"
 version = "0.1.0"
+
+[rosewood-theme]
+submodule = "extensions/rosewood-theme"
+version = "0.0.1"
 
 [roto]
 submodule = "extensions/roto"


### PR DESCRIPTION
This pull request adds a new theme extension, "rosewood-theme", to the project. The main changes involve registering the new theme as a submodule and updating the configuration to include it.

Theme extension addition:

* Added the `rosewood-theme` as a git submodule in `.gitmodules` and initialized it at `extensions/rosewood-theme`. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R4420-R4422) [[2]](diffhunk://#diff-b67050fad8206d5462f6c4357fad137ed5ea5bc76ae4f6ffbef2510d23b3b3dcR1)
* Updated `extensions.toml` to register the `rosewood-theme` extension with its submodule path and version.