### PR TITLE
Add kubernetes snippers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4413,3 +4413,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/kubernetes-snippets"]
+	path = extensions/kubernetes-snippets
+	url = https://github.com/zed-kubernetes/kubernetes-snippets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1902,6 +1902,10 @@
 	path = extensions/ktrz-monokai
 	url = https://github.com/pcminh0505/ktrz-monokai-zed-theme.git
 
+[submodule "extensions/kubernetes-snippets"]
+	path = extensions/kubernetes-snippets
+	url = https://github.com/zed-kubernetes/kubernetes-snippets
+
 [submodule "extensions/kubesong"]
 	path = extensions/kubesong
 	url = https://github.com/helgelol/kubesong-zed-theme.git
@@ -4449,6 +4453,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/kubernetes-snippets"]
-	path = extensions/kubernetes-snippets
-	url = https://github.com/zed-kubernetes/kubernetes-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1917,7 +1917,7 @@ version = "0.0.2"
 submodule = "extensions/ktrz-monokai"
 version = "0.0.6"
 
-[[kubernetes-snippets]]
+[kubernetes-snippets]
 version = "0.0.1"
 submodule = "extensions/kubernetes-snippets"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -1917,6 +1917,10 @@ version = "0.0.2"
 submodule = "extensions/ktrz-monokai"
 version = "0.0.6"
 
+[[kubernetes-snippets]]
+version = "0.0.1"
+submodule = "extensions/kubernetes-snippets"
+
 [kubesong]
 submodule = "extensions/kubesong"
 version = "1.0.0"


### PR DESCRIPTION
A collection of custom Kubernetes YAML snippets for the Zed editor. Use quick autocomplete keywords (like `k8sdeploy`) to instantly generate standard boilerplate for Deployments, Services, ConfigMaps, and more.

**View the full code and the complete list of supported snippets on GitHub:** [zed-kubernetes/kubernetes-snippets](https://github.com/zed-kubernetes/kubernetes-snippets)