### PR TITLE
Add markdown-php extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/markdown-php"]
+	path = extensions/markdown-php
+	url = https://github.com/objectivehtml/zed-markdown-php

--- a/extensions.toml
+++ b/extensions.toml
@@ -2181,6 +2181,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-php]
+submodule = "extensions/markdown-php"
+version = "0.2.0"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.0.7"


### PR DESCRIPTION
## Extension

**Name:** Markdown PHP
**ID:** `markdown-php`
**Repository:** https://github.com/objectivehtml/zed-markdown-php

## Description

Adds PHP syntax highlighting inside Markdown fenced code blocks without requiring `<?php` tags. Uses the `tree-sitter-php` grammar (`php_only` sub-grammar).

## Checklist

- [x] Extension has an `[extension]` section in `extension.toml`
- [x] Extension has a `README.md`
- [x] Grammar sourced from `tree-sitter/tree-sitter-php` at a pinned rev
- [x] Added to `extensions.toml` in alphabetical order