### PR TITLE
Add IRIX Terminal theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1798,6 +1798,10 @@
 	path = extensions/ir-black
 	url = https://github.com/sametaylak/ir-black-zed-theme
 
+[submodule "extensions/irix-terminal-theme"]
+	path = extensions/irix-terminal-theme
+	url = https://codeberg.org/nwgh/zed-irix-terminal-theme
+
 [submodule "extensions/irodori-theme"]
 	path = extensions/irodori-theme
 	url = https://github.com/agrahamlincoln/irodori.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1830,6 +1830,10 @@ version = "0.1.2"
 submodule = "extensions/ir-black"
 version = "0.0.1"
 
+[irix-terminal-theme]
+submodule = "extensions/irix-terminal-theme"
+version = "0.1.0"
+
 [irodori-theme]
 submodule = "extensions/irodori-theme"
 version = "1.0.0"


### PR DESCRIPTION
This adds a new theme extension that themes Zed in a manner similar to the IRIX Terminal of olden times.

I took the colour palette from ghostty/iTerm2's theme of the same name. I used extensions/iterm2-default-theme as an example for how to have this laid out. I used Claude to walk through figuring out how the iterm2-default-theme extension had taken the colours from said theme and applied them to the various elements in a zed theme, and had it do the same with the colours from the IRIX Terminal theme.