### PR TITLE
Update dependi to v1.8.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -973,7 +973,7 @@ version = "0.1.1"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
Bumps the [dependi](https://github.com/mpiton/zed-dependi) extension to v1.8.1.

## Highlights

Patch release fixing npm registry deserialization for packages that publish `"deprecated": false` (boolean) on individual versions — most notably `react`, `react-dom`, and several others. The strict `Option<String>` deserializer rejected the boolean form, causing the entire package metadata response to fail with `error decoding response body` and leaving versions, latest-version hints, and vulnerability info empty in the editor.

## Release Notes

- **fix(npm)**: accept boolean `deprecated` field on version metadata. Also covers empty-string and missing-field cases. Adds regression tests for string, `true`, `false`, absent, empty-string, and a mixed-shape `PackageResponse` payload modelled on the real-world `react` registry response.

Full changelog: https://github.com/mpiton/zed-dependi/releases/tag/v1.8.1