### PR TITLE
Update ultraviolet-theme to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4175,7 +4175,7 @@ version = "0.0.2"
 
 [ultraviolet-theme]
 submodule = "extensions/ultraviolet-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [umbra-theme]
 submodule = "extensions/umbra-theme"


### PR DESCRIPTION
### ultraViolet v0.2.0

Includes **ultraViolet Blur** and **ultraViolet Blur (Borderless)** variants, improved visibility of ignored files in the project panel, and fixed rendering of bold text in markdown.
- **Repository:** https://github.com/Gurvirr/zed-ultraViolet
- **Version:** 0.2.0