### PR TITLE
Add turbo-console-log language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3930,6 +3930,10 @@
 	path = extensions/tsgo
 	url = https://github.com/zed-extensions/tsgo.git
 
+[submodule "extensions/turbo-console-log"]
+	path = extensions/turbo-console-log
+	url = https://github.com/gooonzick/turbo-console-log.git
+
 [submodule "extensions/turtle"]
 	path = extensions/turtle
 	url = https://github.com/MoskitoHero/zed-turtle.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3985,6 +3985,10 @@ version = "0.0.9"
 submodule = "extensions/tsgo"
 version = "0.0.4"
 
+[turbo-console-log]
+submodule = "extensions/turbo-console-log"
+version = "0.0.1"
+
 [turtle]
 submodule = "extensions/turtle"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds `turbo-console-log`, a Zed extension for automated debug logging.

The extension:
- provides a real Zed extension with `extension.toml` at the repository root
- downloads and launches the native `turbo-console-log-lsp` binary from GitHub Releases
- supports a user-configured binary path override
- forwards initialization options to the language server

## What's included

- `extensions.toml` entry for `turbo-console-log`
- `.gitmodules` entry for `extensions/turbo-console-log`
- submodule pointing to `https://github.com/gooonzick/turbo-console-log`
- root-level `extension.toml`, Rust extension crate, and host-side extension tests in the extension repository
- native Rust language server under `server/`

## Test plan

```bash
cargo test
cargo test --manifest-path server/Cargo.toml --locked
cargo build --target wasm32-wasip1 --release
```