### PR TITLE
Upgrade tron-legacy to v1.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4099,7 +4099,7 @@ version = "0.1.1"
 
 [tron-legacy]
 submodule = "extensions/tron-legacy"
-version = "1.1.7"
+version = "1.2.1"
 
 [ts-macro]
 submodule = "extensions/ts-macro"


### PR DESCRIPTION
Update to the latest tron-legacy to support the new [diff selectors!](https://github.com/zed-industries/zed/pull/45459)