### PR TITLE
Add kanagawa-wave-blur-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1850,6 +1850,10 @@
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git
 
+[submodule "extensions/kanagawa-wave-blur-theme"]
+	path = extensions/kanagawa-wave-blur-theme
+	url = https://github.com/funsaized/kanagawa-zed-theme.git
+
 [submodule "extensions/kanso"]
 	path = extensions/kanso
 	url = https://github.com/webhooked/kanso-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1881,6 +1881,10 @@ version = "0.0.1"
 submodule = "extensions/kanagawa-themes"
 version = "0.1.2"
 
+[kanagawa-wave-blur-theme]
+submodule = "extensions/kanagawa-wave-blur-theme"
+version = "0.1.0"
+
 [kanso]
 submodule = "extensions/kanso"
 version = "1.0.4"


### PR DESCRIPTION
## Summary

- Adds **Kanagawa Wave Blur** theme extension featuring two variants:
  - **Kanagawa Wave Blur** — dark theme with blur/transparency effects
  - **Kanagawa Lotus** — light theme with warm, muted tones
- Inspired by the [Kanagawa VS Code theme](https://github.com/metapho-re/kanagawa-vscode-theme), based on the colors of Katsushika Hokusai's famous painting
<img width="1454" height="924" alt="wave_light" src="https://github.com/user-attachments/assets/54d9c295-a5b9-4149-a496-1446fb294f79" />
<img width="1459" height="924" alt="wave_dark" src="https://github.com/user-attachments/assets/ca7f6020-e3d8-410d-9260-6ff2b1334448" />


## Checklist

- [x] Extension ID ends with `-theme`
- [x] MIT license at repository root
- [x] `extensions.toml` version matches `extension.toml` version (`0.1.0`)
- [x] Submodule uses HTTPS URL
- [x] Ran `pnpm sort-extensions`
- [x] Theme-only extension (no mixed features)
- [x] ID/name does not contain "zed" or "extension"