### PR TITLE
Add peppermint-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2914,6 +2914,10 @@
 	path = extensions/penumbra-plus
 	url = https://github.com/everdrone/zed-penumbra-plus.git
 
+[submodule "extensions/peppermint-theme"]
+	path = extensions/peppermint-theme
+	url = https://github.com/sttefaano/peppermint-zed.git
+
 [submodule "extensions/perfect-dusk"]
 	path = extensions/perfect-dusk
 	url = https://github.com/Bikossor/Perfect-Dusk-Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2952,6 +2952,10 @@ version = "0.1.1"
 submodule = "extensions/penumbra-plus"
 version = "0.0.6"
 
+[peppermint-theme]
+submodule = "extensions/peppermint-theme"
+version = "0.0.1"
+
 [perfect-dusk]
 submodule = "extensions/perfect-dusk"
 version = "1.0.1"


### PR DESCRIPTION
## Summary

This PR adds the **Peppermint** theme extension for Zed.

Peppermint is a dark theme with colorful syntax highlighting on a pure black background, inspired by the original [Peppermint theme](https://ghostty.org/docs/config/reference#theme) for [Ghostty](https://ghostty.org/).

- **Repository**: https://github.com/sttefaano/peppermint-zed
- **License**: MIT

The extension provides:
- Pure black (`#000000`) background
- Colorful syntax highlighting (red keywords, green strings, blue functions, yellow types)
- Terminal ANSI colors matching Ghostty's Peppermint palette