### PR TITLE
Add brainylab-react-snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -446,6 +446,10 @@
 	path = extensions/brainfuck
 	url = https://github.com/JosephTLyons/zed-brainfuck.git
 
+[submodule "extensions/brainylab-react-snippets"]
+	path = extensions/brainylab-react-snippets
+	url = https://github.com/brainylab/zed-react-snippets.git
+
 [submodule "extensions/browser-tools-context-server"]
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -451,6 +451,10 @@ version = "0.0.1"
 submodule = "extensions/brainfuck"
 version = "0.0.4"
 
+[brainylab-react-snippets]
+submodule = "extensions/brainylab-react-snippets"
+version = "0.1.0"
+
 [browser-tools-context-server]
 submodule = "extensions/browser-tools-context-server"
 version = "0.0.2"


### PR DESCRIPTION
We created the snippets extension already used in VS for Zed, for use by the BrainyLab team that is migrating from VS Code to Zed.