### PR TITLE
Update cem to v0.9.18

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -546,7 +546,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.9.17"
+version = "0.9.18"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
Updates cem extension to [version 0.9.18](https://github.com/bennypowers/cem/releases/tag/v0.9.18).