### PR TITLE
Update slint to v1.16.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3644,7 +3644,7 @@ version = "1.0.1"
 [slint]
 submodule = "extensions/slint"
 path = "editors/zed"
-version = "1.16.0"
+version = "1.16.1"
 
 [smalisp]
 submodule = "extensions/smalisp"


### PR DESCRIPTION
Bumps the slint extension submodule and extensions.toml to v1.16.1.