### PR TITLE
Add 2026-dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,8 +10,8 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
-[submodule "extensions/2026-dark"]
-	path = extensions/2026-dark
+[submodule "extensions/2026-dark-theme"]
+	path = extensions/2026-dark-theme
 	url = https://github.com/chrocy/zed-2026-dark
 
 [submodule "extensions/a-touch-of-lilac-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/2026-dark"]
+	path = extensions/2026-dark
+	url = https://github.com/chrocy/zed-2026-dark
+
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,8 +10,8 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
-[2026-dark]
-submodule = "extensions/2026-dark"
+[2026-dark-theme]
+submodule = "extensions/2026-dark-theme"
 version = "0.1.0"
 
 [a-touch-of-lilac-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[2026-dark]
+submodule = "extensions/2026-dark"
+version = "0.1.0"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"


### PR DESCRIPTION
This extension provides a faithful port of the new VS Code 2026 Dark theme from Microsoft's official theme defaults.

Accurate Colors: Mapped all UI and syntax tokens by integrating the full metadata chain (Dark Modern -> 2026 Dark).
Full Coverage: Includes semantic tokens for Rust, Go, TypeScript, and more, as well as terminal ANSI colors.
Source: Based on the official [JSON source](https://github.com/microsoft/vscode/blob/main/extensions/theme-defaults/themes/2026-dark.json).
Ported with ❤️ for the Zed community.