### PR TITLE
Update umple to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4240,7 +4240,7 @@ version = "0.0.1"
 
 [umple]
 submodule = "extensions/umple"
-version = "0.1.1"
+version = "0.1.5"
 
 [underground-theme]
 submodule = "extensions/underground-theme"


### PR DESCRIPTION
Bump the Umple Zed extension to 0.1.5.

Changes:
- Updates the `extensions/umple` submodule to `umple/umple.zed@v0.1.5`.
- Bumps the marketplace catalog version from `0.1.1` to `0.1.5`.

This release syncs the extension grammar/highlighting with `umple-lsp@1bb61e1` and the already-published `umple-lsp-server@1.0.0`.

Validation:
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm install --frozen-lockfile`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm build`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm test`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm sort-extensions`
