### PR TITLE
Update tombi to v0.2.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4063,7 +4063,7 @@ version = "0.1.0"
 [tombi]
 submodule = "extensions/tombi"
 path = "editors/zed"
-version = "0.2.2"
+version = "0.2.3"
 
 [toml]
 submodule = "extensions/toml"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4083,7 +4083,7 @@ version = "0.1.0"
 [tombi]
 submodule = "extensions/tombi"
 path = "editors/zed"
-version = "0.2.3"
+version = "0.2.4"
 
 [toml]
 submodule = "extensions/toml"


### PR DESCRIPTION
Updated the logic to fall back to the previous Tombi CLI if downloading the latest version fails.