### PR TITLE
Add DevGlobe extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4649,3 +4649,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/devglobe"]
+	path = extensions/devglobe
+	url = https://github.com/devglobe-xyz/zed-devglobe.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -997,6 +997,10 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
+[devglobe]
+submodule = "extensions/devglobe"
+version = "2.0.0"
+
 [devicetree]
 submodule = "extensions/devicetree"
 version = "0.0.1"


### PR DESCRIPTION
## DevGlobe — Coding activity tracker for developers

[DevGlobe](https://devglobe.xyz) tracks your coding time per language, repo, file and editor, and builds a public developer profile with your stats, projects and links.

It also includes a 3D globe showing developers coding live around the world, so you can discover other developers and the projects they're working on.

This extension brings DevGlobe tracking to Zed.

### How it works

- A lightweight Language Server receives `didOpen`/`didChange`/`didSave` events
- Sends a heartbeat every 30 seconds while you're actively coding
- Pauses automatically after 1 minute of inactivity
- Detects programming language, git repository (multi-provider), and city-level location
- File paths are always relative to the git repo root — never absolute home paths

### Features

- Per-language, per-repo, per-file coding time tracking
- 80+ languages supported
- Multi-provider git detection (GitHub, GitLab, Bitbucket, self-hosted Gitea, Azure DevOps)
- Status message visible on your developer profile
- Offline detection with auto-recovery
- Local privacy flags (`hide_file_names`, `hide_branch_names`, `hide_project_names`) in `~/.devglobe/config.toml`
- Public developer profile with stats, projects and links

### Requirements

- Node.js 18+
- A DevGlobe API key from [devglobe.xyz/dashboard/settings](https://devglobe.xyz/dashboard/settings)

### Privacy

No source code, file contents, or keystrokes are sent. Only programming language, editor name, OS, coding time, optional git repo URL, branch, and the file path relative to your repo root.

**Repository:** https://github.com/devglobe-xyz/zed-devglobe  
**License:** MIT

---

Note: replaces #5237 (closed) — extension repo moved to org and refreshed to v2.0.0 with bearer auth, multi-provider git detection, and config.toml-based settings.
