### PR TITLE
Update tamarin to v1.12.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3030,6 +3030,10 @@
 	path = extensions/tailwind-theme
 	url = https://github.com/biaqat/tailwind-theme-zed.git
 
+[submodule "extensions/tamarin"]
+	path = extensions/tamarin
+	url = https://github.com/LH104729/extensions.git
+
 [submodule "extensions/tanuki"]
 	path = extensions/tanuki
 	url = https://github.com/dylf/zed-tanuki.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3044,7 +3044,7 @@
 
 [submodule "extensions/tamarin"]
 	path = extensions/tamarin
-	url = https://github.com/LH104729/extensions.git
+	url = https://github.com/LH104729/zed-tamarin
 
 [submodule "extensions/tanuki"]
 	path = extensions/tanuki

--- a/extensions.toml
+++ b/extensions.toml
@@ -3068,6 +3068,10 @@ path = "packages/zed"
 submodule = "extensions/tailwind-theme"
 version = "0.6.0"
 
+[tamarin]
+submodule = "extensions/tamarin"
+version = "0.1.0"
+
 [tanuki]
 submodule = "extensions/tanuki"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3936,7 +3936,7 @@ version = "0.6.0"
 
 [tamarin]
 submodule = "extensions/tamarin"
-version = "0.1.0"
+version = "1.12.0"
 
 [tanuki]
 submodule = "extensions/tanuki"


### PR DESCRIPTION
- Using grammar from 'tamarin-prover/tamarin-prover' instead of 'tamarin-prover/vscode-tamarin' since 'tamarin-prover/tamarin-prover' is the source of the grammar while 'tamarin-prover/vscode-tamarin' is just a local copy.
- Version number is now the same as the version of 'tamarin-prover/tamarin-prover'.