### PR TITLE
Add grasp extension v3.18.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4597,3 +4597,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/grasp"]
+	path = extensions/grasp
+	url = https://github.com/ashfordeOU/grasp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4656,3 +4656,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[grasp]
+submodule = "extensions/grasp"
+version = "3.18.0"


### PR DESCRIPTION
Automated submission of Grasp — Code Architecture v3.18.0

Repository: https://github.com/ashfordeOU/grasp
Release: https://github.com/ashfordeOU/grasp/releases/tag/v3.18.0
Extension dir: `zed-extension/`
