### PR TITLE
Add Ayu theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ayu-theme"]
+	path = extensions/ayu-theme
+	url = https://github.com/shamsghi/Ayu-in-Zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -306,6 +306,10 @@
 	path = extensions/ayu-darker
 	url = https://github.com/k4yt3x/zed-theme-ayu-darker.git
 
+[submodule "extensions/ayu-theme"]
+	path = extensions/ayu-theme
+	url = https://github.com/shamsghi/Ayu-in-Zed.git
+
 [submodule "extensions/ayu-themes-glass"]
 	path = extensions/ayu-themes-glass
 	url = https://github.com/jansol/zed-ayu-glass.git
@@ -4697,6 +4701,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ayu-theme"]
-	path = extensions/ayu-theme
-	url = https://github.com/shamsghi/Ayu-in-Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -294,6 +294,10 @@ version = "0.0.3"
 submodule = "extensions/ayu-darker"
 version = "1.1.1"
 
+[ayu-theme]
+submodule = "extensions/ayu-theme"
+version = "0.1.0"
+
 [ayu-themes-glass]
 submodule = "extensions/ayu-themes-glass"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -296,7 +296,7 @@ version = "1.1.1"
 
 [ayu-theme]
 submodule = "extensions/ayu-theme"
-version = "0.1.0"
+version = "1.0.0"
 
 [ayu-themes-glass]
 submodule = "extensions/ayu-themes-glass"

--- a/extensions.toml
+++ b/extensions.toml
@@ -343,7 +343,7 @@ version = "1.1.2"
 
 [ayu-theme]
 submodule = "extensions/ayu-theme"
-version = "1.0.0"
+version = "1.0.1"
 
 [ayu-themes-glass]
 submodule = "extensions/ayu-themes-glass"


### PR DESCRIPTION
## Summary
- add full Ayu theme extension as a new submodule at `extensions/ayu-theme`
- register `ayu-theme` in `extensions.toml` at version `0.1.0`
- include Ayu Dark, Ayu Mirage, and Ayu Light from https://github.com/shamsghi/Ayu-in-Zed

## Notes
- this theme bundles all of the ayu themes in one extension, unlike other existing ayu themes that are more like variants of the official ayu theme (https://github.com/k4yt3x/zed-theme-ayu-darker & https://github.com/jansol/zed-ayu-glass)