### PR TITLE
Add scope-i18n-lens language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/scope-i18n-lens"]
+	path = extensions/scope-i18n-lens
+	url = https://github.com/RebelBIrd/scope-i18n-lens.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3417,6 +3417,11 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.2.0"
 
+[scope-i18n-lens]
+submodule = "extensions/scope-i18n-lens"
+path = "crates/intl-lens-extension"
+version = "0.2.3"
+
 [semgrep]
 submodule = "extensions/semgrep"
 version = "0.0.2"


### PR DESCRIPTION
Add
[scope-i18n-lens](https://github.com/RebelBIrd/scope-i18n-lens) v0.2.3 to the extension registry.
An i18n extension for Zed that provides inline translation previews and key navigation, scoped to project-level locale files.