### PR TITLE
Add pinkzuna theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/pinkzuna-theme"]
+	path = extensions/pinkzuna-theme
+	url = https://github.com/memiux/pinkzuna-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3086,6 +3086,10 @@
 	path = extensions/pink-cat-boo-theme
 	url = https://github.com/jjsalinas/PinkCatBooZed.git
 
+[submodule "extensions/pinkzuna-theme"]
+	path = extensions/pinkzuna-theme
+	url = https://github.com/memiux/pinkzuna-zed.git
+
 [submodule "extensions/pkl"]
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git
@@ -4597,6 +4601,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/pinkzuna-theme"]
-	path = extensions/pinkzuna-theme
-	url = https://github.com/memiux/pinkzuna-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3128,6 +3128,10 @@ version = "0.1.0"
 submodule = "extensions/pink-cat-boo-theme"
 version = "1.3.0"
 
+[pinkzuna-theme]
+submodule = "extensions/pinkzuna-theme"
+version = "1.0.0"
+
 [pkl]
 submodule = "extensions/pkl"
 version = "0.3.0"


### PR DESCRIPTION
Adds the **[Pinkzuna](https://github.com/memiux/pinkzuna-zed)** theme extension — a Zed color theme inspired by the virtual YouTuber Kizuna AI.

## Variants

- **Pinkzuna Classic** (`light`) — warm pinkish-white backgrounds, dark plum foreground, saturated pinks for syntax
- **Pinkzuna Black** (`dark`) — cold charcoal-black backgrounds, hot-pink syntax anchors, garnet strings

## Checklist

- [x] Extension ID ends with `-theme`
- [x] MIT license included
- [x] Repository uses HTTPS submodule URL
- [x] Both light and dark variants provided
- [x] Screenshots included in README