### PR TITLE
Add Ash theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4585,3 +4585,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ash"]
+	path = extensions/ash
+	url = https://github.com/KaikSelhorst/ash-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -94,7 +94,7 @@ version = "2.0.2"
 
 [ash]
 submodule = "extensions/ash"
-version = "0.1.0"
+version = "0.2.0"
 
 [alpental-theme]
 submodule = "extensions/alpental-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -92,6 +92,10 @@ version = "0.0.3"
 submodule = "extensions/alabaster-dark"
 version = "2.0.2"
 
+[ash]
+submodule = "extensions/ash"
+version = "0.1.0"
+
 [alpental-theme]
 submodule = "extensions/alpental-theme"
 version = "0.0.8"


### PR DESCRIPTION
 Adds the Ash theme extension, a dark theme with muted and desaturated colors.

  Includes two variants:
  - **Ash Dark** — dark background with soft, low-saturation colors
  - **Ash Monochrome** — same base, fully grayscale palette