### PR TITLE
Update mistral-vibe to v2.7.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2402,7 +2402,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.7.3"
+version = "2.7.4"
 path = "distribution/zed"
 
 [mnemonic]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.7.4