### PR TITLE
Update mcp-server-threadbridge to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2404,7 +2404,7 @@ version = "0.0.2"
 
 [mcp-server-threadbridge]
 submodule = "extensions/mcp-server-threadbridge"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-weave]
 submodule = "extensions/mcp-server-weave"


### PR DESCRIPTION
Bumps `mcp-server-threadbridge` from 0.2.0 to 0.2.1.

## Changes

- BLL reranker weights (`bll_v2.bin`) are now bundled with the binary release and auto-downloaded by the extension alongside the `mcp-threadbridge` binary, so retrieval ranking works out of the box without any user setup.
- Binary now resolves the BLL weights file relative to its own location (`current_exe().parent()/bll_v2.bin`).

Release: https://github.com/dereklei12/mcp-threadbridge/releases/tag/v0.2.1