### PR TITLE
Add sergio-tech-code-black-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3398,6 +3398,10 @@
 	path = extensions/serendipity-icons
 	url = https://github.com/meocoder31099/Serendipity-Icon-Theme-Zed.git
 
+[submodule "extensions/sergio-tech-code-black-theme"]
+	path = extensions/sergio-tech-code-black-theme
+	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git
+
 [submodule "extensions/seti-icons"]
 	path = extensions/seti-icons
 	url = https://github.com/d1y/zed-seti-icons.git
@@ -4449,6 +4453,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sergio-tech-code-black-theme"]
-	path = extensions/sergio-tech-code-black-theme
-	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sergio-tech-code-black-theme"]
+	path = extensions/sergio-tech-code-black-theme
+	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4769,3 +4769,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sergio-tech-code-black-theme"]
+	path = extensions/sergio-tech-code-black-theme
+	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3670,6 +3670,10 @@
 	path = extensions/serendipity-icons
 	url = https://github.com/meocoder31099/Serendipity-Icon-Theme-Zed.git
 
+[submodule "extensions/sergio-tech-code-black-theme"]
+	path = extensions/sergio-tech-code-black-theme
+	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git
+
 [submodule "extensions/seti-icons"]
 	path = extensions/seti-icons
 	url = https://github.com/d1y/zed-seti-icons.git
@@ -4769,6 +4773,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sergio-tech-code-black-theme"]
-	path = extensions/sergio-tech-code-black-theme
-	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3445,6 +3445,10 @@ version = "1.0.0"
 submodule = "extensions/serendipity-icons"
 version = "0.0.1"
 
+[sergio-tech-code-black-theme]
+submodule = "extensions/sergio-tech-code-black-theme"
+version = "1.0.0"
+
 [seti-icons]
 submodule = "extensions/seti-icons"
 version = "0.0.1"
@@ -4504,7 +4508,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[sergio-tech-code-black-theme]
-submodule = "extensions/sergio-tech-code-black-theme"
-version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4504,3 +4504,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[sergio-tech-code-black-theme]
+submodule = "extensions/sergio-tech-code-black-theme"
+version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3724,6 +3724,10 @@ version = "1.0.0"
 submodule = "extensions/serendipity-icons"
 version = "0.0.1"
 
+[sergio-tech-code-black-theme]
+submodule = "extensions/sergio-tech-code-black-theme"
+version = "1.0.0"
+
 [seti-icons]
 submodule = "extensions/seti-icons"
 version = "0.0.1"
@@ -4831,7 +4835,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[sergio-tech-code-black-theme]
-submodule = "extensions/sergio-tech-code-black-theme"
-version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4831,3 +4831,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[sergio-tech-code-black-theme]
+submodule = "extensions/sergio-tech-code-black-theme"
+version = "1.0.0"


### PR DESCRIPTION
## New Extension: Sergio's Tech Code in Black (OLED Theme)

**Extension ID:** sergio-tech-code-black-theme
**Version:** 1.0.0
**Type:** Theme

### Description
OLED-friendly dark theme for Zed with pure black backgrounds and red accent colors. Designed for OLED displays.

### Checklist
- [x] Extension ID ends with -theme
- [x] MIT License included
- [x] extension.toml with all required fields
- [x] Theme follows v0.2.0 schema
- [x] No use of zed or extension in name