### PR TITLE
Update smithy to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3513,7 +3513,7 @@ path = "extensions/zed"
 
 [smithy]
 submodule = "extensions/smithy"
-version = "0.0.2"
+version = "0.0.3"
 
 [sml]
 submodule = "extensions/sml"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3513,7 +3513,7 @@ path = "extensions/zed"
 
 [smithy]
 submodule = "extensions/smithy"
-version = "0.0.1"
+version = "0.0.2"
 
 [sml]
 submodule = "extensions/sml"


### PR DESCRIPTION
- Bump smithy extension version to 0.0.3 in extensions.toml
- Update smithy submodule to latest commit on main branch.

Biggest change of this is LSP support, related issue on extension repo https://github.com/joshrutkowski/zed-smithy/issues/6