### PR TITLE
Update jellybeans-vim to 0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1848,7 +1848,7 @@ version = "0.0.1"
 
 [jellybeans-vim]
 submodule = "extensions/jellybeans-vim"
-version = "0.0.2"
+version = "0.0.3"
 
 [jetbrains-darcula-theme-by-bronya0]
 submodule = "extensions/jetbrains-darcula-theme-by-bronya0"


### PR DESCRIPTION
Fix hard to see bracket colors by changing them to foreground (white)