### PR TITLE
Add rest-client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3246,6 +3246,10 @@
 	path = extensions/rescript
 	url = https://github.com/rescript-lang/rescript-zed.git
 
+[submodule "extensions/rest-client"]
+	path = extensions/rest-client
+	url = https://github.com/doani/zed-restclient
+
 [submodule "extensions/retrofit-theme"]
 	path = extensions/retrofit-theme
 	url = https://github.com/snapsnapturtle/retrofit-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3306,7 +3306,7 @@ version = "0.4.3"
 
 [rest-client]
 submodule = "extensions/rest-client"
-version = "0.1.3"
+version = "0.1.5"
 
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3292,6 +3292,10 @@ version = "0.0.2"
 submodule = "extensions/rescript"
 version = "0.4.3"
 
+[rest-client]
+submodule = "extensions/rest-client"
+version = "0.1.3"
+
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"


### PR DESCRIPTION
This PR introduces the **REST Client** extension for Zed, inspired by `vscode-restclient`.

**Key Features:**
- Allows sending HTTP requests directly from `.http` and `.rest` files via integrated Code Lenses ("Send Request").
- Utilizes a native Rust Language Server (Sidecar) for high-performance network I/O.
- Basic support for evaluating variables.

**Architecture:**
Because Zed extensions run in a `wasm32-wasi` sandbox and cannot perform raw TCP/HTTP network calls, this extension uses a hybrid architecture. The WASM frontend handles file parsing and Code Lenses, while the Rust LSP (sidecar) performs the actual requests.

The compiled sidecar binaries for macOS (Intel & ARM), Linux, and Windows are securely and automatically downloaded from the extension's [GitHub Releases](https://github.com/doani/zed-restclient/releases) utilizing the `zed::download_file` API upon installation.

**Testing:**
- Tested locally via `zed: install dev extension` on macOS and Linux.
- Binaries are successfully building and attached to the latest release (`v0.1.3`).
- Code formatted with `pnpm sort-extensions`.

Repository: https://github.com/doani/zed-restclient