### PR TITLE
Update haxe to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1616,7 +1616,7 @@ version = "0.2.1"
 
 [haxe]
 submodule = "extensions/haxe"
-version = "0.3.1"
+version = "0.4.0"
 
 [hbuilderx-push-light]
 submodule = "extensions/hbuilderx-push-light"


### PR DESCRIPTION
- Now uses a different Haxe grammar upstream.
- EDIT: Added outline support.
- EDIT: Added injections for the Comment Highlighter extension.
- Bumped required extension API for better Windows support.
- **Runs a Node script** on startup to try to discover a valid build configuration.
  - Removes friction of creating a custom settings file for many projects (default toolchain, non-monorepo).