### PR TITLE
Add fff MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1226,6 +1226,10 @@
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git
 
+[submodule "extensions/fff-mcp"]
+	path = extensions/fff-mcp
+	url = https://github.com/dl-alexandre/zed-fff.git
+
 [submodule "extensions/fiber-snippets"]
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1244,6 +1244,10 @@ version = "1.0.0"
 submodule = "extensions/ferret"
 version = "0.0.11"
 
+[fff-mcp]
+submodule = "extensions/fff-mcp"
+version = "0.0.1"
+
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds `fff-mcp`, a Zed MCP extension that registers the existing `fff-mcp` context server for use from the Agent Panel.

The extension repository is `https://github.com/dl-alexandre/zed-fff` and the initial extension version is `0.0.1`.

## Validation

Extension repo:

- `cargo fmt --check`
- `cargo check`
- `cargo check --target wasm32-wasip2`
- `fff-mcp --version`
- `fff-mcp --healthcheck /home/alexandre/Work/fff-zed`

Registry repo:

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test`

## Notes

This is opened as draft until final Zed Agent Panel screenshots/GIF evidence is attached or confirmed.
