### PR TITLE
Add MoonBit language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2442,6 +2442,10 @@
 	path = extensions/moonbit
 	url = https://github.com/quirk-lab/zed-moonbit.git
 
+[submodule "extensions/moonbit-community"]
+	path = extensions/moonbit-community
+	url = https://github.com/Metalymph/zed-moonbit.git
+
 [submodule "extensions/moonlight"]
 	path = extensions/moonlight
 	url = https://github.com/Rick-VA/moonlight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2439,12 +2439,8 @@
 	url = https://github.com/Abhinav5383/zed-monospace-theme.git
 
 [submodule "extensions/moonbit"]
-	path = extensions/moonbit
-	url = https://github.com/quirk-lab/zed-moonbit.git
-
-[submodule "extensions/moonbit-community"]
-	path = extensions/moonbit-community
-	url = https://github.com/Metalymph/zed-moonbit.git
+    path = extensions/moonbit
+    url = https://github.com/Metalymph/zed-moonbit.git
 
 [submodule "extensions/moonlight"]
 	path = extensions/moonlight

--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,6 +4453,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/moonbit-community"]
-	path = extensions/moonbit-community
-	url = https://github.com/Metalymph/zed-moonbit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/moonbit-community"]
+	path = extensions/moonbit-community
+	url = https://github.com/Metalymph/zed-moonbit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,11 +2475,7 @@ version = "0.2.0"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.1"
-
-[moonbit-community]
-submodule = "extensions/moonbit-community"
-version = "0.1.3"
+version = "0.1.4"
 
 [moonlight]
 submodule = "extensions/moonlight"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2479,7 +2479,7 @@ version = "0.1.1"
 
 [moonbit-community]
 submodule = "extensions/moonbit-community"
-version = "0.1.2"
+version = "0.1.3"
 
 [moonlight]
 submodule = "extensions/moonlight"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2477,6 +2477,10 @@ version = "0.2.0"
 submodule = "extensions/moonbit"
 version = "0.1.1"
 
+[moonbit-community]
+submodule = "extensions/moonbit-community"
+version = "0.1.2"
+
 [moonlight]
 submodule = "extensions/moonlight"
 version = "0.0.4"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.2.0"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.5"
+version = "0.1.6"
 
 [moonlight]
 submodule = "extensions/moonlight"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4508,3 +4508,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[moonbit-community]
+submodule = "extensions/moonbit-community"
+version = "0.1.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.2.0"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.4"
+version = "0.1.5"
 
 [moonlight]
 submodule = "extensions/moonlight"
@@ -4508,7 +4508,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[moonbit-community]
-submodule = "extensions/moonbit-community"
-version = "0.1.5"


### PR DESCRIPTION
Adds `moonbit-community`, a MoonBit language extension for Zed.

Repository:
https://github.com/Metalymph/zed-moonbit

Version:
0.1.2

Features:
- Tree-sitter-based syntax highlighting
- MoonBit language server integration (`moonbit-lsp`)
- Basic outline support
- Bracket and indentation support

Notes:
- `moon.pkg` can be associated manually via `file_types` in Zed settings
- Tested locally as a dev extension