### PR TITLE
Add Remedy theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3250,6 +3250,10 @@
 	path = extensions/relay
 	url = https://github.com/XiNiHa/relay-zed
 
+[submodule "extensions/remedy-theme"]
+	path = extensions/remedy-theme
+	url = https://github.com/andrewRCr/zed-remedy-theme.git
+
 [submodule "extensions/replicant"]
 	path = extensions/replicant
 	url = https://github.com/pierrenel/replicant.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3296,6 +3296,10 @@ version = "0.0.2"
 submodule = "extensions/relay"
 version = "0.0.4"
 
+[remedy-theme]
+submodule = "extensions/remedy-theme"
+version = "0.1.0"
+
 [replicant]
 submodule = "extensions/replicant"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

- Adds [Remedy Theme](https://github.com/andrewRCr/zed-remedy-theme), a port of the [Remedy](https://github.com/robertrossmann/vscode-remedy) color scheme for Zed
- Warm, comfortable theme with orange accents, rooted in the Base16 Eighties palette
- 6 variants: Remedy Dark, Remedy Bright, plus blur and transparent versions of each
- Licensed under BSD 3-Clause