### PR TITLE
Add BugStalker debug adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -470,6 +470,10 @@
 	path = extensions/bubblegum
 	url = https://github.com/koalefant/zed-bubblegum
 
+[submodule "extensions/bugstalker-dap"]
+	path = extensions/bugstalker-dap
+	url = https://github.com/godzie44/BugStalker.git
+
 [submodule "extensions/bun-docs-mcp"]
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -475,6 +475,11 @@ version = "0.0.1"
 submodule = "extensions/bubblegum"
 version = "0.1.0"
 
+[bugstalker-dap]
+submodule = "extensions/bugstalker-dap"
+version = "0.1.0"
+path = "extension/zed"
+
 [bun-docs-mcp]
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"


### PR DESCRIPTION
## Summary

- This PR adds the [BugStalker](https://github.com/godzie44/BugStalker) debugger extension to Zed.
- Licensed under MIT
