### PR TITLE
Add noted language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2650,6 +2650,10 @@
 	path = extensions/not-too-shabby
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
+[submodule "extensions/noted-theme"]
+	path = extensions/noted-theme
+	url = https://github.com/sergeevalera/noted-theme.git
+
 [submodule "extensions/nova-theme"]
 	path = extensions/nova-theme
 	url = https://github.com/overstarry/zed-nova.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2718,6 +2718,10 @@
 	path = extensions/not-too-shabby
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
+[submodule "extensions/noted"]
+	path = extensions/noted
+	url = git@github.com:sergeevalera/noted.git
+
 [submodule "extensions/noted-theme"]
 	path = extensions/noted-theme
 	url = https://github.com/sergeevalera/noted-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2720,7 +2720,7 @@
 
 [submodule "extensions/noted"]
 	path = extensions/noted
-	url = git@github.com:sergeevalera/noted.git
+	url = https://github.com/sergeevalera/noted.git
 
 [submodule "extensions/noted-theme"]
 	path = extensions/noted-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -2718,7 +2718,7 @@
 	path = extensions/not-too-shabby
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
-[submodule "extensions/noted"]
+[submodule "extensions/noted-markdown-lsp"]
 	path = extensions/noted
 	url = https://github.com/sergeevalera/noted.git
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4589,6 +4589,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "noted"]
-	path = noted
-	url = https://github.com/sergeevalera/noted.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2719,7 +2719,7 @@
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
 [submodule "extensions/noted-markdown-lsp"]
-	path = extensions/noted
+	path = extensions/noted-markdown-lsp
 	url = https://github.com/sergeevalera/noted.git
 
 [submodule "extensions/noted-theme"]
@@ -4589,3 +4589,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "noted"]
+	path = noted
+	url = https://github.com/sergeevalera/noted.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2757,6 +2757,10 @@ version = "0.0.1"
 submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
+[noted]
+submodule = "extensions/noted"
+version = "0.1.0"
+
 [noted-theme]
 submodule = "extensions/noted-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2686,6 +2686,10 @@ version = "0.0.1"
 submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
+[noted-theme]
+submodule = "extensions/noted-theme"
+version = "0.1.0"
+
 [nova-theme]
 submodule = "extensions/nova-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2758,7 +2758,7 @@ submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
 [noted-markdown-lsp]
-submodule = "extensions/noted"
+submodule = "extensions/noted-markdown-lsp"
 version = "0.1.0"
 
 [noted-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2757,7 +2757,7 @@ version = "0.0.1"
 submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
-[noted]
+[noted-markdown-lsp]
 submodule = "extensions/noted"
 version = "0.1.0"
 


### PR DESCRIPTION
A language server for Obsidian-flavored Markdown in Zed. Handles wikilink resolution, diagnostics, hover previews, rename refactoring, tag navigation, and live HTML preview via a local server.