### PR TITLE
Add extension for supporting fhir-json messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1226,6 +1226,10 @@
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git
 
+[submodule "extensions/fhir-json"]
+	path = extensions/fhir-json
+	url = https://github.com/Yes25/zed-fhir-extension.git
+
 [submodule "extensions/fiber-snippets"]
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1244,6 +1244,10 @@ version = "1.0.0"
 submodule = "extensions/ferret"
 version = "0.0.11"
 
+[fhir-json]
+submodule = "extensions/fhir-json"
+version = "0.0.1"
+
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the fhir-json extension, which provides language support for [FHIR](https://hl7.org/fhir/) (Fast Healthcare Interoperability Resources) JSON files.

FHIR is a modern standard for exchanging healthcare data that gains traction across the world. FHIR resources are commonly represented as JSON, and this extension makes working with those files easier in Zed.