### PR TITLE
Update mistral-vibe to v2.9.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2485,7 +2485,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.8.1"
+version = "2.9.0"
 path = "distribution/zed"
 
 [mlir-tablegen]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.9.0