### PR TITLE
Add hackthebox-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1514,6 +1514,10 @@
 	path = extensions/hacker-theme
 	url = https://github.com/0xSandiem/zedhacker.git
 
+[submodule "extensions/hackthebox-theme"]
+	path = extensions/hackthebox-theme
+	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
+
 [submodule "extensions/haku-dark-theme"]
 	path = extensions/haku-dark-theme
 	url = https://github.com/ArthurBrussee/haku_dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1537,6 +1537,10 @@ version = "2.0.0"
 submodule = "extensions/hacker-theme"
 version = "1.0.1"
 
+[hackthebox-theme]
+submodule = "extensions/hackthebox-theme"
+version = "0.1.0"
+
 [haku-dark-theme]
 submodule = "extensions/haku-dark-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds **hackthebox-theme**, a theme-only extension with two dark themes:
- **HackTheBox** — colors aligned with the well-known VS Code HackTheBox-style theme
- **HackTheBlue** — blue variant

Repository: https://github.com/b00tk1ll/hackthebox-zed-theme  
Extension id: `hackthebox-theme`  
Version: `0.1.0` (matches `extension.toml`)

## License

GNU GPLv3 — `LICENSE` at repository root.

## Checklist

- [x] Theme-only extension (no language server / no bundled binaries)
- [x] Extension id ends with `-theme`
- [x] HTTPS submodule URL
- [x] `extensions.toml` + `.gitmodules` sorted (`npm run sort-extensions` / `pnpm sort-extensions`)
