### PR TITLE
Add Drupal language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1038,6 +1038,10 @@
 	path = extensions/dream
 	url = https://github.com/arturonegrete-dev/Dream-zed
 
+[submodule "extensions/drupal-syntax-highlighting"]
+	path = extensions/drupal-syntax-highlighting
+	url = https://github.com/abderrahimghazali/zed-drupal-syntax-highlighting.git
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1053,6 +1053,10 @@ version = "1.0.0"
 submodule = "extensions/dream"
 version = "1.0.0"
 
+[drupal-syntax-highlighting]
+submodule = "extensions/drupal-syntax-highlighting"
+version = "0.0.1"
+
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"


### PR DESCRIPTION
Adds the [Drupal Syntax Highlighting](https://github.com/abderrahimghazali/zed-drupal-syntax-highlighting) extension, which treats Drupal-specific PHP files as PHP so they get syntax highlighting: `.module`, `.install`, `.theme`, `.inc`, `.profile`, `.engine`, `.test`.