### PR TITLE
Add Markdown PDF extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2082,6 +2082,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdown-pdf"]
+	path = extensions/markdown-pdf
+	url = https://github.com/matinfo/zed-markdown-pdf.git
+
 [submodule "extensions/markdown-snippets"]
 	path = extensions/markdown-snippets
 	url = https://github.com/bobbymannino/markdown-snippets-for-zed.git
@@ -4453,6 +4457,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/markdown-pdf"]
-	path = extensions/markdown-pdf
-	url = https://github.com/matinfo/zed-markdown-pdf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/markdown-pdf"]
+	path = extensions/markdown-pdf
+	url = https://github.com/matinfo/zed-markdown-pdf.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2116,7 +2116,7 @@ version = "0.0.5"
 
 [markdown-pdf]
 submodule = "extensions/markdown-pdf"
-version = "0.1.2"
+version = "0.1.3"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4511,4 +4511,4 @@ version = "0.2.0"
 
 [markdown-pdf]
 submodule = "extensions/markdown-pdf"
-version = "0.1.1"
+version = "0.1.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4511,4 +4511,4 @@ version = "0.2.0"
 
 [markdown-pdf]
 submodule = "extensions/markdown-pdf"
-version = "0.1.0"
+version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4508,3 +4508,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[markdown-pdf]
+submodule = "extensions/markdown-pdf"
+version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2114,6 +2114,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-pdf]
+submodule = "extensions/markdown-pdf"
+version = "0.1.2"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.0.7"
@@ -4508,7 +4512,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[markdown-pdf]
-submodule = "extensions/markdown-pdf"
-version = "0.1.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2256,7 +2256,7 @@ version = "0.0.5"
 
 [markdown-pdf]
 submodule = "extensions/markdown-pdf"
-version = "0.1.3"
+version = "0.1.4"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2388,7 +2388,7 @@ version = "0.0.5"
 
 [markdown-pdf]
 submodule = "extensions/markdown-pdf"
-version = "0.1.4"
+version = "0.2.0"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"


### PR DESCRIPTION
This PR registers the **Markdown PDF** extension, which adds PDF export capabilities to Zed through an MCP context server powered by Playwright/Chromium.

> Updated 2026-05-27: bumped to **v0.2.0** — adds opt-in KaTeX math rendering, auto-generated `[[toc]]`, and heading anchors. All new behavior defaults off; existing exports remain byte-identical.

### What it does

Ask the AI assistant to export any open Markdown file to PDF:

> *"Export this file to PDF"*
> *"Export with a header showing the title and date, and page numbers in the footer"*
> *"Export in landscape, Letter format, with the monokai highlight theme"*
> *"Export this with math enabled and a table of contents"*

### Key features

- **Math rendering (KaTeX)** — `$inline$` and `$$display$$` syntax, custom LaTeX macros, fonts inlined into the CSS so output is fully self-contained ([guide](https://matinfo.github.io/zed-markdown-pdf/guide/math))
- **Auto-generated table of contents** — drop a `[[toc]]` marker in your markdown; heading anchors enable clickable in-document links ([guide](https://matinfo.github.io/zed-markdown-pdf/guide/toc-and-anchors))
- **Structured header/footer** — declarative zone-based configuration (left / center / right) with typed elements: text, image, date, page number, title, spacer
- **Custom variables** — any YAML front matter field becomes a `{placeholder}` in headers and footers
- **Image embedding** — SVG, PNG, JPEG logos embedded as base64 data URIs; supports `~/` home paths and a global `assets_directory` with `@/` prefix for shared branding assets
- **Per-document overrides** — full settings override via `pdf:` front matter block
- **Syntax highlighting** — 80+ highlight.js themes
- **Zero manual setup** — MCP server and Chromium install automatically on first use
- **Cross-platform** — macOS, Linux, Windows

### Links

- **Repository:** https://github.com/matinfo/zed-markdown-pdf
- **Documentation:** https://matinfo.github.io/zed-markdown-pdf/
- **v0.2.0 release notes:** https://github.com/matinfo/zed-markdown-pdf/releases/tag/server-v0.2.0

### Technical notes

The extension downloads `markdown-pdf-server.tar.gz` from the matching GitHub release on first use. No npm or Chromium installation is required from the user — the MCP server handles everything automatically. The v0.2.0 tarball bundles `vendor/katex-inline.css` with woff2 fonts inlined as base64, so KaTeX rendering works offline without external font fetches.