### PR TITLE
Add Tbilisi Night theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/tbilisi-night"]
+	path = extensions/tbilisi-night
+	url = https://github.com/IosebKoplatadze/tbilisi-night-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3890,6 +3890,10 @@
 	path = extensions/taskfile
 	url = https://github.com/nickalie/zed-taskfile.git
 
+[submodule "extensions/tbilisi-night"]
+	path = extensions/tbilisi-night
+	url = https://github.com/IosebKoplatadze/tbilisi-night-zed.git
+
 [submodule "extensions/tcl"]
 	path = extensions/tcl
 	url = https://github.com/richnou/kissb-zed-tcl.git
@@ -4597,6 +4601,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/tbilisi-night"]
-	path = extensions/tbilisi-night
-	url = https://github.com/IosebKoplatadze/tbilisi-night-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3946,6 +3946,10 @@ version = "0.0.1"
 submodule = "extensions/taskfile"
 version = "0.1.0"
 
+[tbilisi-night]
+submodule = "extensions/tbilisi-night"
+version = "1.0.0"
+
 [tcl]
 submodule = "extensions/tcl"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds the **Tbilisi Night** theme extension — a theme family with three variants inspired by the warm, atmospheric nights of Tbilisi.

- **Tbilisi Night** — dark, warm purple/orange palette
- **Tbilisi Night Light** — light variant with the same accent palette
- **Tbilisi Night Storm** — Monokai Pro–style vibrant variant

Port of an existing VS Code / Cursor theme by the same author.

- Repo: https://github.com/IosebKoplatadze/tbilisi-night-zed
- License: MIT
- Author: Ioseb Koplatadze (@IosebKoplatadze)

## Checklist

- [x] New `[tbilisi-night]` entry added to `extensions.toml` (alphabetically between `taskfile` and `tcl`)
- [x] Submodule added at `extensions/tbilisi-night`
- [x] `extension.toml` valid (`schema_version = 1`, semver `1.0.0`)
- [x] Theme JSON validates against `https://zed.dev/schema/themes/v0.2.0.json`
- [x] Three variants in one file, each with `appearance`, full `style`, `players`, and `syntax` maps