### PR TITLE
Add MCP S3 Browser extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-s3-browser"]
+	path = extensions/mcp-s3-browser
+	url = https://github.com/Bnjoroge1/mcp-s3-browser.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4656,3 +4656,6 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+[mcp-s3-browser]
+submodule = "extensions/mcp-s3-browser"
+version = "0.1.0"


### PR DESCRIPTION
## Summary
- add the `mcp-s3-browser` extension to the registry
- register the extension submodule and version `0.1.0`
- link to the new MCP S3 Browser repository

## Extension
- Repo: https://github.com/Bnjoroge1/mcp-s3-browser
- Tracking issue: #5688

## Validation
- verified the extension repo builds with `npm run check`
- verified the Rust extension compiles with `cargo check --target wasm32-wasip2`
