### PR TITLE
Add Brewfile language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/brewfile"]
+	path = extensions/brewfile
+	url = https://github.com/psg2/zed-brewfile.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -450,6 +450,10 @@
 	path = extensions/brainfuck
 	url = https://github.com/JosephTLyons/zed-brainfuck.git
 
+[submodule "extensions/brewfile"]
+	path = extensions/brewfile
+	url = https://github.com/psg2/zed-brewfile.git
+
 [submodule "extensions/browser-tools-context-server"]
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git
@@ -4453,6 +4457,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/brewfile"]
-	path = extensions/brewfile
-	url = https://github.com/psg2/zed-brewfile.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -451,13 +451,13 @@ version = "0.1.0"
 submodule = "extensions/bqn"
 version = "0.0.1"
 
-[brewfile]
-submodule = "extensions/brewfile"
-version = "0.0.1"
-
 [brainfuck]
 submodule = "extensions/brainfuck"
 version = "0.0.4"
+
+[brewfile]
+submodule = "extensions/brewfile"
+version = "0.0.1"
 
 [browser-tools-context-server]
 submodule = "extensions/browser-tools-context-server"

--- a/extensions.toml
+++ b/extensions.toml
@@ -451,6 +451,10 @@ version = "0.1.0"
 submodule = "extensions/bqn"
 version = "0.0.1"
 
+[brewfile]
+submodule = "extensions/brewfile"
+version = "0.0.1"
+
 [brainfuck]
 submodule = "extensions/brainfuck"
 version = "0.0.4"


### PR DESCRIPTION
## Summary

- Adds syntax highlighting for **Brewfile** files used by [Homebrew Bundle](https://docs.brew.sh/Brew-Bundle-and-Brewfile)
- Uses a custom tree-sitter grammar at [psg2/tree-sitter-brewfile](https://github.com/psg2/tree-sitter-brewfile)
- Supports all Brewfile keywords: `tap`, `brew`, `cask`, `mas`, `vscode`, `whalebrew`, `go`, `cargo`, `uv`, `krew`, `flatpak`, and `cask_args`
- Highlights strings, comments, symbols, numbers, booleans, and key-value arguments

## Test plan

- [x] Installed as dev extension in Zed — compiles and loads successfully
- [x] Tested against a real Brewfile with 0 parse errors
- [x] Verified syntax highlighting for all supported keywords, strings, and comments