### PR TITLE
Add k8s-crd language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1878,6 +1878,10 @@
 	path = extensions/just
 	url = https://github.com/jackTabsCode/zed-just.git
 
+[submodule "extensions/k8s-crd-lsp"]
+	path = extensions/k8s-crd-lsp
+	url = https://github.com/decade-eng/k8s-crd-lsp-zed.git
+
 [submodule "extensions/kagimcp"]
 	path = extensions/kagimcp
 	url = https://github.com/jmylchreest/kagimcp-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2194,6 +2194,10 @@
 	path = extensions/just
 	url = https://github.com/jackTabsCode/zed-just.git
 
+[submodule "extensions/k8s-crd-lsp"]
+	path = extensions/k8s-crd-lsp
+	url = https://github.com/decade-eng/k8s-crd-lsp-zed.git
+
 [submodule "extensions/kagimcp"]
 	path = extensions/kagimcp
 	url = https://github.com/jmylchreest/kagimcp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1910,6 +1910,10 @@ version = "0.1.10"
 submodule = "extensions/just"
 version = "0.2.0"
 
+[k8s-crd-lsp]
+submodule = "extensions/k8s-crd-lsp"
+version = "0.0.1"
+
 [kagimcp]
 submodule = "extensions/kagimcp"
 version = "0.0.31"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2237,6 +2237,10 @@ version = "0.1.10"
 submodule = "extensions/just"
 version = "0.2.0"
 
+[k8s-crd-lsp]
+submodule = "extensions/k8s-crd-lsp"
+version = "0.0.1"
+
 [kagimcp]
 submodule = "extensions/kagimcp"
 version = "0.0.31"


### PR DESCRIPTION
## k8s-crd-lsp

Kubernetes CRD schema completions and validation for YAML files.

- Fetches OpenAPI v3 schemas from connected K8s cluster via kubectl
- Provides completions for all K8s resource types (built-in + CRDs)
- Validates manifests with schema-aware diagnostics
- Lazy per-API-group loading
- Shows loading status while fetching schemas

Repositories:
https://github.com/decade-eng/k8s-crd-lsp
https://github.com/decade-eng/k8s-crd-lsp-zed