### PR TITLE
Update julia to v0.1.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1665,7 +1665,7 @@ version = "0.3.2"
 
 [julia]
 submodule = "extensions/julia"
-version = "0.1.8"
+version = "0.1.9"
 
 [just]
 submodule = "extensions/just"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1900,7 +1900,7 @@ version = "0.3.2"
 
 [julia]
 submodule = "extensions/julia"
-version = "0.1.9"
+version = "0.1.10"
 
 [just]
 submodule = "extensions/just"


### PR DESCRIPTION
Fix missing functions and macros in outline views. 

Fix missing highlighting for certain macros.

Update to tree-sitter-julia v0.25.0. The new grammar is significantly smaller and more performant.

BREAKING: The new grammar drops support for emojis as identifiers. This means that variable or function names etc. cannot contain emojis anymore. Of course, any values can still contain anything.

