### PR TITLE
Add Ars Goetia Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -182,6 +182,10 @@
 	path = extensions/arkts
 	url = https://github.com/liuyanghejerry/zed-arkts.git
 
+[submodule "extensions/ars-goetia"]
+	path = extensions/ars-goetia
+	url = https://github.com/rvdeguzman/ars-goetia-zed.git
+
 [submodule "extensions/arturo"]
 	path = extensions/arturo
 	url = https://github.com/DaZhi-the-Revelator/zed-arturo.git
@@ -4417,6 +4421,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ars-goetia"]
-	path = extensions/ars-goetia
-	url = https://github.com/rvdeguzman/ars-goetia-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ars-goetia"]
+	path = extensions/ars-goetia
+	url = https://github.com/rvdeguzman/ars-goetia-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -181,6 +181,10 @@ version = "0.1.0"
 submodule = "extensions/ariake"
 version = "0.0.1"
 
+[ars-goetia]
+submodule = "extensions/ars-goetia"
+version = "0.0.1"
+
 [arkts]
 submodule = "extensions/arkts"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -181,13 +181,13 @@ version = "0.1.0"
 submodule = "extensions/ariake"
 version = "0.0.1"
 
-[ars-goetia]
-submodule = "extensions/ars-goetia"
-version = "0.0.1"
-
 [arkts]
 submodule = "extensions/arkts"
 version = "0.2.0"
+
+[ars-goetia]
+submodule = "extensions/ars-goetia"
+version = "0.0.1"
 
 [arturo]
 submodule = "extensions/arturo"


### PR DESCRIPTION
  - Adds [Ars Goetia](https://github.com/rvdeguzman/ars-goetia-zed)
  - Five color palettes: Kimaris (purple+gold), Barbatos (red+rust), Gusion
  (green+plague), Vidar (blue+ice), Bael (monochrome)
  - Colors derived from the Apache 2.0-licensed [black-metal-theme-neovim](http
  s://github.com/metalelf0/black-metal-theme-neovim)

  ## Checklist

  - [x] Extension has a license (MIT)
  - [x] `extension.toml` is valid with all required fields (`id`, `name`,
  `version`, `schema_version`, `authors`, `description`, `repository`)
  - [x] Version in `extensions.toml` matches `extension.toml` (`0.0.1`)
  - [x] Ran `pnpm sort-extensions`
  - [x] Theme JSON files include `$schema` reference
