### PR TITLE
Update pink-candy-theme to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3122,7 +3122,7 @@ version = "0.0.1"
 
 [pink-candy-theme]
 submodule = "extensions/pink-candy-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"


### PR DESCRIPTION
## Pink Candy Theme — v0.2.0

Bumps the Pink Candy extension to v0.2.0 to include the **Dark Warm** variant that was already present in the extension repository but missing from the catalog.

### Variants now included
- **Pink Candy Dark** — cool dark background (`#22222A`) with `#FF1277` pink accent
- **Pink Candy Dark Warm** — warm dark background (`#1d2021`) with `#fb3453` pink accent (Gruvbox-inspired)

### Extension repository
https://github.com/paulovictor237/pink-candy-theme