### PR TITLE
Add Paraglide i18n extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2982,6 +2982,10 @@
 	path = extensions/papercolor
 	url = https://github.com/emirror-de/papercolor-zed.git
 
+[submodule "extensions/paraglide-i18n"]
+	path = extensions/paraglide-i18n
+	url = https://github.com/Ysheep666/paraglide-zed-lsp.git
+
 [submodule "extensions/paraiso"]
 	path = extensions/paraiso
 	url = https://github.com/treffynnon/zed-Paraiso.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3025,7 +3025,7 @@ version = "0.2.0"
 
 [paraglide-i18n]
 submodule = "extensions/paraglide-i18n"
-version = "0.1.0"
+version = "0.1.1"
 
 [paraiso]
 submodule = "extensions/paraiso"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3025,7 +3025,7 @@ version = "0.2.0"
 
 [paraglide-i18n]
 submodule = "extensions/paraglide-i18n"
-version = "0.1.2"
+version = "0.1.4"
 
 [paraiso]
 submodule = "extensions/paraiso"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3023,6 +3023,10 @@ version = "1.0.0"
 submodule = "extensions/papercolor"
 version = "0.2.0"
 
+[paraglide-i18n]
+submodule = "extensions/paraglide-i18n"
+version = "0.1.0"
+
 [paraiso]
 submodule = "extensions/paraiso"
 version = "1.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3025,7 +3025,7 @@ version = "0.2.0"
 
 [paraglide-i18n]
 submodule = "extensions/paraglide-i18n"
-version = "0.1.1"
+version = "0.1.2"
 
 [paraiso]
 submodule = "extensions/paraiso"


### PR DESCRIPTION
## Summary

Adds the Paraglide i18n Zed extension to the extensions registry.

- Extension id: `paraglide-i18n`
- Extension repository: https://github.com/Ysheep666/paraglide-zed-lsp
- npm language server package: `paraglide-zed-lsp@0.1.0`
- npm package URL: https://www.npmjs.com/package/paraglide-zed-lsp

## Verification

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test`