### PR TITLE
Add typespec-extended

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4074,6 +4074,10 @@
 	path = extensions/typespec
 	url = https://github.com/rhodee/zed-typespec
 
+[submodule "extensions/typespec-extended"]
+	path = extensions/typespec-extended
+	url = https://github.com/adi-family/zed-typespec-extended.git
+
 [submodule "extensions/typos"]
 	path = extensions/typos
 	url = https://github.com/BaptisteRoseau/zed-typos.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4133,6 +4133,10 @@ version = "0.1.0"
 submodule = "extensions/typespec"
 version = "0.0.1"
 
+[typespec-extended]
+submodule = "extensions/typespec-extended"
+version = "1.0.0"
+
 [typos]
 submodule = "extensions/typos"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Adds **TypeSpec Extended** — a TypeSpec language extension with a dialect-tolerant grammar.

- Extension repo: https://github.com/adi-family/zed-typespec-extended
- Grammar fork: https://github.com/mgorunuch/tree-sitter-typespec (fork of happenslol/tree-sitter-typespec with three additive parse relaxations; upstream tests still pass)
- License: MIT

### What this ships

Syntax highlighting + indent/bracket rules for `.tsp` files. Where it differs from the existing `typespec` extension:

- Accepts bare data-style members in `interface { field: type; }` bodies (emitted as a distinct `interface_property` node, highlighted as `@property` rather than `@function.method`). Useful for dialects that use `interface` as a data holder — notably the ADI plugin protocol (`@plugin`, `@llm.tool`, `@llm.trigger`, `@validate`, ...).
- Accepts plain-brace object/array literals (`{...}` / `[...]`) in decorator arguments alongside strict value-mode (`#{...}` / `#[...]`).
- Allows nested array types like `int64[][]`.
- Uses Zed-canonical capture names (`@property`, `@type.builtin`, `@keyword`) so highlights land reliably across themes.

### Checks

- [x] `pnpm sort-extensions` run — `extensions.toml` and `.gitmodules` sorted
- [x] MIT license present in the extension repo
- [x] No language server bundled
- [x] Extension ID does not contain `zed` / `Zed` / `extension`