### PR TITLE
Update ansible to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -126,7 +126,7 @@ version = "21.0.0"
 
 [ansible]
 submodule = "extensions/ansible"
-version = "0.2.0"
+version = "1.0.0"
 
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"


### PR DESCRIPTION
Bump Ansible extension version to 1.0.0.

Changelog: https://github.com/kartikvashistha/zed-ansible/releases/tag/1.0.0