### PR TITLE
Add csskit language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -770,7 +770,7 @@
 	path = extensions/cspell
 	url = https://github.com/mantou132/zed-cspell
 
-[submodule "extensions/csskit"]
+[submodule "extensions/csskit-lsp"]
 	path = extensions/csskit-lsp
 	url = https://github.com/csskit/csskit
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -770,6 +770,10 @@
 	path = extensions/cspell
 	url = https://github.com/mantou132/zed-cspell
 
+[submodule "extensions/csskit"]
+	path = extensions/csskit-lsp
+	url = https://github.com/csskit/csskit
+
 [submodule "extensions/css-modules-kit"]
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -770,10 +770,6 @@
 	path = extensions/cspell
 	url = https://github.com/mantou132/zed-cspell
 
-[submodule "extensions/csskit-lsp"]
-	path = extensions/csskit-lsp
-	url = https://github.com/csskit/csskit
-
 [submodule "extensions/css-modules-kit"]
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git
@@ -781,6 +777,10 @@
 [submodule "extensions/css-variables"]
 	path = extensions/css-variables
 	url = https://github.com/lmn451/css-variables-zed.git
+
+[submodule "extensions/csskit-lsp"]
+	path = extensions/csskit-lsp
+	url = https://github.com/csskit/csskit
 
 [submodule "extensions/csv"]
 	path = extensions/csv

--- a/extensions.toml
+++ b/extensions.toml
@@ -779,11 +779,6 @@ version = "1.2.4"
 submodule = "extensions/cspell"
 version = "0.0.7"
 
-[csskit-lsp]
-submodule = "extensions/csskit-lsp"
-version = "0.0.1"
-path = "packages/csskit_zed"
-
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
 version = "0.1.1"
@@ -792,6 +787,11 @@ path = "crates/zed"
 [css-variables]
 submodule = "extensions/css-variables"
 version = "0.1.0"
+
+[csskit-lsp]
+submodule = "extensions/csskit-lsp"
+version = "0.0.1"
+path = "packages/csskit_zed"
 
 [csv]
 submodule = "extensions/csv"

--- a/extensions.toml
+++ b/extensions.toml
@@ -779,6 +779,11 @@ version = "1.2.4"
 submodule = "extensions/cspell"
 version = "0.0.7"
 
+[csskit-lsp]
+submodule = "extensions/csskit-lsp"
+version = "0.0.1"
+path = "packages/csskit_zed"
+
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

- Adds the [csskit](https://csskit.rs/) extension which integrates the `csskit lsp` command into Zed, providing LSP support for CSS.
- Supports CSS files.

## Extension details

- **ID**: `csskit`
- **Version**: `0.0.1`
- **Repository**: https://github.com/csskit/csskit
- **License**: MIT

## Checklist

- [x] Extension ID is unique
- [x] Extension ID does not contain "zed" or "extension"
- [x] `extension.toml` includes required fields (id, name, description, version, schema_version, authors, repository, license)
- [x] License is MIT (approved)
- [x] README documents installation and usage