### PR TITLE
Add monokai-spectrum theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2418,6 +2418,10 @@
 	path = extensions/monokai-sharp
 	url = https://github.com/probablykasper/monokai-sharp-zed-theme.git
 
+[submodule "extensions/monokai-spectrum"]
+	path = extensions/monokai-spectrum
+	url = https://github.com/elviskahoro/monokai-spectrum-zed.git
+
 [submodule "extensions/monokai-vibrant-amped"]
 	path = extensions/monokai-vibrant-amped
 	url = https://github.com/Ceebox/zed-monokai-vibrant-amped.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2453,6 +2453,10 @@ version = "0.0.2"
 submodule = "extensions/monokai-sharp"
 version = "1.0.0"
 
+[monokai-spectrum]
+submodule = "extensions/monokai-spectrum"
+version = "0.1.0"
+
 [monokai-vibrant-amped]
 submodule = "extensions/monokai-vibrant-amped"
 version = "0.0.3"


### PR DESCRIPTION
## Summary
- Adds **Monokai Spectrum** — a Zed theme ported from the official [Monokai Pro (Filter Spectrum)](https://monokai.pro) VSCode extension v2.0.13
- Includes full UI color mappings and syntax highlighting

## Test plan
- [ ] Install as dev extension in Zed and verify theme appears in theme picker
- [ ] Verify syntax highlighting colors match Monokai Pro (Filter Spectrum) in VSCode