### PR TITLE
Add viewtree-icon-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4126,6 +4126,10 @@
 	path = extensions/viewtree
 	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
 
+[submodule "extensions/viewtree-icon-theme"]
+	path = extensions/viewtree-icon-theme
+	url = https://github.com/b-on-g/zed-viewtree-icon-theme.git
+
 [submodule "extensions/vim-theme"]
 	path = extensions/vim-theme
 	url = https://github.com/daniel-thompson/vim-theme-for-zed.git
@@ -4449,6 +4453,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/viewtree-icon-theme"]
-	path = extensions/viewtree-icon-theme
-	url = https://github.com/b-on-g/zed-viewtree-icon-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/viewtree-icon-theme"]
+	path = extensions/viewtree-icon-theme
+	url = https://github.com/b-on-g/zed-viewtree-icon-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4182,6 +4182,10 @@ version = "0.4.14"
 submodule = "extensions/viewtree"
 version = "1.0.10"
 
+[viewtree-icon-theme]
+submodule = "extensions/viewtree-icon-theme"
+version = "0.1.1"
+
 [vim-theme]
 submodule = "extensions/vim-theme"
 version = "0.5.1"


### PR DESCRIPTION
## Summary
- Adds icon theme extension for `.view.tree` files ($mol framework)
- Provides a tree-structure file icon for `view.tree` files in the file explorer

## Test plan
- [x] Install extension and verify `.view.tree` files show the tree icon
- [x] Verify icon renders correctly in both dark and light themes