### PR TITLE
add TLA+ extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3850,6 +3850,10 @@
 	path = extensions/tla-plus
 	url = https://github.com/Akanoa/Zed-editor-TLA-syntax
 
+[submodule "extensions/tlaplus"]
+	path = extensions/tlaplus
+	url = https://github.com/suckrowPierre/zed-tlaplus.git
+
 [submodule "extensions/tm-twilight"]
 	path = extensions/tm-twilight
 	url = https://github.com/waldirbertazzijr/zed-twilight

--- a/extensions.toml
+++ b/extensions.toml
@@ -3903,6 +3903,10 @@ version = "0.0.2"
 submodule = "extensions/tla-plus"
 version = "0.2.0"
 
+[tlaplus]
+submodule = "extensions/tlaplus"
+version = "0.0.1"
+
 [tm-twilight]
 submodule = "extensions/tm-twilight"
 version = "0.0.2"


### PR DESCRIPTION
Adds the following [TLA+ extension](https://github.com/suckrowPierre/zed-tlaplus) to the Zed extension registry. 