### PR TITLE
Add css-var-kit language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4649,3 +4649,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/css-var-kit"]
+	path = extensions/css-var-kit
+	url = https://github.com/jo16oh/css-var-kit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -809,6 +809,11 @@ submodule = "extensions/css-modules-kit"
 version = "0.1.1"
 path = "crates/zed"
 
+[css-var-kit]
+submodule = "extensions/css-var-kit"
+version = "0.3.1"
+path = "crates/zed-extension"
+
 [css-variables]
 submodule = "extensions/css-variables"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -811,7 +811,7 @@ path = "crates/zed"
 
 [css-var-kit]
 submodule = "extensions/css-var-kit"
-version = "0.3.1"
+version = "0.4.0"
 path = "crates/zed-extension"
 
 [css-variables]


### PR DESCRIPTION
## Summary

Add [css-var-kit](https://github.com/jo16oh/css-var-kit) — type-aware completion and linting for CSS variables.

Supports CSS, SCSS, HTML, Vue.js, Svelte, and Astro.