### PR TITLE
Add dark-trio-themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,8 +10,8 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
-[submodule "extensions/dark-trio"]
-	path = extensions/dark-trio
+[submodule "extensions/dark-trio-themes"]
+	path = extensions/dark-trio-themes
 	url = https://github.com/2u841r/dark-trio.git
 
 [submodule "extensions/a-distant-hope-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/dark-trio"]
+	path = extensions/dark-trio
+	url = https://github.com/2u841r/dark-trio.git
+
 [submodule "extensions/a-distant-hope-theme"]
 	path = extensions/a-distant-hope-theme
 	url = https://github.com/chrislockard/a-distant-hope-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,10 +10,6 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
-[submodule "extensions/dark-trio-themes"]
-	path = extensions/dark-trio-themes
-	url = https://github.com/2u841r/dark-trio.git
-
 [submodule "extensions/a-distant-hope-theme"]
 	path = extensions/a-distant-hope-theme
 	url = https://github.com/chrislockard/a-distant-hope-theme.git
@@ -1013,6 +1009,10 @@
 [submodule "extensions/dark-purple-theme"]
 	path = extensions/dark-purple-theme
 	url = https://github.com/brgr/dark-purple-theme-for-zed.git
+
+[submodule "extensions/dark-trio-themes"]
+	path = extensions/dark-trio-themes
+	url = https://github.com/2u841r/dark-trio.git
 
 [submodule "extensions/darker-horizon"]
 	path = extensions/darker-horizon

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[dark-trio]
+submodule = "extensions/dark-trio"
+version = "0.0.1"
+
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,8 +10,8 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
-[dark-trio]
-submodule = "extensions/dark-trio"
+[dark-trio-themes]
+submodule = "extensions/dark-trio-themes"
 version = "0.0.1"
 
 [a-distant-hope-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,10 +10,6 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
-[dark-trio-themes]
-submodule = "extensions/dark-trio-themes"
-version = "0.0.1"
-
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"
 version = "0.1.0"
@@ -1031,6 +1027,10 @@ version = "0.0.2"
 [dark-purple-theme]
 submodule = "extensions/dark-purple-theme"
 version = "0.1.0"
+
+[dark-trio-themes]
+submodule = "extensions/dark-trio-themes"
+version = "0.0.1"
 
 [darker-horizon]
 submodule = "extensions/darker-horizon"


### PR DESCRIPTION
## Summary

- Adds **3 Themes** (`3themes`) extension — 3 dark themes in one install
- Bytes Newsletter Colorized+, Svelte 5, Pinky Promise
- MIT licensed

## Checklist

- [x] Extension ID does not contain "zed" or "extension"
- [x] LICENSE file present (MIT)
- [x] Submodule added under `extensions/3themes`
- [x] Entry added to `extensions.toml`
- [x] `pnpm sort-extensions` run
- [x] Theme-only extension (no language servers)