### PR TITLE
Add imzed — IBM mainframe language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4453,3 +4453,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/imzed"]
+	path = extensions/imzed
+	url = https://github.com/Infomanta/imzed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1707,6 +1707,10 @@ version = "1.2.0"
 submodule = "extensions/idris2"
 version = "0.0.1"
 
+[imzed]
+submodule = "extensions/imzed"
+version = "0.3.8"
+
 [immigrant]
 submodule = "extensions/immigrant"
 version = "0.1.2"


### PR DESCRIPTION
## Summary

- Adds **imzed**, a Zed extension providing syntax highlighting, snippets, and language support for IBM mainframe languages
- Supported languages: **JCL**, **COBOL** (IBM Enterprise with EXEC SQL/CICS), **REXX**, **HLASM**
- Each language uses a dedicated tree-sitter grammar
- Built by [Infomanta](https://infomanta.com) — contact: info@infomanta.com

## Extension details

- **Repository:** https://github.com/Infomanta/imzed
- **Version:** 0.3.7
- **License:** MIT