### PR TITLE
Update templ to v0.0.11

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3945,7 +3945,7 @@ path = "zed"
 
 [templ]
 submodule = "extensions/templ"
-version = "0.0.9"
+version = "0.0.10"
 
 [templeos-theme]
 submodule = "extensions/templeos-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3945,7 +3945,7 @@ path = "zed"
 
 [templ]
 submodule = "extensions/templ"
-version = "0.0.10"
+version = "0.0.11"
 
 [templeos-theme]
 submodule = "extensions/templeos-theme"


### PR DESCRIPTION
## Summary
- bump templ to v0.0.11
- update the pinned tree-sitter-templ grammar revision to a newer upstream commit with consistent generated parser artifacts
- avoid the older grammar revision that produced incorrect parser behavior for dynamic attribute keys followed by component for loops