### PR TITLE
Update cem to v0.9.19

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -550,7 +550,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.9.18"
+version = "0.9.19"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
Updates cem extension to [version 0.9.19](https://github.com/bennypowers/cem/releases/tag/v0.9.19).