### PR TITLE
Add bruno language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -458,6 +458,10 @@
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git
 
+[submodule "extensions/bruno"]
+	path = extensions/bruno
+	url = https://github.com/ebina4yaka/bruno-zed-extension
+
 [submodule "extensions/bsl"]
 	path = extensions/bsl
 	url = https://github.com/dlyubanevich/zed-bsl-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -463,6 +463,10 @@ version = "0.0.4"
 submodule = "extensions/browser-tools-context-server"
 version = "0.0.2"
 
+[bruno]
+submodule = "extensions/bruno"
+version = "0.0.1"
+
 [bsl]
 submodule = "extensions/bsl"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

This extension provides Bruno language support for Zed. It adds:
- Syntax highlighting for .bru files
- Language Server Protocol (LSP) integration for Bruno
- Formatting support through a lightweight formatter adapter

## Extension details
- ID: bruno
- Version: 0.0.1
- Repository: https://github.com/ebina4yaka/bruno-zed-extension
- License: MIT