### PR TITLE
Add Reach Variant Tool extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3510,6 +3510,10 @@
 	path = extensions/rust-snippets
 	url = https://github.com/bobbymannino/rust-snippets-for-zed.git
 
+[submodule "extensions/rvt"]
+	path = extensions/rvt
+	url = https://github.com/GageHowe/zed-rvt.git
+
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3562,6 +3562,10 @@ version = "1.0.3"
 submodule = "extensions/rust-snippets"
 version = "0.0.4"
 
+[rvt]
+submodule = "extensions/rvt"
+version = "0.1.0"
+
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
 version = "1.0.3"


### PR DESCRIPTION
## Summary
- add the Reach Variant Tool extension as a submodule
- register rvt in extensions.toml
- include version 0.1.0 for initial publication

## Validation
- tested locally as a Zed dev extension
- cargo check
- node --check src/server.js
- tree-sitter generate
- tree-sitter test
