### PR TITLE
Add rose-pine-no-italics-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3454,6 +3454,10 @@
 	path = extensions/ron
 	url = https://github.com/onbjerg/zed-ron.git
 
+[submodule "extensions/rose-pine-no-italics-theme"]
+	path = extensions/rose-pine-no-italics-theme
+	url = https://github.com/ng-hai/zed-rose-pine-no-italics.git
+
 [submodule "extensions/rose-pine-theme"]
 	path = extensions/rose-pine-theme
 	url = https://github.com/rose-pine/zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3505,6 +3505,10 @@ version = "0.0.6"
 submodule = "extensions/ron"
 version = "0.0.1"
 
+[rose-pine-no-italics-theme]
+submodule = "extensions/rose-pine-no-italics-theme"
+version = "0.0.1"
+
 [rose-pine-theme]
 submodule = "extensions/rose-pine-theme"
 version = "1.3.2"


### PR DESCRIPTION
## Summary

Adds **rose-pine-no-italics-theme**, a Rosé Pine variant covering all three official appearances (Main, Moon, Dawn) with italics removed from code syntax.

Differentiation from existing [`rose-pine-theme`](https://github.com/rose-pine/zed):
- Italics stripped from code syntax (keywords, comments, strings, etc.).
- Italics retained on `emphasis` (markdown `*text*` — semantic meaning) and `predictive` (Zed AI ghost text — functional UI signal).
- `link_text` left non-italic (matches canonical Rosé Pine; color/underline already convey "link").

## Extension

- Repository: https://github.com/ng-hai/zed-rose-pine-no-italics
- License: MIT
- Initial version: `0.0.1`

## Test plan

- [x] Installed locally as a dev extension and verified all three theme variants render in Zed.
- [x] Confirmed code syntax has no italic styling.
- [x] Confirmed markdown `*emphasis*` and inline AI ghost text retain italics.
- [x] `pnpm sort-extensions` order verified manually for `extensions.toml` and `.gitmodules` (alphabetical, before `rose-pine-theme`).