### PR TITLE
Add palenight-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/palenight-theme"]
+	path = extensions/palenight-theme
+	url = https://github.com/hypn4/zed-palenight-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2904,6 +2904,10 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
+[palenight-theme]
+submodule = "extensions/palenight-theme"
+version = "0.1.0"
+
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
 version = "0.1.1"


### PR DESCRIPTION
## Summary
- Adds **Palenight** theme for Zed, ported from [VSCode Palenight Theme](https://github.com/whizkydee/vscode-palenight-theme)
- Includes 4 variants: Palenight, Palenight Italic, Palenight Operator, Palenight Mild Contrast
- Repository: https://github.com/hypn4/zed-palenight-theme

## Checklist
- [x] Extension has `extension.toml` with valid metadata
- [x] Theme JSON follows Zed schema v0.2.0
- [x] MIT license included
- [x] Submodule added and registered in `extensions.toml`