### PR TITLE
Add Night Owl Black theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2558,6 +2558,10 @@
 	path = extensions/nickel
 	url = https://github.com/norpadon/zed-nickel-extension
 
+[submodule "extensions/night-owl-black"]
+	path = extensions/night-owl-black
+	url = https://github.com/IhorPeresunko/night-owl-black-zed-theme.git
+
 [submodule "extensions/night-owlz"]
 	path = extensions/night-owlz
 	url = https://github.com/elGusto/night-owlz.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2593,6 +2593,10 @@ version = "0.0.2"
 submodule = "extensions/nickel"
 version = "0.0.1"
 
+[night-owl-black]
+submodule = "extensions/night-owl-black"
+version = "0.1.0"
+
 [night-owlz]
 submodule = "extensions/night-owlz"
 version = "0.0.4"


### PR DESCRIPTION
This PR adds the Night Owl Black theme extension to Zed.

Checklist:
- Extension has a license
- `extension.toml` includes the required metadata
- Version in this PR matches the extension repo version (`0.1.0`)
- Ran `pnpm sort-extensions`
- Theme JSON includes the Zed schema reference
