### PR TITLE
Add mermaid-render extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4617,3 +4617,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mermaid-render"]
+	path = extensions/mermaid-render
+	url = https://github.com/taciclei/zed-mermaid-render.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2442,6 +2442,11 @@ version = "0.0.1"
 submodule = "extensions/mermaid"
 version = "0.1.0"
 
+[mermaid-render]
+submodule = "extensions/mermaid-render"
+path = "extension"
+version = "0.1.0"
+
 [meson]
 submodule = "extensions/meson"
 version = "0.5.0"


### PR DESCRIPTION
## What this adds

`mermaid-render` — an extension that renders Mermaid diagrams **inline inside the source `.md` file** via an LSP code action, complementing Zed's built-in markdown preview pane (which only shows the rendering as a preview, not in the file).

- Source: https://github.com/taciclei/zed-mermaid-render
- Tag: [`v0.1.0`](https://github.com/taciclei/zed-mermaid-render/releases/tag/v0.1.0)
- Manifest path: `extension/`

## How it works

The extension registers an LSP server for the Markdown language. The server exposes two code actions:

- **Render Mermaid Diagram** — when the cursor is in a ` ```mermaid ` block, replaces the block with the rendered SVG surrounded by HTML markers and saves the source under `<workspace>/.mermaid/<id>.mmd`.
- **Edit Mermaid Source** — when the cursor is on a previously rendered block, restores the original mermaid block from the saved source.

Rendering uses [`mermaid-rs-renderer`](https://crates.io/crates/mermaid-rs-renderer) — pure Rust, no Node, no headless Chromium. The companion LSP binary is shipped on GitHub Releases for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, and `x86_64-pc-windows-msvc`. The extension downloads the right binary on first launch via `zed::download_file`.

## Checklist

- [x] Unique extension ID (`mermaid-render`, no conflict with the existing `mermaid` entry which provides `.mmd` syntax support)
- [x] License at the extension root (Apache-2.0 OR MIT, dual)
- [x] Manifest validated locally; extension installs and runs via `zed: install dev extension`
- [x] Submodule pinned at tag `v0.1.0`
- [x] Release artefacts published for all five supported targets