### PR TITLE
Add Smithy LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3602,6 +3602,10 @@
 	path = extensions/smithy
 	url = https://github.com/joshrutkowski/zed-smithy.git
 
+[submodule "extensions/smithy-lsp"]
+	path = extensions/smithy-lsp
+	url = https://github.com/brewingbytes/zed-smithy.git
+
 [submodule "extensions/sml"]
 	path = extensions/sml
 	url = https://github.com/omarjatoi/zed-sml.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3655,6 +3655,10 @@ path = "extensions/zed"
 submodule = "extensions/smithy"
 version = "0.0.1"
 
+[smithy-lsp]
+submodule = "extensions/smithy-lsp"
+version = "0.1.0"
+
 [sml]
 submodule = "extensions/sml"
 version = "0.2.0"


### PR DESCRIPTION
## Extension

**Name:** Smithy LSP
**ID:** `smithy-lsp`
**Repository:** https://github.com/brewingbytes/zed-smithy

## Description

Adds full Smithy IDL language support including syntax highlighting and LSP features (go-to-definition, completions, hover, diagnostics, find references, rename, formatting, auto-imports, inlay hints) via smithy-language-server. The language server is downloaded and cached automatically on first use, no manual installation required. Grammar sourced from indoorvivants/tree-sitter-smithy.

## Checklist

- [x] Extension has an `[extension]` section in `extension.toml`
- [x] Extension has a `README.md`
- [x] Grammar sourced from `indoorvivants/tree-sitter-smithy` at a pinned rev
- [x] Added to `extensions.toml` in alphabetical order