### PR TITLE
Add token-counter extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4066,6 +4066,10 @@
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git
 
+[submodule "extensions/token-counter"]
+	path = extensions/token-counter
+	url = https://github.com/jvr0x/zed-token-counter.git
+
 [submodule "extensions/tokyo-maple-theme"]
 	path = extensions/tokyo-maple-theme
 	url = https://github.com/Cateds/Tokyo-Maple-Theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4124,6 +4124,10 @@ version = "0.0.2"
 submodule = "extensions/todotxt"
 version = "0.2.3"
 
+[token-counter]
+submodule = "extensions/token-counter"
+version = "0.0.1"
+
 [tokyo-maple-theme]
 submodule = "extensions/tokyo-maple-theme"
 version = "1.3.0"


### PR DESCRIPTION
## Summary

Adds the [token-counter](https://github.com/jvr0x/zed-token-counter) extension to the Zed marketplace.

**Token Counter** displays LLM token counts as inline inlay hints, showing:
- **cl100k_base** — exact count (GPT-4, GPT-4-turbo)
- **o200k_base** — exact count (GPT-4o, o1, o3, o4, GPT-5+)
- **~Claude** — approximate estimate (~3.5 chars/token)
- **Chars** — total character count

The hint follows the viewport, staying visible as you scroll. Counts are cached per document version.

Supported file types: Markdown, Plain Text, TOML, YAML, JSON.

### How it works

The extension downloads the [token-counter-lsp](https://www.npmjs.com/package/token-counter-lsp) npm package at runtime via the Zed npm API. The language server provides inlay hints via LSP using [js-tiktoken](https://github.com/nicktomlin/js-tiktoken) for exact OpenAI token counts and a character-based heuristic for Claude estimates.

### Checklist

- [x] Extension ID does not contain "zed" or "extension"
- [x] MIT license included at extension root
- [x] `extension.toml` version matches `extensions.toml` entry (0.0.1)
- [x] Submodule uses HTTPS URL
- [x] `pnpm sort-extensions` has been run
- [x] No duplication of existing marketplace extensions
- [x] Language server is not bundled — downloaded at runtime via npm API