### PR TITLE
Add zcm extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4526,6 +4526,10 @@
 	path = extensions/zarcula-theme
 	url = https://github.com/igorgoroun/zed-zarcula-theme
 
+[submodule "extensions/zcm"]
+	path = extensions/zcm
+	url = https://github.com/HeZai/zcm.git
+
 [submodule "extensions/zed"]
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4590,6 +4590,10 @@
 	path = extensions/zarcula-theme
 	url = https://github.com/igorgoroun/zed-zarcula-theme
 
+[submodule "extensions/zcm"]
+	path = extensions/zcm
+	url = https://github.com/HeZai/zcm.git
+
 [submodule "extensions/zed"]
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4589,6 +4589,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zcm]
+submodule = "extensions/zcm"
+version = "0.1.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4654,6 +4654,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zcm]
+submodule = "extensions/zcm"
+version = "0.1.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"


### PR DESCRIPTION
## Summary

Adds the `zcm` extension, a CSS Modules language service extension for Zed based on `cssmodules-language-server@1.5.2`.

The extension provides CSS Modules class name completion, go-to-definition, hover, and reference lookup for JavaScript, TypeScript, TSX, CSS, SCSS, Sass (`.sass`), and LESS files. It also adds extensionless relative stylesheet import resolution and reverse reference lookup from stylesheet class declarations.

This is intentionally scoped differently from the existing CSS Modules Kit extension: `zcm` targets the standalone `cssmodules-language-server` workflow, directly resolves `.scss`, `.sass`, and `.less` CSS Modules imports, enables `camelCase` by default, and focuses on relative import workflows without requiring project-level CSS Modules Kit configuration.

## Validation

- In `HeZai/zcm`:
  - `cargo fmt`
  - `cargo test`
  - `node --test server.test.js`
  - `cargo clippy --all-targets`
  - `cargo build --target wasm32-wasip1 --release`
- In this repository:
  - `corepack pnpm sort-extensions`
  - `corepack pnpm build`
  - `corepack pnpm test`
