### PR TITLE
Add import-cost language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1682,6 +1682,10 @@
 	path = extensions/immigrant
 	url = https://github.com/deltarocks/zed-immigrant.git
 
+[submodule "extensions/import-cost-lsp"]
+	path = extensions/import-cost-lsp
+	url = https://github.com/gcampes/zed-import-cost.git
+
 [submodule "extensions/indigo"]
 	path = extensions/indigo
 	url = https://github.com/p3rception/Indigo-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1711,6 +1711,10 @@ version = "0.0.1"
 submodule = "extensions/immigrant"
 version = "0.1.2"
 
+[import-cost-lsp]
+submodule = "extensions/import-cost-lsp"
+version = "0.0.2"
+
 [indigo]
 submodule = "extensions/indigo"
 version = "0.1.2"


### PR DESCRIPTION
Adds the Import Cost extension, which displays inline bundle sizes for JavaScript and TypeScript imports using LSP inlay hints.
``` 
import { debounce } from 'lodash';       42.1kB (gzip: 14.2kB)
import React from 'react';               6.3kB (gzip: 2.8kB)
import type { Foo } from 'bar';          // skipped (type-only)
```
**How it works**
The extension installs and launches a lightweight Node.js LSP server (import-cost-server (https://www.npmjs.com/package/import-cost-server)) that:
1. Parses import and require() statements via the TypeScript compiler API
2. Bundles each import with esbuild (https://esbuild.github.io/) (minified, tree-shaken) to measure size
3. Returns minified + gzipped sizes as textDocument/inlayHint LSP responses

Skips type-only imports, relative imports, and Node.js builtins. Results are cached for performance.

**Details**

- Extension repo: https://github.com/gcampes/zed-import-cost
- npm package: https://www.npmjs.com/package/import-cost-server
- Languages: TypeScript, TSX, JavaScript, JSX
- License: MIT
- Server downloaded at runtime via npm_install_package (not bundled)
Inspired by wix/import-cost (https://github.com/wix/import-cost) for VS Code.