### PR TITLE
Add Hadolint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1594,6 +1594,10 @@
 	path = extensions/hackthebox-theme
 	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
+[submodule "extensions/hadolint"]
+	path = extensions/hadolint
+	url = https://github.com/abderrahimghazali/zed-dockerfile-linter.git
+
 [submodule "extensions/haku-dark-theme"]
 	path = extensions/haku-dark-theme
 	url = https://github.com/ArthurBrussee/haku_dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1619,6 +1619,10 @@ version = "1.0.1"
 submodule = "extensions/hackthebox-theme"
 version = "0.1.0"
 
+[hadolint]
+submodule = "extensions/hadolint"
+version = "0.1.0"
+
 [haku-dark-theme]
 submodule = "extensions/haku-dark-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the [Hadolint](https://github.com/abderrahimghazali/zed-dockerfile-linter) extension, which runs hadolint and surfaces its findings as inline diagnostics. Pairs with the official Dockerfile extension, which only handles syntax and completions.