### PR TITLE
Add Claude theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4585,3 +4585,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/claude-theme"]
+	path = extensions/claude-theme
+	url = https://github.com/Otanikotani/zed-claude-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -624,6 +624,10 @@ version = "0.1.0"
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"
 
+[claude-theme]
+submodule = "extensions/claude-theme"
+version = "0.1.0"
+
 [clean-vscode-icons]
 submodule = "extensions/clean-vscode-icons"
 version = "0.1.1"


### PR DESCRIPTION
Adds the **Claude** theme extension (`claude-theme`).

- Dark + light variants
- Repo: https://github.com/Otanikotani/zed-claude-theme
- Warm palette inspired by Claude's colors (cream/orange light, blue-gray dark)

Screenshots in the theme README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)