### PR TITLE
Add package-json-upgrade language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2998,6 +2998,10 @@
 	path = extensions/pace-pro-theme
 	url = https://github.com/VMachihin/pace-theme-pro.git
 
+[submodule "extensions/package-json-upgrade"]
+	path = extensions/package-json-upgrade
+	url = https://github.com/Arthurmtro/zed-package-json-upgrade.git
+
 [submodule "extensions/package-swift-lsp"]
 	path = extensions/package-swift-lsp
 	url = https://github.com/kattouf/package-swift-lsp-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3090,8 +3090,8 @@
 	path = extensions/pace-pro-theme
 	url = https://github.com/VMachihin/pace-theme-pro.git
 
-[submodule "extensions/package-json-upgrade"]
-	path = extensions/package-json-upgrade
+[submodule "extensions/package-json-upgrade-lsp"]
+	path = extensions/package-json-upgrade-lsp
 	url = https://github.com/Arthurmtro/zed-package-json-upgrade.git
 
 [submodule "extensions/package-swift-lsp"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3042,7 +3042,7 @@ version = "0.1.0"
 
 [package-json-upgrade]
 submodule = "extensions/package-json-upgrade"
-version = "0.1.1"
+version = "0.1.3"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3040,6 +3040,10 @@ version = "0.0.1"
 submodule = "extensions/pace-pro-theme"
 version = "0.1.0"
 
+[package-json-upgrade]
+submodule = "extensions/package-json-upgrade"
+version = "0.0.10"
+
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"
 version = "1.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3042,7 +3042,7 @@ version = "0.1.0"
 
 [package-json-upgrade]
 submodule = "extensions/package-json-upgrade"
-version = "0.1.3"
+version = "0.1.5"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3042,7 +3042,7 @@ version = "0.1.0"
 
 [package-json-upgrade]
 submodule = "extensions/package-json-upgrade"
-version = "0.0.10"
+version = "0.1.1"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3136,7 +3136,7 @@ version = "0.1.0"
 
 [package-json-upgrade]
 submodule = "extensions/package-json-upgrade"
-version = "0.1.5"
+version = "0.1.6"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3134,9 +3134,9 @@ version = "0.0.1"
 submodule = "extensions/pace-pro-theme"
 version = "0.1.0"
 
-[package-json-upgrade]
-submodule = "extensions/package-json-upgrade"
-version = "0.1.6"
+[package-json-upgrade-lsp]
+submodule = "extensions/package-json-upgrade-lsp"
+version = "0.1.7"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"


### PR DESCRIPTION
Adds the `package-json-upgrade` extension.

Surfaces npm dependency updates and security advisories inline in `package.json` files via a Rust LSP server bundled as a binary release. Inspired by the VS Code extension of the same name.

**Repo:** https://github.com/Arthurmtro/zed-package-json-upgrade
**Release:** https://github.com/Arthurmtro/zed-package-json-upgrade/releases/tag/v0.1.3
**License:** Apache-2.0

## What it does

- Inlay hint after each dep listing every distinct upgrade tier — `🟢 17.0.2 · 🟡 17.9.5 · 🔴 19.5.7` for `^17.0.0` when patch / minor / major targets all differ. Tiers that resolve to the same version are de-duplicated.
- Security badge appended when the pinned version has known advisories: `🚨 N vulns` (any critical), `‼ N` (any high), `⚠ N` (moderate-only), `ℹ N` (low-only). Per-CVE details in the hover.
- Diagnostics for genuine errors only — invalid semver (Error), missing-from-registry (Warning), and per-CVE entries with severity scaled to CVSS / GitHub severity. Each carries the GHSA / CVE id and a clickable advisory URL via `code_description`. Outdated deps do not emit diagnostics so files stay readable when many deps are simply behind latest.
- Version completions inside the version string (typing `^`, `~`, `.`, or `"`).
- Hover with package description, latest, license, homepage, changelog, and per-advisory list when CVEs apply.
- Quick-fix code actions: per-dep tier upgrades (patch / minor / major), open homepage, open changelog, "Update to first non-vulnerable version" when audit applies, and document-wide "Update all dependencies (patch / minor / major)".
- Parallel registry + OSV.dev prefetch capped at 8 concurrent requests each, with a 1-hour cache for npm metadata and a 6-hour cache for advisories.
- Security audit defaults on; opt out via `"audit": false` in the LSP settings.

The LSP attaches alongside Zed's built-in `json-language-server` for JSON / JSONC buffers and only activates on files named `package.json`.

## Pre-flight

- [x] Tested locally as a dev extension on macOS arm64.
- [x] Release workflow ships prebuilt LSP binaries for macOS (arm64+x64), Linux (arm64+x64), Windows (x64). The extension WASM downloads the matching asset on first use.
- [x] `extension.toml` `version` matches the tag and the `extensions.toml` entry (`0.1.3`).
- [x] Apache-2.0 license in repo.
- [x] `pnpm sort-extensions` and `pnpm build` clean.