### PR TITLE
Add ShanHai Translate language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3534,6 +3534,10 @@
 	path = extensions/shades-of-purple-theme
 	url = https://github.com/irmhonde/shades-of-purple-theme.git
 
+[submodule "extensions/shanhai-translate"]
+	path = extensions/shanhai-translate
+	url = https://github.com/MageGojo/shanhai-translate.git
+
 [submodule "extensions/shapels"]
 	path = extensions/shapels
 	url = https://github.com/carrascomj/shapels-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3585,6 +3585,10 @@ version = "0.1.0"
 submodule = "extensions/shades-of-purple-theme"
 version = "0.0.6"
 
+[shanhai-translate]
+submodule = "extensions/shanhai-translate"
+version = "0.1.0"
+
 [shapels]
 submodule = "extensions/shapels"
 version = "0.0.1"


### PR DESCRIPTION
## Summary
- add the `shanhai-translate` extension to the marketplace
- register the extension submodule and version `0.1.0`
- point the submodule at the public repo with a published `v0.1.0` release

## Extension
- Repo: https://github.com/MageGojo/shanhai-translate
- Release: https://github.com/MageGojo/shanhai-translate/releases/tag/v0.1.0
- Extension ID: `shanhai-translate`

## Validation
- pnpm test
- pnpm sort-extensions
