### PR TITLE
Add swiftlint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3714,6 +3714,10 @@
 	path = extensions/swift
 	url = https://github.com/samuser107/zed-swift-extension.git
 
+[submodule "extensions/swiftlint"]
+	path = extensions/swiftlint
+	url = https://github.com/julyfun/zed-swiftlint
+
 [submodule "extensions/symbols"]
 	path = extensions/symbols
 	url = https://github.com/sebastiandotdev/zed-symbols.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3764,6 +3764,10 @@ version = "0.1.0"
 submodule = "extensions/swift"
 version = "0.4.6"
 
+[swiftlint]
+submodule = "extensions/swiftlint"
+version = "0.2.0"
+
 [symbols]
 submodule = "extensions/symbols"
 version = "1.0.0"


### PR DESCRIPTION
Adds the SwiftLint extension, which shows inline SwiftLint diagnostics (warnings and errors) for Swift files in Zed via LSP.

```swift
let a: Optional<Int> = nil
// warning: Shorthand syntactic sugar should be used, i.e. Int? instead of Optional<Int> (syntactic_sugar) (swiftlint syntactic_sugar)

struct Foo {
    var a: Int? = nil
    // warning: Optional should be implicitly initialized without nil (implicit_optional_initialization)
}
```

**How it works**

The extension launches a lightweight bundled Node.js LSP server at runtime.

It runs SwiftLint and maps SwiftLint JSON output into LSP diagnostics shown inline in Zed.

1. Starts the bundled `swiftlint-lsp` server script through Node.js
2. Runs `swiftlint lint --quiet --reporter json --use-stdin <filepath>`
3. Converts SwiftLint violations into `textDocument/publishDiagnostics`

Diagnostics refresh on:

- file open
- file edit (debounced)
- file save

Supports extension-level options through Zed settings:

- `strict: true` (equivalent to `--strict`)
- `additionalParameters: [...]` (appended to the SwiftLint command)

**Details**

- Extension repo: https://github.com/julyfun/zed-swiftlint
- Language: Swift
- License: MIT
- LSP bridge is bundled with the extension (no external npm server package required)
- Requires local `swiftlint` available in `PATH`
