### PR TITLE
Update mcp-server-threadbridge to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2404,7 +2404,7 @@ version = "0.0.2"
 
 [mcp-server-threadbridge]
 submodule = "extensions/mcp-server-threadbridge"
-version = "0.1.0"
+version = "0.2.0"
 
 [mcp-server-weave]
 submodule = "extensions/mcp-server-weave"


### PR DESCRIPTION
Release: https://github.com/dereklei12/mcp-threadbridge/releases/tag/v0.2.0

## What's new in v0.2.0

**Five-subsystem verification pipeline:**
- AGM belief revision with versioned fact chains
- CUSUM dual change detector driven by file hash diffs (VCS-independent)
- Structured provenance with content-hash verification
- Contradiction candidate detection via embedding similarity
- Thompson sampling verification budget allocator

**Other improvements:**
- ``THREADBRIDGE_STORAGE`` env var for Local/Global/Custom storage modes
- Atomic write-temp-rename for all disk writes
- Project move detection
- Natural language warnings for contradiction candidates in search_memory responses

**Retrieval benchmark (LoCoMo + LongMemEval):**
- LoCoMo session-level Recall_all@10: 90.13, NDCG@10: 79.90
- LongMemEval session-level Recall@10: 97.56, NDCG@10: 92.94

## Release checklist
- [x] Binary built for macOS (aarch64), Linux (x86_64), Windows (x86_64)
- [x] ``extensions.toml`` version bumped to match ``extension.toml``
- [x] ``pnpm sort-extensions`` run (no diff)