### PR TITLE
Add pytest-local extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4342,6 +4342,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-pytest-local"]
+	path = extensions/zed-pytest-local
+	url = https://github.com/SLR-Software-Solutions-Inc/zed-pytest-local
+
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox
 	url = https://github.com/isaiah-hamilton/zedbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4396,6 +4396,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-pytest-local]
+submodule = "extensions/zed-pytest-local"
+version = "0.1.0"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"


### PR DESCRIPTION
## Summary

Adds the [pytest-local](https://github.com/SLR-Software-Solutions-Inc/zed-pytest-local) extension (v0.1.0).

## What it does

pytest has no native concept of a local override config. Once `pytest.ini` is committed, every developer shares the same settings. This extension solves that with a gitignored `pytest_local.ini` that layers on top of `pytest.ini` at runtime — without touching any committed project files.

**On every Python file open**, the extension automatically:
1. Detects `.venv` or `venv` in the project root
2. Installs a pytest plugin into `.venv/site-packages/` via a `pytest11` entry-point
3. Creates `pytest_local.ini` (templated from `pytest.ini` if present, otherwise built-in template)
4. Adds `pytest_local.ini` to `.gitignore`
5. Writes Python interpreter paths to `.zed/settings.json` for LSP and terminal

Because the plugin is installed via the `pytest11` entry-point, it loads automatically on **every pytest invocation** — gutter ▶ buttons, debugger (F5), task runner, and terminal CLI — with no `conftest.py` changes and no committed project files touched.

## Config precedence

```
CLI args  >  pytest_local.ini  >  pytest.ini
```

## Extension details

- **Language:** Python
- **Mechanism:** Language server hook (`language_server_command`) + no-op LSP
- **No-op LSP:** Satisfies Zed's protocol requirement without competing with pyright / ty / basedpyright
- **License:** MIT
- **Repo:** https://github.com/SLR-Software-Solutions-Inc/zed-pytest-local