### PR TITLE
Add slipstream-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3646,6 +3646,10 @@
 	path = extensions/slint
 	url = https://github.com/slint-ui/slint.git
 
+[submodule "extensions/slipstream-theme"]
+	path = extensions/slipstream-theme
+	url = https://github.com/kylemcd/zed-slipstream.git
+
 [submodule "extensions/smalisp"]
 	path = extensions/smalisp
 	url = https://github.com/AbhiTheModder/smalisp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3699,6 +3699,10 @@ submodule = "extensions/slint"
 path = "editors/zed"
 version = "1.16.1"
 
+[slipstream-theme]
+submodule = "extensions/slipstream-theme"
+version = "0.1.0"
+
 [smalisp]
 submodule = "extensions/smalisp"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the **Slipstream** theme extension.

- Dark AMOLED theme built on true black (`#000000`)
- Accent palette: teal, gold, sky blue, rose (reserved for errors only)
- Extension ID: `slipstream-theme`
- License: MIT

Repository: https://github.com/kylemcd/zed-slipstream