### PR TITLE
Add applescript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -146,6 +146,10 @@
 	path = extensions/apisartisan
 	url = https://github.com/TCeason/zed-theme/
 
+[submodule "extensions/applescript"]
+	path = extensions/applescript
+	url = https://github.com/bluishoul/zed-applescript-extension.git
+
 [submodule "extensions/aptos-move"]
 	path = extensions/aptos-move
 	url = https://github.com/0xbe1/aptos-move-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -149,6 +149,10 @@ path = "packages/zed"
 submodule = "extensions/apisartisan"
 version = "0.0.1"
 
+[applescript]
+submodule = "extensions/applescript"
+version = "0.1.0"
+
 [aptos-move]
 submodule = "extensions/aptos-move"
 version = "0.0.1"


### PR DESCRIPTION
Adds an AppleScript language extension at version `0.1.0`.

Provides syntax highlighting, smart indentation, bracket matching, outline navigation, shebang detection, run / compile tasks, and a gutter ▶ run button for `.applescript`, `.scpt`, `.scptd` files (and shebang `#!/usr/bin/env osascript` scripts), powered by [`waddie/tree-sitter-applescript`](https://github.com/waddie/tree-sitter-applescript).

Repo: https://github.com/bluishoul/zed-applescript-extension
Tag: [`v0.1.0`](https://github.com/bluishoul/zed-applescript-extension/releases/tag/v0.1.0)

## Checklist

- [x] Extension ID is unique (`applescript`) and contains no `zed`/`Zed`/`extension`
- [x] `extension.toml` has all required fields (`id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`)
- [x] License: MIT
- [x] No bundled language server
- [x] Submodule pinned to a tagged commit
- [x] `pnpm sort-extensions` run; `pnpm test` passes (111/111)