### PR TITLE
Add One Monokai theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2926,6 +2926,10 @@
 	path = extensions/one-hunter
 	url = https://github.com/teziovsky/zed-one-hunter-theme.git
 
+[submodule "extensions/one-monokai"]
+	path = extensions/one-monokai
+	url = https://github.com/comua/zed-one-monokai.git
+
 [submodule "extensions/onurb"]
 	path = extensions/onurb
 	url = https://github.com/brunoocrv/onurb-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2969,7 +2969,7 @@ version = "0.0.4"
 
 [one-monokai]
 submodule = "extensions/one-monokai"
-version = "0.1.0"
+version = "0.1.1"
 
 [onurb]
 submodule = "extensions/onurb"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2969,7 +2969,7 @@ version = "0.0.4"
 
 [one-monokai]
 submodule = "extensions/one-monokai"
-version = "0.1.1"
+version = "0.1.2"
 
 [onurb]
 submodule = "extensions/onurb"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2967,6 +2967,10 @@ version = "0.1.0"
 submodule = "extensions/one-hunter"
 version = "0.0.4"
 
+[one-monokai]
+submodule = "extensions/one-monokai"
+version = "0.1.0"
+
 [onurb]
 submodule = "extensions/onurb"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2969,7 +2969,7 @@ version = "0.0.4"
 
 [one-monokai]
 submodule = "extensions/one-monokai"
-version = "0.1.2"
+version = "0.1.3"
 
 [onurb]
 submodule = "extensions/onurb"


### PR DESCRIPTION
Adds the **One Monokai** theme — a faithful port of [azemoh/vscode-one-monokai](https://github.com/azemoh/vscode-one-monokai) to Zed's theme schema.

Source: https://github.com/comua/zed-one-monokai (v0.1.0, MIT)