### PR TITLE
Add Autumn theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4570,6 +4570,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-theme-autumn"]
+	path = extensions/zed-theme-autumn
+	url = https://github.com/getreu/zed-theme-autumn
+
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox
 	url = https://github.com/isaiah-hamilton/zedbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -274,6 +274,10 @@ version = "0.2.1"
 submodule = "extensions/autohotkey"
 version = "2.0.1"
 
+[autumn]
+submodule = "extensions/zed-theme-autumn"
+version = "0.8.0"
+
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"
 version = "0.0.1"


### PR DESCRIPTION
Autumn is a dark theme with a warm, earthy palette featuring golden yellows, deep greens, and soft terracotta accents.

## History & Attribution

This theme has a rich history spanning multiple editors and authors:

1. **Original concept** — The "Autumn" color scheme was originally designed for the Komodo IDE
2. **Vim port** — Kenneth Love and Chris Jones ported it to Vim
3. **Improvements** — Yorick Peterse further improved the Vim version ([Autumn.vim](https://github.com/YorickPeterse/Autumn.vim))
4. **Helix & Zed ports** — Jens Getreu ported and optimized the theme for both the Helix editor and Zed

Most of the colors come from the original Autumn theme, inspired by the colors of autumn.

## Features

- **Dark background** — Easy on the eyes for extended coding sessions
- **Warm palette** — Golden yellows, earthy greens, and terracotta tones
- **High contrast** — Code elements remain clearly distinguishable
- **Terminal colors** — Fully themed terminal with ANSI color support
- **Git gutter colors** — Clear visual distinction for additions, modifications, and deletions
