### PR TITLE
Add turbo-console-log extention

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3930,6 +3930,10 @@
 	path = extensions/tsgo
 	url = https://github.com/zed-extensions/tsgo.git
 
+[submodule "extensions/turbo-console-log"]
+	path = extensions/turbo-console-log
+	url = https://github.com/gooonzick/turbo-console-log.git
+
 [submodule "extensions/turtle"]
 	path = extensions/turtle
 	url = https://github.com/MoskitoHero/zed-turtle.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3985,6 +3985,10 @@ version = "0.0.9"
 submodule = "extensions/tsgo"
 version = "0.0.4"
 
+[turbo-console-log]
+submodule = "extensions/turbo-console-log"
+version = "0.0.1"
+
 [turtle]
 submodule = "extensions/turtle"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- Zed extension that downloads and launches the turbo-console-log-lsp binary
- Downloads platform-specific LSP binary from GitHub Releases on first use
- Forwards user configuration via initializationOptions
- Supports user-configured binary path override for local development

## What's included

- `extension.toml` — registers LSP for JavaScript, TypeScript, TSX, Python, Go, Rust, PHP
- `src/lib.rs` — Extension impl with GitHub release download, platform detection, binary caching
- README with usage instructions, keybindings, and configuration reference

## Test plan

- [x] `cargo build --target wasm32-wasip1 --release` — WASM compiles (270K)
- [ ] Install as dev extension in Zed with local LSP binary override
- [ ] Verify code actions work end-to-end
- [ ] Test on macOS (aarch64) with GitHub Release download