### PR TITLE
Add maho language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/maho"]
+	path = extensions/maho
+	url = https://github.com/MahoCommerce/zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2290,6 +2290,10 @@
 	path = extensions/macos-classic
 	url = https://github.com/huacnlee/zed-theme-macos-classic.git
 
+[submodule "extensions/maho-intelligence"]
+	path = extensions/maho-intelligence
+	url = https://github.com/MahoCommerce/zed.git
+
 [submodule "extensions/mainframe-theme"]
 	path = extensions/mainframe-theme
 	url = https://github.com/jmg-duarte/mainframe-zed.git
@@ -4841,6 +4845,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/maho"]
-	path = extensions/maho
-	url = https://github.com/MahoCommerce/zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2386,8 +2386,8 @@
 	path = extensions/magento2-snippets
 	url = https://github.com/mage-os-lab/zed-magento2-snippets
 
-[submodule "extensions/maho-intelligence"]
-	path = extensions/maho-intelligence
+[submodule "extensions/maho-lsp"]
+	path = extensions/maho-lsp
 	url = https://github.com/MahoCommerce/zed.git
 
 [submodule "extensions/mainframe-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2078,6 +2078,10 @@ version = "0.4.0"
 submodule = "extensions/make"
 version = "1.1.2"
 
+[maho]
+submodule = "extensions/maho"
+version = "0.0.1"
+
 [malibu]
 submodule = "extensions/malibu"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2080,7 +2080,7 @@ version = "1.1.2"
 
 [maho]
 submodule = "extensions/maho"
-version = "0.0.1"
+version = "0.8.1"
 
 [malibu]
 submodule = "extensions/malibu"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2330,6 +2330,10 @@ version = "0.1.0"
 submodule = "extensions/macos-classic"
 version = "0.4.0"
 
+[maho-intelligence]
+submodule = "extensions/maho-intelligence"
+version = "0.9.0"
+
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"
 version = "0.1.0"
@@ -2337,10 +2341,6 @@ version = "0.1.0"
 [make]
 submodule = "extensions/make"
 version = "1.1.2"
-
-[maho]
-submodule = "extensions/maho"
-version = "0.8.1"
 
 [mako]
 submodule = "extensions/mako"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2429,9 +2429,9 @@ version = "0.4.0"
 submodule = "extensions/magento2-snippets"
 version = "0.1.0"
 
-[maho-intelligence]
-submodule = "extensions/maho-intelligence"
-version = "0.9.0"
+[maho-lsp]
+submodule = "extensions/maho-lsp"
+version = "0.9.1"
 
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"


### PR DESCRIPTION
## Summary

- Adds the [Maho](https://mahocommerce.com) extension, which integrates the Maho Intelligence LSP server with Zed
- Provides class alias completion, hover, go-to-definition, and diagnostics for [Maho](https://github.com/MahoCommerce/maho) ecommerce projects
- Repository: https://github.com/MahoCommerce/zed