### PR TITLE
Add Lateralus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4613,3 +4613,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/lateralus"]
+	path = extensions/lateralus
+	url = https://github.com/bad-antics/zed-lateralus.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2004,7 +2004,7 @@ version = "1.0.3"
 
 [lateralus]
 submodule = "extensions/lateralus"
-version = "0.1.0"
+version = "0.1.1"
 
 [latex]
 submodule = "extensions/latex"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2002,6 +2002,10 @@ version = "0.0.1"
 submodule = "extensions/kvs-cyberpunk-2077"
 version = "1.0.3"
 
+[lateralus]
+submodule = "extensions/lateralus"
+version = "0.1.0"
+
 [latex]
 submodule = "extensions/latex"
 version = "0.2.3"


### PR DESCRIPTION
## Add Lateralus extension

Adds the **Lateralus** systems-language extension to the Zed extensions registry.

- Extension repo: https://github.com/bad-antics/zed-lateralus
- Tree-sitter grammar: https://github.com/bad-antics/tree-sitter-lateralus (MIT)
- Reference compiler: https://github.com/bad-antics/lateralus-lang
- npm: [`tree-sitter-lateralus`](https://www.npmjs.com/package/tree-sitter-lateralus)

### What you get

- 🎨 Syntax highlighting (functions, types, paths, pipelines, strings, numbers, comments)
- 🧱 Code folding for `fn`, `struct`, `enum`, `impl`, `match`
- 🪄 Bracket matching, autoclose, line/block comment behaviour

### Verification

- [x] `extensions.toml` entry added alphabetically between `[kvs-cyberpunk-2077]` and `[latex]`
- [x] Submodule under `extensions/lateralus`
- [x] `extension.toml` schema_version = 1
- [x] Tree-sitter grammar pinned to commit SHA
- [x] MIT licensed

### Companion editor support

The same grammar already powers a [VS Marketplace + Open VSX extension](https://marketplace.visualstudio.com/items?itemName=lateralus.lateralus-lang) (5.5k+ install target) and is used by `bad-antics/lateralus-lang` (~600 `.ltl` files in the canonical tree).
