### PR TITLE
Add Loupe extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4425,3 +4425,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/loupe"]
+	path = extensions/loupe
+	url = https://github.com/stefanbc/loupe-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1998,6 +1998,10 @@
 	path = extensions/lotus-theme
 	url = https://github.com/skylissh/lotus-theme-zed.git
 
+[submodule "extensions/loupe"]
+	path = extensions/loupe
+	url = https://github.com/stefanbc/loupe-zed
+
 [submodule "extensions/lox"]
 	path = extensions/lox
 	url = https://github.com/arian81/zed-lox.git
@@ -4425,6 +4429,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/loupe"]
-	path = extensions/loupe
-	url = https://github.com/stefanbc/loupe-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2083,6 +2083,10 @@ path = "zed"
 submodule = "extensions/lotus-theme"
 version = "0.1.0"
 
+[loupe]
+submodule = "extensions/loupe"
+version = "0.1.0"
+
 [lox]
 submodule = "extensions/lox"
 version = "0.0.1"


### PR DESCRIPTION
Loupe shows the latest available version of your dependencies as inlay hints, directly in the editor. It supports multiple package ecosystems out of the box.

## Supported ecosystems

| File | Registry | Sections scanned |
|---|---|---|
| `package.json` | npm | `dependencies`, `devDependencies`, `peerDependencies` |
| `composer.json` | Packagist | `require`, `require-dev` |
| `pyproject.toml` | PyPI | `[project].dependencies`, `[project.optional-dependencies].*`, `[tool.poetry.dependencies]`, `[tool.poetry.dev-dependencies]`, `[tool.poetry.group.*.dependencies]` |

## What it looks like

Each dependency gets an inlay hint at the end of its line:

- `✓ 9.0.1` — already on the latest version
- `⬆ 9.1.0 available` — a newer version exists

## Notes

- Requires inlay hints to be enabled in Zed settings
  (`"inlay_hints": { "enabled": true }`)
- Results are cached for 5 minutes; saving a handled file clears the cache and fetches fresh versions immediately
- Hints are also refreshed automatically every hour in the background

## Links

- Repository: https://github.com/stefanbc/loupe-zed
- Extension id: `loupe`

---

**Checklist**
- [x] Extension repo is public on GitHub
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml`
- [x] `pnpm sort-extensions` run
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] License file present at repo root (Apache 2.0)
- [x] Tested locally via Install Dev Extension