### PR TITLE
Add Refract Ruby LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3334,6 +3334,10 @@
 	path = extensions/redscript
 	url = https://github.com/jac3km4/redscript-zed.git
 
+[submodule "extensions/refract"]
+	path = extensions/refract
+	url = https://github.com/hrtsx/zed-refract.git
+
 [submodule "extensions/regedit"]
 	path = extensions/regedit
 	url = https://github.com/JasonGH17/regedit

--- a/extensions.toml
+++ b/extensions.toml
@@ -3383,6 +3383,9 @@ version = "0.2.0"
 submodule = "extensions/redscript"
 version = "0.2.0"
 
+[refract]
+submodule = "extensions/refract"
+
 [regedit]
 submodule = "extensions/regedit"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds [Refract](https://github.com/hrtsx/refract), a fast Ruby LSP server backed by SQLite, as a Zed extension.

**What it provides:**
- Completion — type-aware, route helpers, i18n keys
- Hover — types, YARD docs, Rails DSL
- Go to definition / references / rename — MRO-aware, cross-file
- Inlay hints, semantic tokens, diagnostics (Prism + RuboCop)
- HAML / ERB template support

**Binary delivery:** auto-downloaded from GitHub releases (`refract-{arch}-{os}` naming). No bundled binary.

**Extension repo:** https://github.com/hrtsx/zed-refract