### PR TITLE
Add JSONPath extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1854,6 +1854,10 @@
 	path = extensions/jq
 	url = https://github.com/dangh/zed-jq.git
 
+[submodule "extensions/json-path"]
+	path = extensions/json-path
+	url = https://github.com/PashaFG/zed-json-path.git
+
 [submodule "extensions/json5"]
 	path = extensions/json5
 	url = https://github.com/ChunzhengLab/json5-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1886,6 +1886,10 @@ version = "0.1.0"
 submodule = "extensions/jq"
 version = "0.0.2"
 
+[json-path]
+submodule = "extensions/json-path"
+version = "0.0.2"
+
 [json5]
 submodule = "extensions/json5"
 version = "0.1.0"


### PR DESCRIPTION
JSONPath helper for [Zed](https://zed.dev/).

The extension adds a JSON code action that copies the key path at the cursor position. It is a Zed alternative to the VS Code extension [Copy JSON Path](https://marketplace.visualstudio.com/items?itemName=nidu.copy-json-path).