### PR TITLE
Update mlir-tablegen to v0.6.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2438,6 +2438,10 @@
 	path = extensions/mistral-vibe
 	url = https://github.com/mistralai/mistral-vibe.git
 
+[submodule "extensions/mlir-suite"]
+	path = extensions/mlir-suite
+	url = https://github.com/felixtensor/zed-mlir.git
+
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen
 	url = https://github.com/feichai0017/mlir-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2440,7 +2440,7 @@
 
 [submodule "extensions/mlir-suite"]
 	path = extensions/mlir-suite
-	url = https://github.com/felixtensor/zed-mlir.git
+	url = https://github.com/felixtensor/zed-mlir-suite.git
 
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen

--- a/.gitmodules
+++ b/.gitmodules
@@ -3152,7 +3152,7 @@
 
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen
-	url = https://github.com/zed-extensions/mlir-tablegen.git
+	url = https://github.com/felixtensor/zed-mlir.git
 
 [submodule "extensions/mnemonic"]
 	path = extensions/mnemonic

--- a/.gitmodules
+++ b/.gitmodules
@@ -3152,7 +3152,7 @@
 
 [submodule "extensions/mlir-suite"]
 	path = extensions/mlir-suite
-	url = https://github.com/felixtensor/zed-mlir.git
+	url = https://github.com/felixtensor/zed-mlir-suite.git
 
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen

--- a/.gitmodules
+++ b/.gitmodules
@@ -3150,6 +3150,10 @@
 	path = extensions/mjml
 	url = https://github.com/pataruco/zed-mjml.git
 
+[submodule "extensions/mlir-suite"]
+	path = extensions/mlir-suite
+	url = https://github.com/felixtensor/zed-mlir.git
+
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen
 	url = https://github.com/feichai0017/mlir-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3150,13 +3150,9 @@
 	path = extensions/mjml
 	url = https://github.com/pataruco/zed-mjml.git
 
-[submodule "extensions/mlir-suite"]
-	path = extensions/mlir-suite
-	url = https://github.com/felixtensor/zed-mlir-suite.git
-
 [submodule "extensions/mlir-tablegen"]
 	path = extensions/mlir-tablegen
-	url = https://github.com/feichai0017/mlir-zed.git
+	url = https://github.com/zed-extensions/mlir-tablegen.git
 
 [submodule "extensions/mnemonic"]
 	path = extensions/mnemonic

--- a/extensions.toml
+++ b/extensions.toml
@@ -2476,6 +2476,10 @@ submodule = "extensions/mistral-vibe"
 version = "2.7.6"
 path = "distribution/zed"
 
+[mlir-suite]
+submodule = "extensions/mlir-suite"
+version = "0.5.0"
+
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
 version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2478,7 +2478,7 @@ path = "distribution/zed"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.5.0"
+version = "0.5.1"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.5.3"
+version = "0.6.0"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.6.0"
+version = "0.6.1"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.6.1"
+version = "0.6.2"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.5.0"
+version = "0.5.1"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.5.1"
+version = "0.5.2"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3212,6 +3212,10 @@ version = "0.0.1"
 submodule = "extensions/mjml"
 version = "0.2.0"
 
+[mlir-suite]
+submodule = "extensions/mlir-suite"
+version = "0.5.0"
+
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
 version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
-version = "0.6.2"
+version = "0.6.3"
 
 [mnemonic]
 submodule = "extensions/mnemonic"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3212,13 +3212,9 @@ version = "0.0.1"
 submodule = "extensions/mjml"
 version = "0.2.0"
 
-[mlir-suite]
-submodule = "extensions/mlir-suite"
-version = "0.6.2"
-
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
-version = "0.2.1"
+version = "0.6.2"
 
 [mnemonic]
 submodule = "extensions/mnemonic"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3214,7 +3214,7 @@ version = "0.2.0"
 
 [mlir-suite]
 submodule = "extensions/mlir-suite"
-version = "0.5.2"
+version = "0.5.3"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"


### PR DESCRIPTION
Closes #1358

`mlir-tablegen` goes from v0.2.1 to v0.6.3. Rather than adding a second MLIR extension alongside it, the two are merged: the entry now tracks the MLIR/TableGen/PDLL extension, and @feichai0017 is credited as an author on it.

## What this version brings

v0.2.1 covered MLIR and TableGen at the syntax layer. On top of that:

- **PDLL (`.pdll`)** joins MLIR and TableGen as a supported language.
- **The three upstream LLVM language servers** — `mlir-lsp-server`, `mlir-pdll-lsp-server`, and `tblgen-lsp-server` are integrated, bringing definitions, references, hover, completion, and diagnostics to all three languages. They resolve through `binary.path` → `settings.path` → `$PATH`, with `compilation_database`, `extra_dirs`, `log`, and `pretty` settings. No binaries are shipped; the README documents the CMake flow for building them from LLVM.
- **MLIR code actions** come with that integration, including inserting the `expected-error` and `expected-warning` comments used for MLIR's diagnostic verification.
- **MLIR highlighting becomes dialect-agnostic.** The grammar recognizes the `dialect.op` form structurally, so downstream, experimental, and project-private dialects are highlighted without listing operation names.
- **Compilation databases are discovered automatically** — `build/` and `out/` are probed for the TableGen and PDLL databases when none is configured.
- **C++ injection is scoped.** `[{ ... }]` blocks delegate to the C++ grammar; in TableGen the injection is limited to the ODS fields that actually carry C++, so `description` text is not mis-highlighted.
- **Symbol outlines, bracket matching, and per-language indentation** are tuned for each of the three languages.
- **Vim text object support** Adapt Vim mode support on zed editor without LSP to be enabled.

The MLIR and TableGen grammars change to
- [felixtensor/tree-sitter-mlir](https://github.com/felixtensor/tree-sitter-mlir)
- [felixtensor/tree-sitter-tablegen](https://github.com/felixtensor/tree-sitter-tablegen)
- [felixtensor/tree-sitter-pdll](https://github.com/felixtensor/tree-sitter-pdll)
- [artagnon/tree-sitter-mlir](https://github.com/artagnon/tree-sitter-mlir) (the MLIR one takes some design cues from, which v0.2.1 used.)

Licensed Apache-2.0 WITH LLVM-exception, matching the LLVM project.