### PR TITLE
Add GN language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4514,6 +4514,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-gn-language"]
+	path = extensions/zed-gn-language
+	url = https://github.com/dsa28s/zed-gn-language.git
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1438,6 +1438,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/gn"]
+	path = extensions/gn
+	url = https://github.com/dsa28s/zed-gn-language.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets
@@ -4513,10 +4517,6 @@
 [submodule "extensions/zed"]
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
-
-[submodule "extensions/zed-gn-language"]
-	path = extensions/zed-gn-language
-	url = https://github.com/dsa28s/zed-gn-language.git
 
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes

--- a/extensions.toml
+++ b/extensions.toml
@@ -4573,6 +4573,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zed-gn-language]
+submodule = "extensions/zed-gn-language"
+version = "1.4.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1462,6 +1462,10 @@ submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.3"
 
+[gn]
+submodule = "extensions/gn"
+version = "1.4.0"
+
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.5"
@@ -4572,10 +4576,6 @@ version = "0.0.3"
 [zarcula-theme]
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
-
-[zed-gn-language]
-submodule = "extensions/zed-gn-language"
-version = "1.4.0"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"


### PR DESCRIPTION
### Summary
Adds `zed-gn-language` extension to the Zed extensions registry.

- [x] Registers the extensions/zed-gn-language submodule
- [x] Adds the extension entry to extensions.toml
