### PR TITLE
Add Birdie language server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2010,6 +2010,10 @@
 	path = extensions/lox
 	url = https://github.com/arian81/zed-lox.git
 
+[submodule "extensions/ls-birdie"]
+	path = extensions/ls-birdie
+	url = https://github.com/giacomocavalieri/birdie_language_server_zed_extension
+
 [submodule "extensions/ltex"]
 	path = extensions/ltex
 	url = https://github.com/vitallium/zed-ltex.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2042,6 +2042,10 @@ version = "0.1.0"
 submodule = "extensions/lox"
 version = "0.0.1"
 
+[ls-birdie]
+submodule = "extension/ls-birdie"
+version = "1.0.0"
+
 [ltex]
 submodule = "extensions/ltex"
 version = "0.1.1"


### PR DESCRIPTION
Hello! [`birdie`](https://github.com/giacomocavalieri/birdie) is a snapshot testing library for Gleam. The latest release candidate also implements a language server, this PR adds the zed extension to use it to the extensions. Hope I haven't messed anything up!