### PR TITLE
Add drogon-csp language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1038,6 +1038,10 @@
 	path = extensions/dream
 	url = https://github.com/arturonegrete-dev/Dream-zed
 
+[submodule "extensions/drogon-csp-language"]
+	path = extensions/drogon-csp-language
+	url = https://github.com/rbprsp/zed-drogon-csp.git
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension

--- a/.gitmodules
+++ b/.gitmodules
@@ -1266,6 +1266,10 @@
 	path = extensions/dream
 	url = https://github.com/arturonegrete-dev/Dream-zed
 
+[submodule "extensions/drogon-csp"]
+	path = extensions/drogon-csp
+	url = https://github.com/rbprsp/zed-drogon-csp.git
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1053,6 +1053,10 @@ version = "1.0.0"
 submodule = "extensions/dream"
 version = "1.0.0"
 
+[drogon-csp-language]
+submodule = "extensions/drogon-csp-language"
+version = "0.1.0"
+
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1292,6 +1292,10 @@ version = "1.0.0"
 submodule = "extensions/dream"
 version = "1.0.0"
 
+[drogon-csp]
+submodule = "extensions/drogon-csp"
+version = "0.1.0"
+
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"


### PR DESCRIPTION
Adds a Zed extension for Drogon CSP (.csp), the html + cpp template format used by the [Drogon](https://github.com/drogonframework/drogon) framework.

Tokenization comes from a small tree-sitter grammar; cpp and html are injected into the nested content.

Tags covered: `<%c++ %>, <%inc %>, <%view %>, <%layout %>, [[ ]], {% %}`.
Tested locally as a dev extension.
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/0c6b05dc-5578-4bb7-afdd-8e563a20cc65" />


Extension: https://github.com/rbprsp/zed-drogon-csp
Grammar: https://github.com/rbprsp/tree-sitter-csp
License: MIT