### PR TITLE
Add pine-script extension v0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2974,6 +2974,10 @@
 	path = extensions/pinata-theme
 	url = https://github.com/stevedylandev/pinata-theme-zed
 
+[submodule "extensions/pine-script"]
+	path = extensions/pine-script
+	url = https://github.com/nuniesmith/pine-script-zed.git
+
 [submodule "extensions/pink-cat-boo-theme"]
 	path = extensions/pink-cat-boo-theme
 	url = https://github.com/jjsalinas/PinkCatBooZed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3013,6 +3013,10 @@ version = "0.1.0"
 submodule = "extensions/pinata-theme"
 version = "0.0.1"
 
+[pine-script]
+submodule = "extensions/pine-script"
+version = "0.1.0"
+
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"
 version = "1.3.0"


### PR DESCRIPTION
## Pine Script v6 language support

Adds the `pine-script` extension for [Pine Script v6](https://www.tradingview.com/pine-script-docs/) (TradingView's scripting language).

### What it provides
- **Diagnostics** — parse errors and lint warnings via the `pine-lsp` language server
- **Hover documentation** — for ~85 built-in functions and ~80 built-in variables
- **Completions** — keywords, built-in functions, and variables
- **.pine file association** with language config (comments, brackets, autoclose)

### Architecture
- The extension itself (`pine-script-zed`) is a thin WASM bridge that locates `pine-lsp` on the user's PATH
- The `pine-lsp` language server is installed separately via `cargo install`
- Language server is **not** shipped inside the extension (per Zed guidelines)

### Extension repo
https://github.com/nuniesmith/pine-script-zed

### License
- Extension code: **MIT** ✅
- Language server (`pine-lsp`): MPL-2.0 (separate binary, not part of extension)

### Checklist
- [x] Extension ID (`pine-script`) does not contain "zed" or "extension"
- [x] `schema_version = 1` in extension.toml
- [x] MIT license at extension repo root
- [x] Language server not shipped in extension
- [x] Submodule uses HTTPS URL
- [x] Entry in `extensions.toml` is alphabetically sorted