### PR TITLE
Add Poryscript language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/poryscript"]
+	path = extensions/poryscript
+	url = https://github.com/chris-wilson-1/zed-poryscript.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3050,6 +3050,10 @@
 	path = extensions/popping-and-locking
 	url = https://github.com/randoneering/popping-and-locking-zed-theme.git
 
+[submodule "extensions/poryscript"]
+	path = extensions/poryscript
+	url = https://github.com/chris-wilson-1/zed-poryscript.git
+
 [submodule "extensions/postgres-context-server"]
 	path = extensions/postgres-context-server
 	url = https://github.com/zed-extensions/postgres-context-server.git
@@ -4453,6 +4457,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/poryscript"]
-	path = extensions/poryscript
-	url = https://github.com/chris-wilson-1/zed-poryscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3089,6 +3089,10 @@ version = "0.6.1"
 submodule = "extensions/popping-and-locking"
 version = "1.0.3"
 
+[poryscript]
+submodule = "extensions/poryscript"
+version = "0.2.0"
+
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Adds the [Poryscript](https://github.com/huderlem/poryscript) language extension, providing language support for the pokeemerald / pokeruby / pokefirered ROM hack decomp communities.

### Features

- Syntax highlighting via [tree-sitter-poryscript](https://github.com/chris-wilson-1/tree-sitter-poryscript)
- Full LSP support via [poryscript-ls](https://github.com/chris-wilson-1/poryscript-ls) (diagnostics, completions, hover, go-to-definition, find references, rename, formatting, code
actions, inlay hints, and more)
- Zero-config install: the extension auto-downloads the language server binary from GitHub releases

### Extension repo

https://github.com/chris-wilson-1/zed-poryscript

### Supporting repos

https://github.com/chris-wilson-1/tree-sitter-poryscript
https://github.com/chris-wilson-1/poryscript-ls