### PR TITLE
Add inference-sh extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1726,6 +1726,10 @@
 	path = extensions/indigo
 	url = https://github.com/p3rception/Indigo-zed.git
 
+[submodule "extensions/inference-sh"]
+	path = extensions/inference-sh
+	url = https://github.com/inference-sh/zed-inference-mcp.git
+
 [submodule "extensions/inform6"]
 	path = extensions/inform6
 	url = https://github.com/Or4c/zed-inform6.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1756,6 +1756,10 @@ version = "0.0.2"
 submodule = "extensions/indigo"
 version = "0.1.2"
 
+[inference-sh]
+submodule = "extensions/inference-sh"
+version = "0.0.1"
+
 [inform6]
 submodule = "extensions/inform6"
 version = "1.0.0"


### PR DESCRIPTION
## Summary

- Adds the [inference.sh](https://inference.sh) MCP server extension
- Provides access to 250+ AI apps (image, video, audio, LLMs, 3D and more) from Zed's Agent panel
- Uses a native bridge binary (downloaded from GitHub releases) for stdio-to-HTTP MCP transport with Bearer token auth
- No Node.js or other runtime dependencies required

## Test plan

- [x] Extension compiles with `cargo build --target wasm32-wasip1`
- [x] Bridge binary compiles and tested on macOS (arm64)
- [x] GitHub release v0.1.0 published with binaries for all platforms
- [x] Configure UI shows installation instructions and API key settings
- [x] Successfully connects to inference.sh MCP server from Zed Agent panel
- [x] License: MIT
