### PR TITLE
Add Nightfall theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2566,6 +2566,10 @@
 	path = extensions/night-shift
 	url = https://github.com/Jean-Tinland/zed-theme-night-shift.git
 
+[submodule "extensions/nightfall-theme"]
+	path = extensions/nightfall-theme
+	url = https://github.com/andrewzhuk/nightfall-theme.git
+
 [submodule "extensions/nightfox"]
 	path = extensions/nightfox
 	url = https://github.com/ssaunderss/zed-nightfox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2601,6 +2601,10 @@ version = "0.0.4"
 submodule = "extensions/night-shift"
 version = "1.0.3"
 
+[nightfall-theme]
+submodule = "extensions/nightfall-theme"
+version = "0.1.0"
+
 [nightfox]
 submodule = "extensions/nightfox"
 version = "0.1.1"


### PR DESCRIPTION
## Summary
- Adds **Nightfall** — a warm, vivid color scheme with macOS-native UI colors
- 3 variants: Nightfall (dark), Nightfall Italic (dark), Nightfall Light

## Links
- Extension repo: https://github.com/andrewzhuk/nightfall-theme
- License: MIT