### PR TITLE
Add fluent-oled-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1290,6 +1290,10 @@
 	path = extensions/flow-theme
 	url = https://github.com/Rics-Dev/zed-flow-theme.git
 
+[submodule "extensions/fluent-oled-theme"]
+	path = extensions/fluent-oled-theme
+	url = https://github.com/fermeridamagni/fluent-oled-for-zed.git
+
 [submodule "extensions/flutter-snippets"]
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1309,6 +1309,10 @@ version = "0.0.1"
 submodule = "extensions/flow-theme"
 version = "1.1.0"
 
+[fluent-oled-theme]
+submodule = "extensions/fluent-oled-theme"
+version = "1.0.0"
+
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"


### PR DESCRIPTION
## Summary
- add `fluent-oled-theme` as a new extension submodule
- register extension in `extensions.toml` with version `1.0.0`

Repository: https://github.com/fermeridamagni/fluent-oled-for-zed

This is the initial publication for the Fluent OLED Zed theme extension.