### PR TITLE
Add mcp-proxy extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4649,3 +4649,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-proxy"]
+	path = extensions/mcp-proxy
+	url = https://github.com/denisfl/zed-mcp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2295,6 +2295,10 @@ version = "0.0.1"
 submodule = "extensions/mcp-planetscale"
 version = "0.0.1"
 
+[mcp-proxy]
+submodule = "extensions/mcp-proxy"
+version = "0.1.0"
+
 [mcp-server-2slides]
 submodule = "extensions/mcp-server-2slides"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

This extension exposes a Zed workspace as an MCP (Model Context Protocol) server for external AI clients — Claude Desktop, local LLMs, Cursor, and any other MCP-compatible tool.

## What it does

A native Rust binary (`mcp-proxy-server`) runs alongside the editor and implements the MCP protocol over stdio or HTTP. The Zed extension downloads and registers this binary automatically on first use.

### Tools

| Tool | Description |
|------|-------------|
| `read_file` | Read file contents relative to workspace root |
| `write_file` | Write file contents (creates directories as needed) |
| `list_files` | Recursive directory listing, hidden files and .git excluded |
| `open_file` | Open a file in Zed |
| `get_workspace_info` | Workspace name, root path, current git branch |

### Example (Claude Desktop config)

```json
{
  "mcpServers": {
    "zed-proxy": {
      "command": "/usr/local/bin/mcp-proxy-server",
      "args": ["--workspace", "/Users/you/projects/myapp"]
    }
  }
}
```

## Checklist

- [x] Tested locally as a dev extension
- [x] MIT license included
- [x] extension.toml at repo root with correct schema_version and repository fields
- [x] GitHub Actions workflow publishes binaries to Releases for macOS (arm64/x86_64), Linux (x86_64), Windows
- [x] Repository is public: https://github.com/denisfl/zed-mcp