### PR TITLE
Update blueprint to v0.4.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -429,7 +429,7 @@ version = "1.0.0"
 
 [blueprint]
 submodule = "extensions/blueprint"
-version = "0.4.0"
+version = "0.4.1"
 
 [bluespec-systemverilog]
 submodule = "extensions/bluespec-systemverilog"


### PR DESCRIPTION
Updates grammar to the latest commit, adds highlighting support for `Gtk.LevelBar` offsets and `try` binding expression.