### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to Zed Extensions
+
+Thanks for contributing to the Zed extension ecosystem!
+
+For the process to go smoothly, please read the [Extension Publishing Prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites) thoroughly and make sure to follow the steps described in [Publishing Your Extension](https://zed.dev/docs/extensions/developing-extensions#publishing-your-extension). Following these steps helps us a lot with going through the pull requests and will help you with getting your extension published sooner.
+
+Note that not every extension is a good fit for being published - for example, if your extension provides functionality already provided by another extension, you should consider contributing fixes in the existing extension for all users first before opening a pull request for a new extension here.
+
+Furthermore, we expect extensions to be tested locally as a dev extension before they're submitted. PRs for extensions that clearly don't work will be closed.
+
+Your extension repository also needs to include an [accepted license](https://zed.dev/docs/extensions/developing-extensions#extension-license-requirements).
+
+## Updating an existing extension
+
+If you're updating an extension you maintain, please make sure to follow the [Updating an Extension](https://zed.dev/docs/extensions/developing-extensions#updating-an-extension) guide.
+
+## Documentation
+
+For anything not covered here, feel free to have a look at the [extension section](https://zed.dev/docs/extensions) of our documentation or see the full guide on the process of developing and publishing an extension over at [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions).


### PR DESCRIPTION
This adds a brief contributing file in an attempt to help new contributors when opening new PRs. 

We could consider the following:
- adding a note that reviewing sometimes take longer than wanted
- build on top of this and require new PRs to include a pattern like "I have read and acknowledged the contributing guidelines" so that people can take care of the first round themselves

but both of this could probably also just be a follow-up.