### PR TITLE
Add Osaka Jade theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2998,6 +2998,10 @@
 	path = extensions/orng
 	url = https://github.com/elithrar/orng-zed.git
 
+[submodule "extensions/osaka-jade-theme"]
+	path = extensions/osaka-jade-theme
+	url = https://github.com/ruslan-kurchenko/osaka-jade-zed-theme.git
+
 [submodule "extensions/oscura"]
 	path = extensions/oscura
 	url = https://github.com/webhooked/oscura-zed.git
@@ -4697,6 +4701,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/osaka-jade-theme"]
-	path = extensions/osaka-jade-theme
-	url = https://github.com/ruslan-kurchenko/osaka-jade-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/osaka-jade-theme"]
+	path = extensions/osaka-jade-theme
+	url = https://github.com/ruslan-kurchenko/osaka-jade-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3040,6 +3040,10 @@ version = "0.0.1"
 submodule = "extensions/orng"
 version = "0.0.2"
 
+[osaka-jade-theme]
+submodule = "extensions/osaka-jade-theme"
+version = "0.1.0"
+
 [oscura]
 submodule = "extensions/oscura"
 version = "0.2.0"


### PR DESCRIPTION
## Summary

Adds the **Osaka Jade** theme, ported from the [Osaka Jade](https://github.com/basecamp/omarchy/tree/master/themes/osaka-jade) theme by Justin Lowry (Omarchy / 37signals).

## Variants

| Variant | Appearance | Background | Foreground |
|---|---|---|---|
| Osaka Jade Dark | dark | `#111c18` | `#C1C497` |
| Osaka Jade Soft | dark | `#1b2f23` | `#c9c8a0` |
| Osaka Jade Muted | dark | `#273f30` | `#d0cfac` |
| Osaka Jade Light | light | `#edead4` | `#2d4a35` |

All variants include the full 16-color ANSI palette (normal, bright, and dim) for the integrated terminal.

## Checklist

- [x] Theme tested locally via dev extension install
- [x] `extension.toml` includes all required fields
- [x] `LICENSE` (MIT) present
- [x] Entry added to `extensions.toml` in alphabetical order
- [x] Submodule uses HTTPS URL
- [x] Extension id does not contain `zed`, `Zed`, or `extension`

## Extension repo

https://github.com/ruslan-kurchenko/osaka-jade-zed-theme