### PR TITLE
Add cursor-themes extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4417,3 +4417,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/cursor-themes-for-zed"]
+	path = extensions/cursor-themes-for-zed
+	url = https://github.com/nexmoe/cursor-themes-for-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -804,6 +804,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[cursor-themes]
+submodule = "extensions/cursor-themes-for-zed"
+version = "2.0.0"
+
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"


### PR DESCRIPTION
Adds the Cursor Themes extension (v2.0.0) by Nexmoe, which ports Cursor's theme family to Zed: Cursor Dark, Cursor Dark Midnight, Cursor Dark High Contrast, and Cursor Light.