### PR TITLE
Add Magento 2 snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4425,3 +4425,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/magento2-snippets"]
+	path = extensions/magento2-snippets
+	url = https://github.com/mage-os-lab/zed-magento2-snippets

--- a/.gitmodules
+++ b/.gitmodules
@@ -2174,6 +2174,10 @@
 	path = extensions/macos-classic
 	url = https://github.com/huacnlee/zed-theme-macos-classic.git
 
+[submodule "extensions/magento2-snippets"]
+	path = extensions/magento2-snippets
+	url = https://github.com/mage-os-lab/zed-magento2-snippets
+
 [submodule "extensions/mainframe-theme"]
 	path = extensions/mainframe-theme
 	url = https://github.com/jmg-duarte/mainframe-zed.git
@@ -4701,6 +4705,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/magento2-snippets"]
-	path = extensions/magento2-snippets
-	url = https://github.com/mage-os-lab/zed-magento2-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -2070,6 +2070,10 @@ version = "0.4.0"
 submodule = "extensions/make"
 version = "1.1.2"
 
+[magento2-snippets]
+submodule = "extensions/magento2-snippets"
+version = "0.1.0"
+
 [malibu]
 submodule = "extensions/malibu"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2210,6 +2210,10 @@ version = "0.1.0"
 submodule = "extensions/macos-classic"
 version = "0.4.0"
 
+[magento2-snippets]
+submodule = "extensions/magento2-snippets"
+version = "0.1.0"
+
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"
 version = "0.1.0"
@@ -2221,10 +2225,6 @@ version = "1.1.2"
 [mako]
 submodule = "extensions/mako"
 version = "0.0.3"
-
-[magento2-snippets]
-submodule = "extensions/magento2-snippets"
-version = "0.1.0"
 
 [malibu]
 submodule = "extensions/malibu"


### PR DESCRIPTION
Adds the [magento2-snippets](https://github.com/mage-os-lab/zed-magento2-snippets) extension as a submodule, providing code snippets for Magento 2 development in Zed.