### PR TITLE
Add Fallow language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1210,6 +1210,10 @@
 	path = extensions/factory-droid
 	url = https://github.com/Factory-AI/factory-zed-extension.git
 
+[submodule "extensions/fallow"]
+	path = extensions/fallow
+	url = https://github.com/fallow-rs/fallow
+
 [submodule "extensions/fantasticons-icons-theme"]
 	path = extensions/fantasticons-icons-theme
 	url = https://github.com/caiolandgraf/fantasticons-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1186,6 +1186,10 @@
 	path = extensions/factory-droid
 	url = https://github.com/Factory-AI/factory-zed-extension.git
 
+[submodule "extensions/fallow"]
+	path = extensions/fallow
+	url = https://github.com/fallow-rs/fallow
+
 [submodule "extensions/fantasticons-icons-theme"]
 	path = extensions/fantasticons-icons-theme
 	url = https://github.com/caiolandgraf/fantasticons-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1228,6 +1228,11 @@ version = "0.0.8"
 submodule = "extensions/factory-droid"
 version = "0.68.1"
 
+[fallow]
+submodule = "extensions/fallow"
+path = "editors/zed"
+version = "0.1.0"
+
 [fantasticons-icons-theme]
 submodule = "extensions/fantasticons-icons-theme"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1203,6 +1203,11 @@ version = "0.0.8"
 submodule = "extensions/factory-droid"
 version = "0.68.1"
 
+[fallow]
+submodule = "extensions/fallow"
+path = "editors/zed"
+version = "0.1.0"
+
 [fantasticons-icons-theme]
 submodule = "extensions/fantasticons-icons-theme"
 version = "1.0.0"


### PR DESCRIPTION
## Summary
- add the Fallow repository as the `extensions/fallow` submodule
- register the `fallow` extension from the `editors/zed` path
- publish version `0.1.0` from the extension manifest

## Validation
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test`
- `cargo build --target wasm32-wasip2 --manifest-path extensions/fallow/editors/zed/Cargo.toml`