### PR TITLE
Add Vikasit Code extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4254,6 +4254,10 @@
 	path = extensions/viewtree
 	url = https://github.com/Dev-cmyser/zed-view.tree-mol-support.git
 
+[submodule "extensions/vikasit"]
+	path = extensions/vikasit
+	url = https://github.com/Vikasit-AI/releases.git
+
 [submodule "extensions/vim-theme"]
 	path = extensions/vim-theme
 	url = https://github.com/daniel-thompson/vim-theme-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4314,6 +4314,11 @@ version = "0.4.14"
 submodule = "extensions/viewtree"
 version = "1.0.10"
 
+[vikasit]
+submodule = "extensions/vikasit"
+path = "packages/extensions/zed"
+version = "2.0.1"
+
 [vim-theme]
 submodule = "extensions/vim-theme"
 version = "0.5.1"


### PR DESCRIPTION
Adding [Vikasit Code](https://github.com/Vikasit-AI/releases) as a new extension to the Zed extensions registry.

Vikasit Code is an AI coding agent powered by Vikasit AI. It provides agent server integration for Zed with support for darwin-aarch64, darwin-x86_64, linux-aarch64, linux-x86_64, and windows-x86_64.

Extension version: 2.0.1

## Changes
- Added `[vikasit]` entry to `extensions.toml`
- Added submodule entry to `.gitmodules` pointing to `https://github.com/Vikasit-AI/releases.git`
- Added submodule gitlink for `extensions/vikasit`