### PR TITLE
Add 3D Model Viewer extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/3d-model-viewer"]
+	path = extensions/3d-model-viewer
+	url = https://github.com/imboni/zed-gltf-model-viewer.git
+
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme
@@ -1469,10 +1473,6 @@
 [submodule "extensions/gleam-theme"]
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
-
-[submodule "extensions/gltf-model-viewer"]
-	path = extensions/gltf-model-viewer
-	url = https://github.com/imboni/zed-gltf-model-viewer.git
 
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1470,6 +1470,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/gltf-model-viewer"]
+	path = extensions/gltf-model-viewer
+	url = https://github.com/imboni/zed-gltf-model-viewer.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[3d-model-viewer]
+submodule = "extensions/3d-model-viewer"
+version = "0.1.0"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"
@@ -1494,10 +1498,6 @@ version = "0.2.1"
 submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.3"
-
-[gltf-model-viewer]
-submodule = "extensions/gltf-model-viewer"
-version = "0.1.0"
 
 [go-snippets]
 submodule = "extensions/go-snippets"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1495,6 +1495,10 @@ submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.3"
 
+[gltf-model-viewer]
+submodule = "extensions/gltf-model-viewer"
+version = "0.1.0"
+
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.5"


### PR DESCRIPTION
## Summary

- Adds `3d-model-viewer` to the Zed extensions index.
- Registers `https://github.com/imboni/zed-gltf-model-viewer.git` as a submodule at `extensions/3d-model-viewer`.
- Points the extension entry at version `0.1.0`.

## Notes

The extension is named 3D Model Viewer because it is intended as a general 3D model previewer. The current implementation supports `.glb` and `.gltf` files.

## Validation

- `cargo check --locked`
- `npm run build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm sort-extensions`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm test`
- `git diff --cached --check`
- Official extension index validation via `validateExtensionsToml`, `validateGitmodules`, and `validateGitmodulesLocations`.