### PR TITLE
Add MikroTik RouterOS extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2358,6 +2358,10 @@
 	path = extensions/minizinc
 	url = https://tangled.org/dekker.one/zed-minizinc
 
+[submodule "extensions/mikrotik-routeros"]
+	path = extensions/mikrotik-routeros
+	url = https://github.com/Azagtot/zed-mikrotik-routeros.git
+
 [submodule "extensions/mint-theme"]
 	path = extensions/mint-theme
 	url = https://github.com/Ivanopulo124/zed-theme-mint.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.9"
+version = "0.1.10"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.8"
+version = "0.1.9"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.0"
+version = "0.1.1"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2392,6 +2392,10 @@ version = "1.0.0"
 submodule = "extensions/minizinc"
 version = "0.1.0"
 
+[mikrotik-routeros]
+submodule = "extensions/mikrotik-routeros"
+version = "0.1.0"
+
 [mint-theme]
 submodule = "extensions/mint-theme"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.5"
+version = "0.1.6"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.1"
+version = "0.1.2"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.7"
+version = "0.1.8"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.6"
+version = "0.1.7"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.4"
+version = "0.1.5"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.2"
+version = "0.1.3"
 
 [mint-theme]
 submodule = "extensions/mint-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2394,7 +2394,7 @@ version = "0.1.0"
 
 [mikrotik-routeros]
 submodule = "extensions/mikrotik-routeros"
-version = "0.1.3"
+version = "0.1.4"
 
 [mint-theme]
 submodule = "extensions/mint-theme"


### PR DESCRIPTION
## Summary
- add the MikroTik RouterOS extension as a submodule
- register `mikrotik-routeros` in `extensions.toml` at version `0.1.0`
- point the submodule to the public repository at https://github.com/Azagtot/zed-mikrotik-routeros

## Notes
- the extension repository includes an accepted MIT license
- the manifest includes repository metadata
- the extension version matches the tagged GitHub release `v0.1.0`
- `.gitmodules` and `extensions.toml` were inserted in sorted order