### PR TITLE
Add Panache language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2966,6 +2966,10 @@
 	path = extensions/palenight
 	url = https://github.com/alanmontgomery/palenight-zed.git
 
+[submodule "extensions/panache-language-server"]
+	path = extensions/panache-language-server
+	url = https://github.com/jolars/panache.git
+
 [submodule "extensions/panda-plus-theme"]
 	path = extensions/panda-plus-theme
 	url = https://github.com/lucianoratamero/panda-plus-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3007,6 +3007,11 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
+[panache-language-server]
+submodule = "extensions/panache-language-server"
+path = "editors/zed"
+version = "2.35.0"
+
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3007,6 +3007,11 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
+[panache-language-server]
+submodule = "extensions/panache-language-server"
+path = "editors/zed"
+version = "2.35.1"
+
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
 version = "0.1.1"


### PR DESCRIPTION
This PR adds support for the [Panache language server](https://panache.bz), with support for Markdown, Quarto, and RMarkdown languages.

## Features

- Support for Pandoc Markdown, including multiple flavors (GFM, CommonMark, Quarto, R Markdown)
- Granular support for Pandoc extensions
- Formatting support (including range formatting)
- Ability to configure external formatters for code chunks (air, ruff, black, clang-format, etc)
- Ability to configure external linters for code chunks (ruff, jarl, eslint, shellsheck, etc)
- Configuration through `panache.toml`
- Broad LSP feature set (renaming, incremental parsing, go-to-definition/declaraction, find references, document and workspace symbols, completiong, and more)