### PR TITLE
Add shadcn-svelte MCP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3526,6 +3526,10 @@
 	path = extensions/shadcn-mcp
 	url = https://github.com/MrUprizing/zed-mcp-server-shadcn.git
 
+[submodule "extensions/shadcn-svelte-mcp"]
+	path = extensions/shadcn-svelte-mcp
+	url = https://github.com/cellulosa/zed-mcp-server-shadcn-svelte
+
 [submodule "extensions/shader-ls"]
 	path = extensions/shader-ls
 	url = https://github.com/cjhowe-us/zed-shader-ls

--- a/extensions.toml
+++ b/extensions.toml
@@ -3577,6 +3577,10 @@ version = "0.1.1"
 submodule = "extensions/shadcn-mcp"
 version = "0.1.0"
 
+[shadcn-svelte-mcp]
+submodule = "extensions/shadcn-svelte-mcp"
+version = "0.1.0"
+
 [shader-ls]
 submodule = "extensions/shader-ls"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds a Zed extension for the shadcn-svelte-mcp-server, enabling integration with the shadcn-svelte component registry through MCP (Model Context Protocol).

The extension launches the MCP server via npx and supports optional authentication via GitHub Personal Access Token configured through Zed context server settings.

**What this does**

* Adds a Zed context server integration for shadcn-svelte-mcp-server
* Supports running the MCP server via npx
* Supports optional GITHUB_PERSONAL_ACCESS_TOKEN via Zed settings
* Passes token both as:
    * CLI argument (--github-api-key)
    * environment variable (GITHUB_PERSONAL_ACCESS_TOKEN)
* Uses bash -lc wrapper to ensure proper npx resolution in user environments