### PR TITLE
Update dependi to v1.8.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -948,7 +948,7 @@ version = "0.1.1"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.7.0"
+version = "1.8.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
Bumps the [dependi](https://github.com/mpiton/zed-dependi) extension to v1.8.0.

## Highlights

- New: Maven (`pom.xml`) support — direct dependencies and `<dependencyManagement>`, with `${property}` substitution
- New: `Ignore package "<name>"` quick-fix code action — adds the package to `.zed/settings.json`
- New: `--output html` format for `dependi-lsp scan`, suitable for CI artifacts
- New: lockfile-based vulnerability scanning across 9 ecosystems (Cargo.lock, package-lock.json v2/v3, pnpm-lock.yaml v6/v9, yarn.lock v1, poetry.lock, uv.lock, Pipfile.lock, composer.lock, Gemfile.lock) — surfaces transitive vulnerabilities
- Perf: hybrid memory + SQLite advisory cache for RustSec; bounded OSV concurrency
- Fix: prefixed XML namespaces in `pom.xml` (`<m:project xmlns:m="...">`) now parse correctly
- Fix: bare PEP 440 pre-release versions are compared correctly
- Fix: npm and Packagist repository/homepage URLs are sanitized
- Maintenance: parser refactors (JSON span-aware parsing, lockfile resolver trait), async cache traits, comprehensive Rustdoc + architecture guide

Full changelog: https://github.com/mpiton/zed-dependi/blob/v1.8.0/CHANGELOG.md
Release: https://github.com/mpiton/zed-dependi/releases/tag/v1.8.0