### PR TITLE
Add Oceans of Andromeda theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2726,6 +2726,10 @@
 	path = extensions/oceanic-next
 	url = https://github.com/rkunev/oceanic-next.git
 
+[submodule "extensions/oceans-of-andromeda-theme"]
+	path = extensions/oceans-of-andromeda-theme
+	url = https://github.com/jdonlucas/zed-oceans-of-andromeda
+
 [submodule "extensions/odin"]
 	path = extensions/odin
 	url = https://github.com/zed-extensions/odin

--- a/extensions.toml
+++ b/extensions.toml
@@ -2762,6 +2762,10 @@ version = "0.0.1"
 submodule = "extensions/oceanic-next"
 version = "0.3.0"
 
+[oceans-of-andromeda-theme]
+submodule = "extensions/oceans-of-andromeda-theme"
+version = "1.0.0"
+
 [odin]
 submodule = "extensions/odin"
 version = "0.3.11"


### PR DESCRIPTION
## Summary

This PR adds the Oceans of Andromeda theme. A port from the original [Oceans of Andromeda](https://github.com/samlovescoding/oceans-of-andromeda) VS Code theme.

<img width="1913" height="1079" alt="Screenshot 2026-04-03 181616" src="https://github.com/user-attachments/assets/763e6356-04a4-4ad4-a079-715bba6984ec" />

## Checklist

- [x] Extension ID is suffixed with `-theme`
- [x] `LICENSE` (MIT) at repo root
- [x] `extension.toml` with all required fields
- [x] `pnpm sort-extensions` has been run

## Credits

Based on the original work by [@samlovescoding](https://github.com/samlovescoding):

- [https://github.com/samlovescoding/oceans-of-andromeda](https://github.com/samlovescoding/oceans-of-andromeda)