### PR TITLE
Add SFTP File Sync extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3409,3 +3409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sftp"]
+	path = extensions/sftp
+	url = https://github.com/andreyc0d3r/zed-sftp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2606,6 +2606,10 @@
 	path = extensions/severance
 	url = https://github.com/Zev18/severance-zed.git
 
+[submodule "extensions/sftp"]
+	path = extensions/sftp
+	url = https://github.com/andreyc0d3r/zed-sftp.git
+
 [submodule "extensions/shadcn-mcp"]
 	path = extensions/shadcn-mcp
 	url = https://github.com/MrUprizing/zed-mcp-server-shadcn.git
@@ -3409,6 +3413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sftp"]
-	path = extensions/sftp
-	url = https://github.com/andreyc0d3r/zed-sftp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4174,8 +4174,8 @@
 	path = extensions/severance-theme
 	url = https://github.com/Zev18/severance-zed.git
 
-[submodule "extensions/sftp"]
-	path = extensions/sftp
+[submodule "extensions/sftp-file-sync"]
+	path = extensions/sftp-file-sync
 	url = https://github.com/andreyc0d3r/zed-sftp.git
 
 [submodule "extensions/shadcn-mcp"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[sftp]
+submodule = "extensions/sftp"
+version = "0.0.1"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,7 +1,3 @@
-[sftp]
-submodule = "extensions/sftp"
-version = "0.0.1"
-
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.5"
@@ -2650,6 +2646,10 @@ version = "0.0.1"
 [severance-theme]
 submodule = "extensions/severance"
 version = "0.1.1"
+
+[sftp]
+submodule = "extensions/sftp"
+version = "0.0.1"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4146,7 +4146,7 @@ version = "0.1.1"
 
 [sftp]
 submodule = "extensions/sftp"
-version = "0.0.1"
+version = "0.1.1"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4146,7 +4146,7 @@ version = "0.1.1"
 
 [sftp]
 submodule = "extensions/sftp"
-version = "0.1.1"
+version = "0.1.2"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4246,8 +4246,8 @@ version = "0.0.1"
 submodule = "extensions/severance-theme"
 version = "0.1.1"
 
-[sftp]
-submodule = "extensions/sftp"
+[sftp-file-sync]
+submodule = "extensions/sftp-file-sync"
 version = "0.1.2"
 
 [shadcn-mcp]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4248,7 +4248,7 @@ version = "0.1.1"
 
 [sftp-file-sync]
 submodule = "extensions/sftp-file-sync"
-version = "0.1.2"
+version = "0.1.3"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"


### PR DESCRIPTION
Adds the SFTP File Sync extension for Zed using the permanent extension ID `sftp-file-sync`.

This supersedes the closed PR #3983. The SFTP language server is published as `zed-sftp-server@1.0.3` on npm, and the extension installs and runs it through `zed::npm_install_package` instead of relying on bundled server files.

The registry entry points `extensions/sftp-file-sync` at extension version `0.1.3` and source commit [`1cb840c`](https://github.com/andreyc0d3r/zed-sftp/commit/1cb840c2a581f89abedc402e893c32afb34cbed5). This release adds SSH agent authentication through `"agent": "$SSH_AUTH_SOCK"` without storing a private-key passphrase, while retaining the existing reconnect and upload-on-save behavior.

Validation:
- `zed-sftp-server@1.0.3` is public with shasum `d9ec70731be80d97ba472b4e1c5c6c4ca352a5d5`.
- 16 server tests passed.
- 115 registry tests passed.
- The registry branch is merged with current `zed-industries:main`.

A fresh local WASM build could not be run because Cargo is unavailable in the release environment; no Rust source changed. The registry `danger` and `package` workflows are awaiting maintainer approval.