### PR TITLE
Update lilypond to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2073,7 +2073,7 @@ version = "0.0.1"
 
 [lilypond]
 submodule = "extensions/lilypond"
-version = "0.0.9"
+version = "0.1.0"
 
 [linkerscript]
 submodule = "extensions/linkerscript"


### PR DESCRIPTION
This PR updates the LilyPond extension to v0.1.0.