### PR TITLE
Add sql-tools language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sql-tools"]
+	path = extensions/sql-tools
+	url = https://github.com/kidkender/zed-sql-tools.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4194,6 +4194,10 @@
 	path = extensions/sql
 	url = https://github.com/zed-extensions/sql.git
 
+[submodule "extensions/sql-tools"]
+	path = extensions/sql-tools
+	url = https://github.com/kidkender/zed-sql-tools.git
+
 [submodule "extensions/sqlc-snippets"]
 	path = extensions/sqlc-snippets
 	url = https://github.com/NarmadaWeb/sqlc-snippets-zed.git
@@ -5153,6 +5157,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sql-tools"]
-	path = extensions/sql-tools
-	url = https://github.com/kidkender/zed-sql-tools.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3627,6 +3627,10 @@ version = "0.1.0"
 submodule = "extensions/sql"
 version = "1.1.7"
 
+[sql-tools]
+submodule = "extensions/sql-tools"
+version = "0.2.1"
+
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4265,7 +4265,7 @@ version = "1.1.7"
 
 [sql-tools]
 submodule = "extensions/sql-tools"
-version = "0.2.1"
+version = "0.4.0"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"


### PR DESCRIPTION
## Summary

Adds the **SQL Tools** extension (`sql-tools`) to the registry.

**Repository:** https://github.com/kidkender/zed-sql-tools

### What it does

- AST-based SQL formatter (no external CLI required)
- Smart formatting rules: single-line for short queries, multi-line with indented columns for complex ones
- Linting: warns on `UPDATE` without `WHERE`, syntax errors, missing columns
- Inline comment preservation, idempotent formatting

### Checklist

- [x] Unique extension ID (`sql-tools`) — does not contain "zed" or "extension"
- [x] MIT license included
- [x] `extension.toml` with id, name, version
- [x] Public repository
- [x] Release tag `v0.2.1` exists
- [x] Language server is downloaded at runtime (not bundled)
- [x] entry added in alphabetical order in `extensions.toml`