### PR TITLE
Add `bump-submodule` recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,3 +26,14 @@ reset-submodules: clean-submodules
 update-submodule SUBMODULE_PATH COMMIT_HASH:
     git submodule update --init --recursive {{SUBMODULE_PATH}}
     git -C {{SUBMODULE_PATH}} checkout {{COMMIT_HASH}}
+
+# Bumps the submodule at the given path to the latest commit on its default branch and stages the change.
+bump-submodule SUBMODULE_PATH:
+    git submodule update --init --recursive {{SUBMODULE_PATH}}
+    git -C {{SUBMODULE_PATH}} fetch origin
+    git -C {{SUBMODULE_PATH}} checkout origin/HEAD
+    git add {{SUBMODULE_PATH}}
+    @echo ""
+    @echo "Bumped {{SUBMODULE_PATH}} to $(git -C {{SUBMODULE_PATH}} rev-parse --short HEAD)."
+    @echo "Submodule extension.toml version: $(grep '^version' {{SUBMODULE_PATH}}/extension.toml || echo '<not found>')"
+    @echo "If the version changed, remember to bump the matching entry in extensions.toml."


### PR DESCRIPTION
## Summary

Adds a new `just bump-submodule <path>` recipe that bumps an extension's submodule pointer to the latest commit on its default remote branch in one step.

```sh
just bump-submodule extensions/<name>
```

The recipe:
1. Initializes the submodule (no-op if already cloned).
2. Fetches the submodule's remote.
3. Checks out `origin/HEAD`.
4. Stages the updated pointer in the parent repo.
5. Prints the new short SHA and the submodule's current `extension.toml` version, with a reminder to keep the matching entry in the root `extensions.toml` in sync.

## Why this is useful

Bumping an extension submodule is one of the most common contributions to this repo, but the steps are entirely manual today and easy to get wrong:

- `git submodule update --init <path>` (or it silently does nothing because the submodule wasn't cloned).
- `cd` into the submodule, `git fetch`, `git checkout` the new ref.
- `cd` back, `git add` the submodule pointer.
- Cross-check the submodule's `extension.toml` version against the entry in the root `extensions.toml`.

The existing `update-submodule` recipe still requires the contributor to look up a commit SHA by hand and pass it in. For the very common "just take the latest" case that is unnecessary friction, and forgetting any of the above steps results in PRs that either don't actually bump anything or land with a stale `extensions.toml` version.

`bump-submodule` collapses this into a single command, makes the "did I forget the version bump?" check explicit, and standardizes how contributors and maintainers (and tooling/bots like Renovate fallbacks) refresh extensions.

## Notes

- Non-destructive: only stages changes, never commits or pushes.
- Uses `origin/HEAD`, matching the existing `update-submodule` recipe's reliance on the submodule's default branch. Contributors who need to pin to a specific tag or commit can keep using `just update-submodule <path> <sha>`.
- No changes to existing recipes, CI, or any extension.

## Test plan

- [ ] `just bump-submodule extensions/<some-extension>` on a submodule with no upstream changes — recipe completes, no pointer change, version line printed.
- [ ] Same recipe on a submodule with new upstream commits — pointer is updated and staged, new SHA + version printed.
- [ ] Recipe on an uninitialized submodule — clones, then bumps.