### PR TITLE
Add Neon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4570,6 +4570,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-neon"]
+	path = extensions/zed-neon
+	url = https://github.com/spences10/zed-neon.git
+
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox
 	url = https://github.com/isaiah-hamilton/zedbox.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2658,6 +2658,10 @@
 	path = extensions/neon-pulse-theme
 	url = https://github.com/ArnoldWW/neon-pulse-theme
 
+[submodule "extensions/neon-theme"]
+	path = extensions/neon-theme
+	url = https://github.com/spences10/zed-neon.git
+
 [submodule "extensions/neosolarized"]
 	path = extensions/neosolarized
 	url = https://github.com/carlocaione/NeoSolarized.zed.git
@@ -4601,10 +4605,6 @@
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
-
-[submodule "extensions/zed-neon"]
-	path = extensions/zed-neon
-	url = https://github.com/spences10/zed-neon.git
 
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox

--- a/extensions.toml
+++ b/extensions.toml
@@ -4630,6 +4630,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-neon]
+submodule = "extensions/zed-neon"
+version = "0.0.1"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2697,6 +2697,10 @@ version = "0.0.1"
 submodule = "extensions/neon-pulse-theme"
 version = "2.1.0"
 
+[neon-theme]
+submodule = "extensions/neon-theme"
+version = "0.0.1"
+
 [neosolarized]
 submodule = "extensions/neosolarized"
 version = "0.0.2"
@@ -4661,10 +4665,6 @@ version = "0.1.2"
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
-
-[zed-neon]
-submodule = "extensions/zed-neon"
-version = "0.0.1"
 
 [zedbox]
 submodule = "extensions/zedbox"


### PR DESCRIPTION
Adds the Zed Neon theme extension.
- Repository: https://github.com/spences10/zed-neon
- Extension id: neon-theme
- Version: 0.0.1
- Includes italic and no-italic variants for each theme.
- Tested locally as a Zed dev extension and validated theme JSON against Zed's theme schema.