### PR TITLE
Add hl7v2 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1630,6 +1630,10 @@
 	path = extensions/hivacruz-theme
 	url = https://github.com/kinoute/zed-hivacruz-theme
 
+[submodule "extensions/hl7v2"]
+	path = extensions/hl7v2
+	url = https://github.com/Yes25/zed-hl7v2-extension.git
+
 [submodule "extensions/hledger"]
 	path = extensions/hledger
 	url = https://github.com/juev/hledger-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1910,6 +1910,10 @@
 	path = extensions/hivacruz-theme
 	url = https://github.com/kinoute/zed-hivacruz-theme
 
+[submodule "extensions/hl7v2"]
+	path = extensions/hl7v2
+	url = https://github.com/Yes25/zed-hl7v2-extension.git
+
 [submodule "extensions/hledger"]
 	path = extensions/hledger
 	url = https://github.com/juev/hledger-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1655,6 +1655,10 @@ version = "1.0.0"
 submodule = "extensions/hivacruz-theme"
 version = "0.2.0"
 
+[hl7v2]
+submodule = "extensions/hl7v2"
+version = "0.0.1"
+
 [hledger]
 submodule = "extensions/hledger"
 version = "0.1.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1946,6 +1946,10 @@ version = "1.0.0"
 submodule = "extensions/hivacruz-theme"
 version = "0.2.0"
 
+[hl7v2]
+submodule = "extensions/hl7v2"
+version = "0.0.1"
+
 [hledger]
 submodule = "extensions/hledger"
 version = "0.1.3"


### PR DESCRIPTION
Adds an extension for [HL7 v2](https://en.wikipedia.org/wiki/HL7) messages (old but still widely used standard in the medical domain).

  - Syntax highlighting via [tree-sitter-hl7v2](https://github.com/Yes25/tree-sitter-hl7v2)
  - Loads the Language server ([hl7_v2_lsp](https://github.com/Yes25/hl7_v2_lsp))
