### PR TITLE
Add pgfmt language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2946,6 +2946,10 @@
 	path = extensions/pest
 	url = https://github.com/pest-parser/zed-pest.git
 
+[submodule "extensions/pgfmt"]
+	path = extensions/pgfmt
+	url = https://github.com/middle-management/pgfmt.git
+
 [submodule "extensions/phasmid-theme"]
 	path = extensions/phasmid-theme
 	url = https://github.com/t-lander/phasmid-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3454,8 +3454,8 @@
 	path = extensions/pest
 	url = https://github.com/pest-parser/zed-pest.git
 
-[submodule "extensions/pgfmt"]
-	path = extensions/pgfmt
+[submodule "extensions/pgfmt-lsp"]
+	path = extensions/pgfmt-lsp
 	url = https://github.com/middle-management/pgfmt.git
 
 [submodule "extensions/phasmid-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2984,6 +2984,11 @@ version = "0.2.0"
 submodule = "extensions/pest"
 version = "0.1.1"
 
+[pgfmt]
+submodule = "extensions/pgfmt"
+path = "zed-pgfmt"
+version = "0.3.1"
+
 [phasmid-theme]
 submodule = "extensions/phasmid-theme"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3509,10 +3509,10 @@ version = "0.2.0"
 submodule = "extensions/pest"
 version = "0.1.1"
 
-[pgfmt]
+[pgfmt-lsp]
 submodule = "extensions/pgfmt"
 path = "zed-pgfmt"
-version = "0.3.1"
+version = "0.3.3"
 
 [phasmid-theme]
 submodule = "extensions/phasmid-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3510,7 +3510,7 @@ submodule = "extensions/pest"
 version = "0.1.1"
 
 [pgfmt-lsp]
-submodule = "extensions/pgfmt"
+submodule = "extensions/pgfmt-lsp"
 path = "zed-pgfmt"
 version = "0.3.3"
 


### PR DESCRIPTION
Adds [pgfmt](https://github.com/middle-management/pgfmt) — a PostgreSQL SQL formatter extension.

pgfmt provides formatting and diagnostics for SQL files via `pgfmt-lsp`, which is downloaded automatically on first use.

- **Languages:** SQL
- **License:** MIT