### PR TITLE
Added hicks hexagon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/hicks-hexagon-theme"]
+	path = extensions/hicks-hexagon-theme
+	url = https://github.com/JordanGunn/zed-theme-hicks-hexagon

--- a/extensions.toml
+++ b/extensions.toml
@@ -1590,6 +1590,10 @@ version = "0.0.4"
 submodule = "extensions/hexpeek"
 version = "0.1.0"
 
+[hicks-hexagon-theme]
+submodule = "extensions/hicks-hexagon-theme"
+version = "0.1.0"
+
 [hilleer-v-theme]
 submodule = "extensions/hilleer-v-theme"
 version = "0.0.1"


### PR DESCRIPTION
### Add Hick's Hexagon theme

A warm, earth-toned dark theme inspired by the Hick's Hexagon carpet pattern from _The Shining_. No cool tones -- built entirely from burnt orange, olive, mustard, rust, and sandstone on a dark walnut background.

Three variants:

- **Hearth** -- balanced warmth
- **Ember** -- deeper background, more saturated accents
- **Ash** -- quieter, pulled-back saturation

Repository: [https://github.com/JordanGunn/hicks-hexagon-theme](https://github.com/JordanGunn/hicks-hexagon-theme)