### PR TITLE
Add Structurizr language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3802,6 +3802,10 @@
 	path = extensions/structured-text
 	url = https://github.com/Blake-Haydon/zed-structured-text.git
 
+[submodule "extensions/structurizr"]
+	path = extensions/structurizr
+	url = https://github.com/sinon/zed-structurizr.git
+
 [submodule "extensions/stylelint"]
 	path = extensions/stylelint
 	url = https://github.com/florian-sanders/zed-stylelint.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2633,6 +2633,10 @@ version = "0.0.1"
 submodule = "extensions/muted"
 version = "0.0.1"
 
+[my-extension]
+submodule = "extensions/structurizr"
+version = "0.0.1"
+
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2633,10 +2633,6 @@ version = "0.0.1"
 submodule = "extensions/muted"
 version = "0.0.1"
 
-[my-extension]
-submodule = "extensions/structurizr"
-version = "0.0.1"
-
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"
@@ -3858,6 +3854,10 @@ version = "0.0.1"
 
 [structured-text]
 submodule = "extensions/structured-text"
+version = "0.0.1"
+
+[structurizr]
+submodule = "extensions/structurizr"
 version = "0.0.1"
 
 [stylelint]


### PR DESCRIPTION
### What?

Adds the a Zed extension for the [Structurizr DSL](https://structurizr.com/) used for describing [C4 Models](https://c4model.com/)

Extension id: `structurizr`
Extension repository: https://github.com/sinon/zed-structurizr
Grammar/LSP repo used by extension: https://github.com/sinon/tree-sitter-structurizr 

### Verification

`pnpm sort-extensions`

