### PR TITLE
Add pyatlas language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3198,8 +3198,8 @@
 	path = extensions/px-to-rem
 	url = https://github.com/ugi-dev/px-to-rem
 
-[submodule "extensions/pyatlas"]
-	path = extensions/pyatlas
+[submodule "extensions/pyatlas-lsp"]
+	path = extensions/pyatlas-lsp
 	url = https://github.com/Akamine2001/zed-pyatlas.git
 
 [submodule "extensions/pycharm-modern-themes"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -3198,6 +3198,10 @@
 	path = extensions/px-to-rem
 	url = https://github.com/ugi-dev/px-to-rem
 
+[submodule "extensions/pyatlas"]
+	path = extensions/pyatlas
+	url = https://github.com/Akamine2001/zed-pyatlas.git
+
 [submodule "extensions/pycharm-modern-themes"]
 	path = extensions/pycharm-modern-themes
 	url = https://github.com/injirez/zed-pycharm-modern-themes

--- a/extensions.toml
+++ b/extensions.toml
@@ -3245,6 +3245,10 @@ version = "0.0.4"
 submodule = "extensions/px-to-rem"
 version = "0.1.0"
 
+[pyatlas]
+submodule = "extensions/pyatlas"
+version = "0.1.0"
+
 [pycharm-modern-themes]
 submodule = "extensions/pycharm-modern-themes"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3245,9 +3245,9 @@ version = "0.0.4"
 submodule = "extensions/px-to-rem"
 version = "0.1.0"
 
-[pyatlas]
-submodule = "extensions/pyatlas"
-version = "0.1.0"
+[pyatlas-lsp]
+submodule = "extensions/pyatlas-lsp"
+version = "0.1.1"
 
 [pycharm-modern-themes]
 submodule = "extensions/pycharm-modern-themes"


### PR DESCRIPTION
## Summary                                                                  
                                                                              
Adds pyatlas https://github.com/Akamine2001/pyatlas, a Python auto-import LSP                                                                  companion for basedpyright.
                                                                              
• Returns import-aware completion items from a workspace symbol index       
• Designed to run alongside basedpyright, which continues to handle type checking / hover / go-to-definition                                         
• Extension repo: https://github.com/Akamine2001/zed-pyatlas                
• LSP repo: https://github.com/Akamine2001/pyatlas                          
                                                                              
The extension downloads a prebuilt pyatlas binary for the user's platform   
(macOS aarch64, Linux x86_64/aarch64, Windows x86_64) from the upstream GitHub Releases, matching the asset naming convention pyatlas-<rust-target-triple>.{tar.gz,zip}. Users can override the binary path via lsp.pyatlas.binary.path in their Zed settings.                              
                                                                              
## Test plan

- [x] Extension compiles locally for wasm32-wasip1
- [x] Release assets exist for all advertised platforms at v0.1.0
- [x] extension.toml uses schema_version = 1
- [x] License (MIT) is present at the submodule root
- [x] Extension ID, name, and submodule path follow registry naming rules