### PR TITLE
Adding Miramare theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2426,6 +2426,10 @@
 	path = extensions/mint-theme
 	url = https://github.com/Ivanopulo124/zed-theme-mint.git
 
+[submodule "extensions/miramare-theme"]
+	path = extensions/miramare-theme
+	url = https://github.com/franbach/miramare-zed.git
+
 [submodule "extensions/missing-theme"]
 	path = extensions/missing-theme
 	url = https://codeberg.org/dz4k/zed-missing.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2463,6 +2463,10 @@ version = "0.1.0"
 submodule = "extensions/mint-theme"
 version = "0.1.1"
 
+[miramare-theme]
+submodule = "extensions/miramare-theme"
+version = "0.0.1"
+
 [missing-theme]
 submodule = "extensions/missing-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds Miramare as a new theme extension to the Zed extension registry.

Extension ID: miramare-theme
Version: 0.0.1
Repo: https://github.com/franbach/miramare-zed

Thanks Zed team for this great editor!