### PR TITLE
Add Postman MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4617,3 +4617,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/postman-context-server"]
+	path = extensions/postman-context-server
+	url = https://github.com/postmanlabs/postman-mcp-zed-extension

--- a/.gitmodules
+++ b/.gitmodules
@@ -3174,7 +3174,7 @@
 	path = extensions/postgres-language-server
 	url = https://github.com/LoamStudios/zed-postgres-language-server.git
 
-[submodule "extensions/postman"]
+[submodule "extensions/postman-context-server"]
 	path = extensions/postman
 	url = https://github.com/postmanlabs/postman-mcp-zed-extension
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -3174,8 +3174,8 @@
 	path = extensions/postgres-language-server
 	url = https://github.com/LoamStudios/zed-postgres-language-server.git
 
-[submodule "extensions/postman-context-server"]
-	path = extensions/postman-context-server
+[submodule "extensions/postman"]
+	path = extensions/postman
 	url = https://github.com/postmanlabs/postman-mcp-zed-extension
 
 [submodule "extensions/powershell"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -3174,6 +3174,10 @@
 	path = extensions/postgres-language-server
 	url = https://github.com/LoamStudios/zed-postgres-language-server.git
 
+[submodule "extensions/postman-context-server"]
+	path = extensions/postman-context-server
+	url = https://github.com/postmanlabs/postman-mcp-zed-extension
+
 [submodule "extensions/powershell"]
 	path = extensions/powershell
 	url = https://github.com/zed-extensions/powershell
@@ -4617,6 +4621,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/postman-context-server"]
-	path = extensions/postman-context-server
-	url = https://github.com/postmanlabs/postman-mcp-zed-extension

--- a/.gitmodules
+++ b/.gitmodules
@@ -3175,7 +3175,7 @@
 	url = https://github.com/LoamStudios/zed-postgres-language-server.git
 
 [submodule "extensions/postman-context-server"]
-	path = extensions/postman
+	path = extensions/postman-context-server
 	url = https://github.com/postmanlabs/postman-mcp-zed-extension
 
 [submodule "extensions/powershell"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3216,6 +3216,10 @@ version = "0.0.5"
 submodule = "extensions/postgres-language-server"
 version = "0.1.0"
 
+[postman-context-server]
+submodule = "extensions/postman-context-server"
+version = "1.0.0"
+
 [powershell]
 submodule = "extensions/powershell"
 version = "0.4.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3263,7 +3263,7 @@ version = "0.1.0"
 
 [postman-context-server]
 submodule = "extensions/postman-context-server"
-version = "1.0.0"
+version = "0.1.0"
 
 [powershell]
 submodule = "extensions/powershell"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3216,8 +3216,8 @@ version = "0.0.5"
 submodule = "extensions/postgres-language-server"
 version = "0.1.0"
 
-[postman-context-server]
-submodule = "extensions/postman-context-server"
+[postman]
+submodule = "extensions/postman"
 version = "1.0.0"
 
 [powershell]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3216,8 +3216,8 @@ version = "0.0.5"
 submodule = "extensions/postgres-language-server"
 version = "0.1.0"
 
-[postman]
-submodule = "extensions/postman"
+[postman-context-server]
+submodule = "extensions/postman-context-server"
 version = "1.0.0"
 
 [powershell]


### PR DESCRIPTION
## Summary

Adds the [Postman MCP Server](https://github.com/postmanlabs/postman-mcp-server) as a Zed context server extension.

**Extension repo**: https://github.com/postmanlabs/postman-mcp-zed-extension  
**npm package**: [`@postman/postman-mcp-server`](https://www.npmjs.com/package/@postman/postman-mcp-server)  
**Extension ID**: `postman-context-server`

### What it does

Connects the Zed AI Agent to Postman workspaces via the official Postman MCP Server. Users can:
- Create, update, and run Postman collections
- Manage environments and variables
- Generate and sync API specs
- Search and generate client code from API definitions
- Manage workspaces and collaborate with their team

### Configuration

The extension prompts users for a `postman_api_key` and a `tool_config` setting (`minimal` / `full` / `code`). It runs the server locally via `npx -y @postman/postman-mcp-server@latest`.

### Checklist

- [x] Extension has a valid `extension.toml` with `schema_version = 1`
- [x] Implements `context_server_command` and `context_server_configuration`
- [x] Includes `configuration/default_settings.jsonc` and `configuration/installation_instructions.md`
- [x] Apache-2.0 licensed
- [x] Published under the official Postman org (`postmanlabs`)