### PR TITLE
Add Cassette Futurism theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -530,6 +530,10 @@
 	path = extensions/cargo-tom
 	url = https://github.com/frederik-uni/zed-cargotom.git
 
+[submodule "extensions/cassette-futurism-theme"]
+	path = extensions/cassette-futurism-theme
+	url = https://github.com/taotao7/cassette-futurism-theme
+
 [submodule "extensions/catbox"]
 	path = extensions/catbox
 	url = https://github.com/adibhanna/catbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -536,6 +536,10 @@ version = "0.2.0"
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
 
+[cassette-futurism-theme]
+submodule = "extensions/cassette-futurism-theme"
+version = "0.0.1"
+
 [catbox]
 submodule = "extensions/catbox"
 version = "0.0.1"


### PR DESCRIPTION
Adds the `cassette-futurism-theme` Zed theme extension.

The extension provides two Analog Dream variants:

- `Analog Dream: Magnetic Night` for dark mode
- `Analog Dream: Beige Terminal` for light mode

Validation run locally:

- `COREPACK_ENABLE_AUTO_PIN=0 pnpm sort-extensions`
- `git diff --check`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm build`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm test`

`pnpm package-extensions` is expected to run in repository CI with the official Linux `zed-extension` CLI.
