### PR TITLE
Add note language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2726,6 +2726,10 @@
 	path = extensions/not-too-shabby
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
+[submodule "extensions/note"]
+	path = extensions/note
+	url = https://github.com/ciiqr/tree-sitter-note.git
+
 [submodule "extensions/noted-theme"]
 	path = extensions/noted-theme
 	url = https://github.com/sergeevalera/noted-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2765,6 +2765,11 @@ version = "0.0.1"
 submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
+[note]
+submodule = "extensions/note"
+path = "zed"
+version = "1.0.0"
+
 [noted-theme]
 submodule = "extensions/noted-theme"
 version = "0.1.0"


### PR DESCRIPTION
This is the zed port of my note syntax
[vscode extension](https://marketplace.visualstudio.com/items?itemName=ciiqr.note-syntax)
[extension readme](https://github.com/ciiqr/tree-sitter-note/blob/main/zed/readme.md)

![sample](https://raw.githubusercontent.com/ciiqr/tree-sitter-note/main/images/sample.png)