### PR TITLE
Add Catppuccin Black theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -538,6 +538,10 @@
 	path = extensions/catppuccin
 	url = https://github.com/catppuccin/zed.git
 
+[submodule "extensions/catppuccin-black-theme"]
+	path = extensions/catppuccin-black-theme
+	url = https://github.com/ek2kk/catppuccin-black-zed.git
+
 [submodule "extensions/catppuccin-blur"]
 	path = extensions/catppuccin-blur
 	url = https://github.com/jenslys/zed-catppuccin-blur.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -544,6 +544,10 @@ version = "0.0.1"
 submodule = "extensions/catppuccin"
 version = "0.2.25"
 
+[catppuccin-black-theme]
+submodule = "extensions/catppuccin-black-theme"
+version = "0.1.0"
+
 [catppuccin-blur]
 submodule = "extensions/catppuccin-blur"
 version = "0.3.4"


### PR DESCRIPTION
Adds Catppuccin Black Theme, a true black Catppuccin-inspired theme.

Tested locally with `zed: install dev extension`; the extension builds, loads, and the theme applies successfully.

Repository: https://github.com/ek2kk/catppuccin-black-zed
