### PR TITLE
Add magento2-lsp language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/magento2-lsp"]
+	path = extensions/magento2-lsp
+	url = https://github.com/mage-os-lab/magento2-lsp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2078,6 +2078,10 @@ version = "0.4.0"
 submodule = "extensions/make"
 version = "1.1.2"
 
+[magento2-lsp]
+submodule = "extensions/magento2-lsp"
+version = "0.0.1"
+
 [malibu]
 submodule = "extensions/malibu"
 version = "0.0.1"


### PR DESCRIPTION
Adds the Magento 2 LSP extension — a language server for Magento 2 XML config and PHP navigation in Zed.