### PR TITLE
Add REST Client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/rest-client"]
+	path = extensions/rest-client
+	url = https://github.com/mikolajsemeniuk/zed-rest-client.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3415,6 +3415,10 @@ version = "0.0.2"
 submodule = "extensions/rescript"
 version = "0.4.3"
 
+[rest-client]
+submodule = "extensions/rest-client"
+version = "0.0.1"
+
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the `rest-client` extension to the Zed marketplace.

REST Client for `.http` and `.rest` files — send HTTP requests directly from the editor with response displayed in a new tab. VS Code REST Client compatible syntax for easy migration.

## Features

- Send HTTP requests via code lens above each request
- Response displayed in a new tab with JSON syntax highlighting
- Syntax highlighting for `.http` and `.rest` files
- File variables: `@name = value` declarations + `{{name}}` substitution
- System variables:
  - `{{$guid}}` — UUID v4
  - `{{$timestamp [N unit]}}` — Unix timestamp with optional offset (s/m/h/d/w/y)
  - `{{$datetime rfc1123|iso8601|"format" [N unit]}}` — formatted dates
  - `{{$randomInt min max}}` — random integer in range
  - `{{$processEnv VAR}}` — environment variable lookup

## Repositories

- Extension (this submodule): https://github.com/mikolajsemeniuk/zed-rest-client
- LSP server (separate native binary): https://github.com/mikolajsemeniuk/zed-rest-client-lsp

## Architecture

The extension is a thin WASM wrapper around a native LSP server (Rust + tower-lsp). The LSP binary is downloaded on first use from GitHub Release assets, with platform-specific archives:

- macOS arm64 (Apple Silicon)
- macOS x86_64 (Intel)
- Linux x86_64
- Windows x86_64

## License

Apache-2.0 (both the extension and the LSP server).