### PR TITLE
Add easy-opaque-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1070,6 +1070,10 @@
 	path = extensions/earthsong-theme
 	url = https://github.com/hsjoberg/zedsong.git
 
+[submodule "extensions/easy-opaque-theme"]
+	path = extensions/easy-opaque-theme
+	url = https://github.com/KarmanyaIyer/zed-easy-opaque-theme.git
+
 [submodule "extensions/eclat"]
 	path = extensions/eclat
 	url = https://github.com/utakotoba/eclat-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1086,6 +1086,10 @@ version = "0.1.0"
 submodule = "extensions/earthsong-theme"
 version = "1.0.0"
 
+[easy-opaque-theme]
+submodule = "extensions/easy-opaque-theme"
+version = "0.0.1"
+
 [eclat]
 submodule = "extensions/eclat"
 version = "0.1.0"


### PR DESCRIPTION
Adds the easy-opaque-theme extension.

- Light theme with red highlights and strong contrast (no gray-on-white fonts)
- Extension repository: https://github.com/KarmanyaIyer/zed-easy-opaque-theme