### PR TITLE
Update datadog-mcp to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -940,7 +940,7 @@ version = "0.3.6"
 
 [datadog-mcp]
 submodule = "extensions/datadog-mcp"
-version = "0.2.1"
+version = "0.3.0"
 
 [day-shift]
 submodule = "extensions/day-shift"


### PR DESCRIPTION
Fixes broken extension and adds support for toolsets.