### PR TITLE
Add EBNF language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3086,6 +3086,10 @@
 	path = extensions/the-best-theme
 	url = https://github.com/Nidal-Bakir/zed-the-best-theme.git
 
+[submodule "extensions/the-code-fixer-23-asciidoc"]
+	path = extensions/the-code-fixer-23-asciidoc
+	url = https://github.com/louiss0/zed-asciidoc-extension.git
+
 [submodule "extensions/the-dark-side"]
 	path = extensions/the-dark-side
 	url = https://github.com/Imgkl/the-dark-side.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1022,6 +1022,10 @@
 	path = extensions/earthsong-theme
 	url = https://github.com/hsjoberg/zedsong.git
 
+[submodule "extensions/ebnf"]
+	path = extensions/ebnf
+	url = https://github.com/louiss0/zed-ebnf.git
+
 [submodule "extensions/eclat"]
 	path = extensions/eclat
 	url = https://github.com/utakotoba/eclat-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4378,10 +4378,6 @@
 	path = extensions/the-best-theme
 	url = https://github.com/Nidal-Bakir/zed-the-best-theme.git
 
-[submodule "extensions/the-code-fixer-23-asciidoc"]
-	path = extensions/the-code-fixer-23-asciidoc
-	url = https://github.com/louiss0/zed-asciidoc-extension.git
-
 [submodule "extensions/the-dark-side"]
 	path = extensions/the-dark-side
 	url = https://github.com/Imgkl/the-dark-side.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1173,7 +1173,6 @@
 [submodule "extensions/easy-opaque-theme"]
 	path = extensions/easy-opaque-theme
 	url = https://github.com/KarmanyaIyer/zed-easy-opaque-theme.git
-  
 [submodule "extensions/ebnf"]
 	path = extensions/ebnf
 	url = https://github.com/louiss0/zed-ebnf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1173,6 +1173,7 @@
 [submodule "extensions/easy-opaque-theme"]
 	path = extensions/easy-opaque-theme
 	url = https://github.com/KarmanyaIyer/zed-easy-opaque-theme.git
+
 [submodule "extensions/ebnf"]
 	path = extensions/ebnf
 	url = https://github.com/louiss0/zed-ebnf.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3124,6 +3124,10 @@ version = "0.1.0"
 submodule = "extensions/the-best-theme"
 version = "0.0.1"
 
+[the-code-fixer-23-asciidoc]
+submodule = "extensions/the-code-fixer-23-asciidoc"
+version = "1.0.0"
+
 [the-dark-side]
 submodule = "extensions/the-dark-side"
 version = "0.3.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1036,6 +1036,10 @@ version = "0.1.0"
 submodule = "extensions/earthsong-theme"
 version = "1.0.0"
 
+[ebnf]
+submodule = "extensions/ebnf"
+version = "1.0.0"
+
 [eclat]
 submodule = "extensions/eclat"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4450,10 +4450,6 @@ version = "0.1.1"
 submodule = "extensions/the-best-theme"
 version = "0.0.1"
 
-[the-code-fixer-23-asciidoc]
-submodule = "extensions/the-code-fixer-23-asciidoc"
-version = "1.0.0"
-
 [the-dark-side]
 submodule = "extensions/the-dark-side"
 version = "0.3.0"


### PR DESCRIPTION
## Summary
- add the ebnf extension as a new registry submodule
- register ebnf in extensions.toml at version 1.0.0
- point the submodule at louiss0/zed-ebnf tag 1.0.0 (e71e836)

## Notes
- extension repo now includes an MIT license to satisfy publishing requirements
- this is a first-time publish, so there was no existing extensions.toml entry to update
