### PR TITLE
Add grove-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1478,6 +1478,10 @@
 	path = extensions/groq
 	url = https://github.com/juice49/zed-groq
 
+[submodule "extensions/grove-theme"]
+	path = extensions/grove-theme
+	url = https://github.com/HimaAramona/grove-theme.git
+
 [submodule "extensions/gruber-darker"]
 	path = extensions/gruber-darker
 	url = https://github.com/th0jensen/gruber-darker.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1501,6 +1501,10 @@ version = "1.3.0"
 submodule = "extensions/groq"
 version = "0.0.1"
 
+[grove-theme]
+submodule = "extensions/grove-theme"
+version = "0.0.1"
+
 [gruber-darker]
 submodule = "extensions/gruber-darker"
 version = "0.0.8"


### PR DESCRIPTION
## Summary

- Adds [Grove](https://github.com/HimaAramona/grove-theme), a nature-inspired, Gruvbox-based color theme
- 6 variants: Dark, Dark Hard, Dark Soft, Light, Light Hard, Light Soft
- Licensed under MIT

## Checklist

- [x] Extension ID is suffixed with `-theme`
- [x] `LICENSE` (MIT) at repo root
- [x] `extension.toml` with all required fields
- [x] `pnpm sort-extensions` has been run