### PR TITLE
Add qml-language-server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4585,3 +4585,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/qml-language-server"]
+	path = extensions/qml-language-server
+	url = https://github.com/cushycush/zed-qml-language-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3282,6 +3282,10 @@ version = "0.1.0"
 submodule = "extensions/qml"
 version = "0.0.4"
 
+[qml-language-server]
+submodule = "extensions/qml-language-server"
+version = "0.1.1"
+
 [qqcode]
 submodule = "extensions/qqcode"
 version = "1.2.0"


### PR DESCRIPTION
Adds a QML language extension backed by [qml-language-server](https://github.com/cushycush/qml-language-server) — a pure-Go LSP implementation with completions, go-to-definition, hover, diagnostics, document links, document symbols, signature help, workspace symbol search, and formatting.

Extension repo: https://github.com/cushycush/zed-qml-language-server at tag `v0.1.1` (commit `889a5083e8a16ce1c793793b1722c3724e5def5e`).

## Coexistence with existing \`qml\` extension

The existing [\`qml\`](https://github.com/lkroll/zed-qml) extension drives \`qmlls\` (Qt's reference LSP). This extension drives a different backend — \`qml-language-server\`, a pure-Go server — so I registered it under a distinct id (\`qml-language-server\`) rather than replacing the existing entry. Users can install either, depending on which backend they prefer.

## Notes

- Tested as a dev extension locally — WASM build succeeds and the LSP wire-up works.
- Grammar: \`tree-sitter-qmljs\` @ \`606a66b9\` (same grammar the existing extension uses).
- Extension API version: \`zed_extension_api = "0.7.0"\`.