### PR TITLE
feat: add Apex language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,6 +142,10 @@
 	path = extensions/apathy-theme
 	url = https://github.com/coopmoney/apathy-theme
 
+[submodule "extensions/apex"]
+	path = extensions/apex
+	url = https://github.com/jasonkradams/zed-apex.git
+
 [submodule "extensions/apisartisan"]
 	path = extensions/apisartisan
 	url = https://github.com/TCeason/zed-theme/

--- a/extensions.toml
+++ b/extensions.toml
@@ -145,6 +145,10 @@ submodule = "extensions/apathy-theme"
 version = "3.5.0"
 path = "packages/zed"
 
+[apex]
+submodule = "extensions/apex"
+version = "0.0.4"
+
 [apisartisan]
 submodule = "extensions/apisartisan"
 version = "0.0.1"


### PR DESCRIPTION
Adds Apex, SOQL, and SOSL syntax highlighting via tree-sitter-sfapex.

Closes (no upstream issue — new extension submission)

- Extension ID: apex
- Repo: https://github.com/jasonkradams/zed-apex
- Version: 0.0.4
- License: Apache-2.0