### PR TITLE
Add IFC language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ifc"]
+	path = extensions/ifc
+	url = https://github.com/Finradon/zed-ifc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2070,6 +2070,10 @@
 	path = extensions/idris2
 	url = https://github.com/dylanbraithwaite/zed-idris2-lsp
 
+[submodule "extensions/ifc"]
+	path = extensions/ifc
+	url = https://github.com/Finradon/zed-ifc.git
+
 [submodule "extensions/immigrant"]
 	path = extensions/immigrant
 	url = https://github.com/deltarocks/zed-immigrant.git
@@ -5425,6 +5429,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ifc"]
-	path = extensions/ifc
-	url = https://github.com/Finradon/zed-ifc.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4656,3 +4656,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[ifc]
+submodule = "extensions/ifc"
+version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1748,6 +1748,10 @@ version = "1.2.0"
 submodule = "extensions/idris2"
 version = "0.0.1"
 
+[ifc]
+submodule = "extensions/ifc"
+version = "0.1.0"
+
 [immigrant]
 submodule = "extensions/immigrant"
 version = "0.1.2"
@@ -4656,7 +4660,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[ifc]
-submodule = "extensions/ifc"
-version = "0.1.0"


### PR DESCRIPTION
## Extension

**Name:** IFC
**ID:** `ifc`
**Repository:** https://github.com/Finradon/zed-ifc

## Description

Adds a new Zed extension for Industry Foundation Classes (IFC) files.
[IFC](https://www.buildingsmart.org/standards/bsi-standards/industry-foundation-classes/) is a data standard for architecture, engineering, and construction data developed by buildingSMART.

Repository with sample files: https://github.com/buildingSMART/Sample-Test-Files

Uses https://github.com/NepomukWolf/IFC-Language-Server as the language server source and https://github.com/NepomukWolf/tree-sitter-ifc as the grammar source.

### What it provides

- `.ifc` language detection
- tree-sitter-based syntax highlighting
- IFC Language Server integration for:
  - hover
  - go to definition
  - find references

## Checklist

- [x] Extension has an `[extension]` section in `extension.toml`
- [x] Extension has a `README.md`
- [x] Grammar sourced from `NepomukWolf/tree-sitter-ifc` at a pinned rev
- [x] Added to `extensions.toml` in alphabetical order