### PR TITLE
Add MetaScript language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2446,6 +2446,10 @@
 	path = extensions/metal
 	url = https://github.com/computer-graphics-tools/metal-analyzer.git
 
+[submodule "extensions/metascript"]
+	path = extensions/metascript
+	url = https://github.com/metascriptlang/metascript-zed.git
+
 [submodule "extensions/microscript"]
 	path = extensions/microscript
 	url = https://github.com/Nascir/zed-microscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2484,6 +2484,10 @@ submodule = "extensions/metal"
 path = "editors/zed"
 version = "0.1.19"
 
+[metascript]
+submodule = "extensions/metascript"
+version = "0.2.0"
+
 [microscript]
 submodule = "extensions/microscript"
 version = "0.2.0"


### PR DESCRIPTION
Adds `MetaScript` (https://metascriptlang.org) support — a systems language with TypeScript syntax that compiles to C, JavaScript, WebAssembly, and Erlang.

Tree-sitter highlighting, LSP via `msc lsp` (auto-detected from PATH), code outline, smart indent, bracket matching.
- Extension: https://github.com/metascriptlang/metascript-zed
- Grammar: https://github.com/metascriptlang/tree-sitter-metascript
- License: MIT