### PR TITLE
Add zed-rdf extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3310,6 +3310,10 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
+[submodule "extensions/rdf"]
+	path = extensions/rdf
+	url = https://github.com/sparkling/zed-rdf.git
+
 [submodule "extensions/react-snippets"]
 	path = extensions/react-snippets
 	url = https://github.com/tamimhasandev/react-snippets
@@ -4517,10 +4521,6 @@
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
-
-[submodule "extensions/zed-rdf"]
-	path = extensions/zed-rdf
-	url = https://github.com/sparkling/zed-rdf.git
 
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox

--- a/.gitmodules
+++ b/.gitmodules
@@ -4518,6 +4518,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-rdf"]
+	path = extensions/zed-rdf
+	url = https://github.com/sparkling/zed-rdf.git
+
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox
 	url = https://github.com/isaiah-hamilton/zedbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3359,6 +3359,11 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
+[rdf]
+submodule = "extensions/rdf"
+version = "0.1.1"
+path = "extensions/zed-rdf"
+
 [react-snippets]
 submodule = "extensions/react-snippets"
 version = "1.0.6"
@@ -4576,11 +4581,6 @@ version = "0.1.2"
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
-
-[zed-rdf]
-submodule = "extensions/zed-rdf"
-version = "0.1.0"
-path = "extensions/zed-rdf"
 
 [zedbox]
 submodule = "extensions/zedbox"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4577,6 +4577,11 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-rdf]
+submodule = "extensions/zed-rdf"
+version = "0.1.0"
+path = "extensions/zed-rdf"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"


### PR DESCRIPTION
## Summary

Adds **zed-rdf** — a Zed extension + Rust LSP for the RDF family of 11 languages: Turtle, TriG, N-Triples, N-Quads, RDF/XML, JSON-LD, TriX, Notation3, SPARQL 1.1, ShEx, Datalog.

## Features

- Error-tolerant parsing with structured diagnostics (stable error codes, e.g. `SPARQL-BIND-001`).
- Hover against **513 curated vocabulary terms** (`xsd`, `rdf`, `rdfs`, `owl`, `skos`, `sh`, `dcterms`, `dcat`, `foaf`, `schema`, `prov`).
- Completion (per-language keywords + prefix expansion).
- Goto-definition (Turtle `@prefix` → IRI; SPARQL variable → first binding site).
- Document symbols, formatting (NT/N-Quads/Turtle/TriG — idempotent).
- Rename (Turtle prefix labels, SPARQL variables).
- Code actions: sort-prefixes, add-missing-prefix, extract-prefix.
- 9-type delta-encoded semantic tokens (562 µs for 10k-line Turtle — 178× under the 100 ms gate).
- Incremental parse cache.

## Conformance

- 100% W3C on NT / N-Quads / Turtle / TriG / RDF-XML / JSON-LD syntax suites.
- 149/149 W3C SPARQL 1.1 syntax-test entries pass.

## Extension layout

- Source: https://github.com/sparkling/zed-rdf (v0.1.0 tagged).
- The extension itself lives at `extensions/zed-rdf/` inside a Rust workspace (same monorepo pattern as PR #5494). Registered with `path = "extensions/zed-rdf"`.
- WASM launcher (`cdylib`) uses `zed_extension_api = "0.2"` and spawns `rdf-lsp` via `worktree.which`.
- 3 tree-sitter grammar pins: [tree-sitter-turtle](https://github.com/nicowillis/tree-sitter-turtle), [tree-sitter-sparql](https://github.com/GordianDziwis/tree-sitter-sparql), [tree-sitter-shex](https://github.com/nicowillis/tree-sitter-shex).
- RDF/XML, JSON-LD, TriX delegate to Zed's built-in XML / JSON grammars.

## License

Apache-2.0 OR MIT (dual-licensed). Files at the repo root: `LICENSE-APACHE`, `LICENSE-MIT`.

## Pre-submission checks

- [x] `pnpm sort-extensions` clean.
- [x] `pnpm test` — 111/111 pass.
- [x] Submodule pinned at SHA matching `extension.toml` version 0.1.0.
- [x] License present at repo root.
- [x] Not a duplicate of any existing extension.