### PR TITLE
Add excalidraw-preview extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1146,6 +1146,10 @@
 	path = extensions/evolved-theme
 	url = https://github.com/evoL/evolved-theme.git
 
+[submodule "extensions/excalidraw-preview"]
+	path = extensions/excalidraw-preview
+	url = git@github.com:arindampradhan/excalidraw-zed-extension.git
+
 [submodule "extensions/exograph"]
 	path = extensions/exograph
 	url = https://github.com/exograph/zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1162,6 +1162,11 @@ submodule = "extensions/evolved-theme"
 path = "dist/zed"
 version = "0.3.0"
 
+[excalidraw-preview]
+submodule = "extensions/excalidraw-preview"
+path = "extension"
+version = "0.1.0"
+
 [exograph]
 submodule = "extensions/exograph"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

In both case `ctrl + S` syncs the changes in either editor views

- Add Excalidraw Preview extension for viewing .excalidraw files in a native window
- Supports .excalidraw, .excalidraw.svg, and .excalidraw.png formats
- Includes slash command for easy access
- Ships companion binary that downloads on first use


https://github.com/user-attachments/assets/37ba4f47-084f-4270-be0f-4d4096519e1f


