### PR TITLE
Add kanagawa-mist extension (v0.1.4)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1834,6 +1834,10 @@
 	path = extensions/kamui-dark-theme
 	url = https://gitlab.com/kamuiqf/zed-kamui-theme.git
 
+[submodule "extensions/kanagawa-mist"]
+	path = extensions/kanagawa-mist
+	url = https://github.com/hisea/zed-kanagawa-mist
+
 [submodule "extensions/kanagawa-themes"]
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1865,6 +1865,10 @@ version = "1.0.1"
 submodule = "extensions/kamui-dark-theme"
 version = "0.0.1"
 
+[kanagawa-mist]
+submodule = "extensions/kanagawa-mist"
+version = "0.1.4"
+
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
 version = "0.1.2"


### PR DESCRIPTION
   ## Summary

   This PR adds a new Zed extension: **kanagawa-mist**.

   - Extension ID: `kanagawa-mist`
   - Submodule: `extensions/kanagawa-mist`
   - Repository: https://github.com/hisea/zed-kanagawa-mist
   - Version: `0.1.4`

   ## What was changed

   - Added submodule entry in `.gitmodules`:
     - `extensions/kanagawa-mist` -> `https://github.com/hisea/zed-kanagawa-mist`
   - Added extension registry entry in `extensions.toml`:
     - `[kanagawa-mist]`
     - `submodule = "extensions/kanagawa-mist"`
     - `version = "0.1.4"`

   ## Notes

   `kanagawa-mist` is a fork/rebrand of Kanagawa for Zed with muted border colors.