### PR TITLE
Add Civet language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4581,3 +4581,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/civet"]
+	path = extensions/civet
+	url = https://github.com/DanielXMoore/Civet

--- a/.gitmodules
+++ b/.gitmodules
@@ -698,6 +698,10 @@
 	path = extensions/city-lights
 	url = https://github.com/DP19/zed-theme-city-lights.git
 
+[submodule "extensions/civet"]
+	path = extensions/civet
+	url = https://github.com/DanielXMoore/Civet.git
+
 [submodule "extensions/clarity"]
 	path = extensions/clarity
 	url = https://github.com/stx-labs/clarity-zed.git
@@ -5101,6 +5105,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/civet"]
-	path = extensions/civet
-	url = https://github.com/DanielXMoore/Civet

--- a/extensions.toml
+++ b/extensions.toml
@@ -616,6 +616,11 @@ version = "1.0.0"
 submodule = "extensions/city-lights"
 version = "0.0.2"
 
+[civet]
+submodule = "extensions/civet"
+path = "lsp/zed"
+version = "0.0.1"
+
 [clarity]
 submodule = "extensions/clarity"
 version = "0.1.0"


### PR DESCRIPTION
Adds support for the [Civet](https://civet.dev) programming language.

Civet is a language that compiles to TypeScript/JavaScript, with concise syntax inspired by CoffeeScript and modern JS.

The extension uses the `civet-lsp` language server (installed via `npm install -g @danielx/civet-language-server`) and a Tree-sitter grammar included in the Civet monorepo.

This uses `path = "lsp/zed"` to point into the extension subdirectory of the Civet monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)