### PR TITLE
Add subliminal-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3862,6 +3862,10 @@
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall
 
+[submodule "extensions/subliminal-theme"]
+	path = extensions/subliminal-theme
+	url = https://github.com/ghostvox/subliminal-theme
+
 [submodule "extensions/sumi-light"]
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
@@ -4697,6 +4701,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/subliminal-theme"]
-	path = extensions/subliminal-theme
-	url = https://github.com/ghostvox/subliminal-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -4645,3 +4645,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/subliminal-theme"]
+	path = extensions/subliminal-theme
+	url = https://github.com/ghostvox/subliminal-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,7 +1,3 @@
-[subliminal-theme]
-submodule = "extensions/subliminal-theme"
-version = "0.1.0"
-
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.6"
@@ -3920,6 +3916,10 @@ version = "1.1.4"
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
 version = "0.1.15"
+
+[subliminal-theme]
+submodule = "extensions/subliminal-theme"
+version = "0.1.0"
 
 [sumi-light]
 submodule = "extensions/sumi-light"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[subliminal-theme]
+submodule = "extensions/subliminal-theme"
+version = "0.1.0"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.6"


### PR DESCRIPTION
Add subliminal-theme
Adds the Subliminal theme extension for Zed.
Subliminal is a color theme with muted, low-contrast tones designed for long coding sessions, available in both dark and light variants. Previously published as a Neovim colorscheme and JetBrains IDE theme.

Extension ID: subliminal-theme
Appearances: dark, light
Repository: [ghostvox/subliminal-theme](https://github.com/ghostvox/subliminal-theme)