### PR TITLE
Add PHP CS Fixer language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3338,6 +3338,10 @@
 	path = extensions/php
 	url = https://github.com/zed-extensions/php.git
 
+[submodule "extensions/php-cs-fixer"]
+	path = extensions/php-cs-fixer
+	url = https://github.com/jariz/zed-php-cs-fixer.git
+
 [submodule "extensions/php-snippets"]
 	path = extensions/php-snippets
 	url = https://github.com/seekode/zed-php-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -3388,6 +3388,10 @@ version = "0.0.2"
 submodule = "extensions/php"
 version = "0.4.10"
 
+[php-cs-fixer]
+submodule = "extensions/php-cs-fixer"
+version = "0.0.1"
+
 [php-snippets]
 submodule = "extensions/php-snippets"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- Adds a Zed extension for [PHP CS Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) via the [php-cs-fixer-lsp](https://github.com/balthild/php-cs-fixer-lsp) language server
- Auto-downloads the LSP server PHAR from GitHub releases
- Configurable PHP binary path, server path, worker count, and log level

## Repository

https://github.com/jariz/zed-php-cs-fixer