### PR TITLE
Add mcp-webshift MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4581,3 +4581,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-webshift"]
+	path = extensions/mcp-webshift
+	url = https://github.com/x-hannibal/webshift.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2410,6 +2410,11 @@ version = "0.0.2"
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"
 
+[mcp-webshift]
+submodule = "extensions/mcp-webshift"
+path = "integrations/zed"
+version = "0.1.0"
+
 [mdx]
 submodule = "extensions/mdx"
 version = "0.3.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2852,6 +2852,7 @@ version = "5.4.2"
 [mcp-webshift]
 submodule = "extensions/mcp-webshift"
 path = "integrations/zed"
+version = "0.1.0"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
## Summary

- Adds [mcp-webshift](https://github.com/x-hannibal/webshift) as a Zed MCP context server extension
- Native Rust binary, zero runtime dependencies (no Node, Python, or Docker required)
- Provides denoised web search via multiple configurable backends (SearXNG, Brave, Tavily, Exa, SerpAPI, Google, Bing)
- Extension defined in `integrations/zed/` within the webshift repository

## Test plan

- [x] Extension entry added alphabetically to `extensions.toml` (after `mcp-server-webflow`, before `mdx`)
- [x] Submodule points to `x-hannibal/webshift` at latest `main` commit
- [x] `path = "integrations/zed"` correctly resolves to the Zed extension subdirectory
- [x] Only 3 files changed: `.gitmodules`, `extensions.toml`, `extensions/mcp-webshift` gitlink