### PR TITLE
Add Claude Warm theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -614,6 +614,10 @@
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git
 
+[submodule "extensions/claude-warm-theme"]
+	path = extensions/claude-warm-theme
+	url = https://github.com/intherejeet/claude-warm-theme.git
+
 [submodule "extensions/clean-vscode-icons"]
 	path = extensions/clean-vscode-icons
 	url = https://github.com/jacobtread/clean-vscode-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -620,6 +620,10 @@ version = "0.1.0"
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"
 
+[claude-warm-theme]
+submodule = "extensions/claude-warm-theme"
+version = "0.0.1"
+
 [clean-vscode-icons]
 submodule = "extensions/clean-vscode-icons"
 version = "0.1.1"


### PR DESCRIPTION
## Claude Warm Theme

A warm, amber-tinted theme for Zed inspired by Claude Code's terminal aesthetic.

### Variants
- **Claude Warm** (dark) - deep brown-orange background with warm syntax colors
- **Claude Warm Light** - subtle cream warmth with high-contrast syntax highlighting

### Details
- MIT licensed
- Includes full syntax highlighting, terminal ANSI colors, UI surface colors, and multiplayer cursor palette
- Both variants share a consistent warm amber accent color

Repository: https://github.com/intherejeet/claude-warm-theme