### PR TITLE
Add unreal-cpp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4002,6 +4002,10 @@
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
 
+[submodule "extensions/unreal-cpp"]
+	path = extensions/unreal-cpp
+	url = https://github.com/hoklims/unreal-cpp-zed
+
 [submodule "extensions/usd"]
 	path = extensions/usd
 	url = https://github.com/elkraneo/zed-usd.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4056,6 +4056,10 @@ version = "0.0.5"
 submodule = "extensions/unoflat"
 version = "0.1.4"
 
+[unreal-cpp]
+submodule = "extensions/unreal-cpp"
+version = "0.1.0"
+
 [usd]
 submodule = "extensions/usd"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- Adds **Unreal C++** language extension for Unreal Engine C++ development
- Provides UE-aware syntax highlighting using the `tree-sitter-cpp` grammar
- Highlights reflection macros (`UCLASS`, `USTRUCT`, `UPROPERTY`, `UFUNCTION`, etc.) as `@attribute`
- Highlights specifier flags (`EditAnywhere`, `BlueprintReadWrite`, `Category`, etc.) as `@constant`
- Highlights UE logging (`UE_LOG`), assertions (`check`, `ensure`), API exports (`*_API`), and more
- Includes brackets, outline, and indentation support

## Test plan

- [x] `pnpm sort-extensions` passes
- [x] Extension installs as dev extension in Zed without errors
- [x] Language "Unreal C++" appears in language selector
- [x] UE reflection macros highlighted distinctly from regular function calls
- [x] Standard C/C++ highlighting works correctly alongside UE additions
- [ ] Verify on macOS/Linux (developed on Windows)

## Links

- Extension repo: https://github.com/hoklims/unreal-cpp-zed
- License: MIT