### PR TITLE
Update ninja to v1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2704,7 +2704,7 @@
 
 [submodule "extensions/ninja"]
 	path = extensions/ninja
-	url = https://github.com/c0mpiler/ninja.theme.git
+	url = https://github.com/c0mpiler/theme.ninja.git
 
 [submodule "extensions/niva"]
 	path = extensions/niva

--- a/extensions.toml
+++ b/extensions.toml
@@ -2744,7 +2744,7 @@ version = "0.2.0"
 [ninja]
 submodule = "extensions/ninja"
 path = "zed"
-version = "1.0.0"
+version = "1.1.0"
 
 [niva]
 submodule = "extensions/niva"


### PR DESCRIPTION
## Summary

Updates the [Ninja theme collection](https://github.com/c0mpiler/theme.ninja) to **v1.1.0**.

Originally added in #2326. This release brings the theme's key set in line with current Zed (`crates/theme/src/styles/colors.rs`), removes invalid keys, and corrects two real accessibility defects.

### v1.1.0 highlights

**Schema currency** — added across all 4 variants:
- `editor.hover_line_number`
- `search.active_match_background`
- `version_control.word_added` / `.word_deleted`
- `version_control.conflict_marker.ours` / `.theirs`

**Removed invalid keys** (×16, 4 keys × 4 variants) — `version_control.{added,deleted,modified,conflict}_background` are not defined in `ThemeColors` and were silently ignored.

**Accessibility fixes**:
- Ninja Light: 64 syntax tokens that previously fell below WCAG AA 4.5:1 on `#f9fafb` now pass.
- Ninja Colorblind: rebuilt on the Bang Wong (Nature Methods 2011) CVD-safe palette. The previous palette used pink-red and green for deleted/added — the exact pair conflated by protanopia/deuteranopia. New diff axis uses vermillion `#d55e00` and bluish-green `#009e73`. ANSI cyan separated from magenta along the blue channel to remain distinguishable under deuteranopia.

**Repo hygiene**:
- Theme repo renamed from `c0mpiler/ninja.theme` to `c0mpiler/theme.ninja`; submodule URL updated to match. The old URL auto-redirects.
- README badge URL corrected; recommended-settings example fixed (`"theme": "Ninja Dark"` instead of the previous `"ninja"`, which matched no theme name).
- CI validation scripts had two latent bugs (dotted-string keys traversed as nested objects, silently no-op'ing line-number contrast and recommended-property checks). Both fixed; `continue-on-error: true` removed so the badge is now load-bearing.

### Tested

All four variants render correctly as a dev extension in Zed. The repo's CI (schema validation via `ajv`, `taplo` for `extension.toml`, contrast and consistency checks) passes locally and on `main`.

Full changelog: https://github.com/c0mpiler/theme.ninja/blob/main/CHANGELOG.md

Drafting per the [Updating an Extension](https://zed.dev/docs/extensions/developing-extensions#updating-an-extension) guide; will mark ready when this submission is sanity-checked end-to-end.