### PR TITLE
Add PlatformIO Tools extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3126,6 +3126,10 @@
 	path = extensions/platformio
 	url = https://github.com/weirdo-adam/zed-platformio.git
 
+[submodule "extensions/platformio-tools"]
+	path = extensions/platformio-tools
+	url = https://github.com/Obed0101/platformio-for-zed.git
+
 [submodule "extensions/plato-themes"]
 	path = extensions/plato-themes
 	url = https://github.com/mishankov/plato.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3168,6 +3168,10 @@ version = "1.0.0"
 submodule = "extensions/platformio"
 version = "v0.0.1"
 
+[platformio-tools]
+submodule = "extensions/platformio-tools"
+version = "0.1.0"
+
 [plato-themes]
 submodule = "extensions/plato-themes"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds `platformio-tools`, an unofficial PlatformIO workflow extension for Zed.

This is separate from the existing `platformio` extension, which provides `platformio.ini` syntax highlighting. `platformio-tools` focuses on workflow/task generation for existing PlatformIO projects:

- detect `platformio.ini`
- discover PlatformIO environments
- generate Zed task definitions for build, upload, clean, monitor, and compiledb workflows
- provide a small CLI/helper path for project-local `.zed/tasks.json` and `.clangd` generation

The project is clearly marked as unofficial and not affiliated with PlatformIO Labs or Zed Industries.

## Validation

In `Obed0101/platformio-for-zed`:

- `cargo fmt -- --check`
- `cargo test` — 11 passed
- installed locally as a Zed dev extension
- tested generated tasks against a real PlatformIO project

In this registry repo:

- `npm run sort-extensions`
- `npm test` — 111 passed
- `npm run build`

## Notes

The current MVP is task-first because Zed does not expose VS Code-style status bar/activity panel APIs for this workflow. The README and docs call that out explicitly.
