### PR TITLE
Update mistral-vibe to v2.8.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2473,7 +2473,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.7.6"
+version = "2.8.1"
 path = "distribution/zed"
 
 [mlir-tablegen]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.8.1