### PR TITLE
Add Deep PRO theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -918,6 +918,10 @@
 	path = extensions/deep-ocean-theme
 	url = https://github.com/axatbhardwaj/deep-ocean-theme.git
 
+[submodule "extensions/deep-pro"]
+	path = extensions/deep-pro
+	url = https://github.com/alibi85/deep-pro-zed.git
+
 [submodule "extensions/defold"]
 	path = extensions/defold
 	url = https://github.com/whiterabbit1983/zed-defold

--- a/extensions.toml
+++ b/extensions.toml
@@ -929,6 +929,10 @@ version = "1.0.0"
 submodule = "extensions/deep-ocean-theme"
 version = "0.1.0"
 
+[deep-pro]
+submodule = "extensions/deep-pro"
+version = "0.0.2"
+
 [defold]
 submodule = "extensions/defold"
 version = "0.1.4"


### PR DESCRIPTION
Adds the Deep PRO theme by Parvez Ahmed, originally published on the VS Code Marketplace (`ParvezAhmed.deepcodepro`), ported to Zed.

- Upstream: https://marketplace.visualstudio.com/items?itemName=ParvezAhmed.deepcodepro
- Port repo: https://github.com/alibi85/deep-pro-zed
- License: MIT (dual copyright — Parvez Ahmed 2023, Jonah Purinton 2026)
- One theme: `Deep PRO` (dark)