### PR TITLE
Update arturo to v1.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -184,7 +184,7 @@
 
 [submodule "extensions/arturo"]
 	path = extensions/arturo
-	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo
+	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo.git
 
 [submodule "extensions/asciidoc"]
 	path = extensions/asciidoc

--- a/.gitmodules
+++ b/.gitmodules
@@ -184,7 +184,7 @@
 
 [submodule "extensions/arturo"]
 	path = extensions/arturo
-	url = https://github.com/DaZhi-the-Revelator/zed-arturo.git
+	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo
 
 [submodule "extensions/asciidoc"]
 	path = extensions/asciidoc

--- a/extensions.toml
+++ b/extensions.toml
@@ -187,7 +187,7 @@ version = "0.2.0"
 
 [arturo]
 submodule = "extensions/arturo"
-version = "1.0.1"
+version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"


### PR DESCRIPTION
### Description
Updates the `Arturo` extension to version `v1.0.3`.

### Changes
- Updated version in `extension.toml`.
- Updated submodule URL to point to the new home on **Codeberg** (previous GitHub repo was deleted).
- Pointed submodule to the latest commit hash for `v1.0.3`.

### Testing
- [ x ] Extension builds correctly.
- [ x ] (Optional) Verified functionality in Zed.
