### PR TITLE
Add hosts language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1886,6 +1886,10 @@
 	path = extensions/horizon-theme
 	url = https://codeberg.org/ava/horizon-zed.git
 
+[submodule "extensions/hosts"]
+	path = extensions/hosts
+	url = https://github.com/vlasikhin/zed-hosts.git
+
 [submodule "extensions/hot-dog-stand"]
 	path = extensions/hot-dog-stand
 	url = https://github.com/CoasterFan5/hotdog-stand-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1919,6 +1919,10 @@ version = "0.0.1"
 submodule = "extensions/horizon-theme"
 version = "1.0.0"
 
+[hosts]
+submodule = "extensions/hosts"
+version = "0.0.1"
+
 [hot-dog-stand]
 submodule = "extensions/hot-dog-stand"
 version = "0.0.2"


### PR DESCRIPTION
  Adds syntax highlighting for `/etc/hosts` files.

  ## What it highlights
  - Full-line and inline `#` comments
  - IPv4 and IPv6 addresses (as `@number`)
  - Hostnames (as `@variable`)

  ## Grammar
  Backed by a new tree-sitter grammar: https://github.com/vlasikhin/tree-sitter-hosts
  Pinned to commit `5ab61f0`.

  ## Testing
  Tested locally as a dev extension on `/etc/hosts` and several copies. Comments, IPv4 and IPv6 entries, multiple hostnames, and inline comments all highlight correctly under default themes.

  ## License
  MIT (see `LICENSE` in the extension repo).