### PR TITLE
Add RMarkdown language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4449,3 +4449,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/rmarkdown"]
+	path = extensions/rmarkdown
+	url = https://github.com/scfurl/rmarkdown.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3256,6 +3256,10 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
+[rmarkdown]
+submodule = "extensions/rmarkdown"
+version = "0.1.0"
+
 [react-snippets]
 submodule = "extensions/react-snippets"
 version = "1.0.6"


### PR DESCRIPTION
## Summary
- Adds R Markdown (`.Rmd`) language support for Zed
- Provides Markdown syntax highlighting for `.Rmd` files using the existing `markdown` tree-sitter grammar
- Injects R language highlighting into knitr-style ```` ```{r} ```` and ```` ```{r, opts} ```` code chunks
- Supports YAML/TOML frontmatter and fenced code block background highlighting

Closes #1120

## Extension repo
https://github.com/scfurl/rmarkdown