### PR TITLE
Update umple to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4191,7 +4191,7 @@ version = "0.0.1"
 
 [umple]
 submodule = "extensions/umple"
-version = "0.1.0"
+version = "0.1.1"
 
 [underground-theme]
 submodule = "extensions/underground-theme"


### PR DESCRIPTION
Bumps the Umple extension from 0.1.0 to 0.1.1.

## Changes in 0.1.1

- Auto-refresh `umplesync.jar` when the Umple compiler releases a new version. Previously the jar was only downloaded on first install and never updated, so Zed users were pinned to whichever compiler they installed initially. 0.1.1 fetches the current version string from `cruise.umple.org/umpleonline/scripts/versionRunning.txt` on each activation and re-downloads the jar only when it differs from the cached version. All network paths fail open so diagnostics keep working on flaky connections.

## Release notes

- Release notes: none