### PR TITLE
Add Vuex Helper extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4653,3 +4653,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/vuex-helper"]
+	path = extensions/vuex-helper
+	url = https://github.com/dmxiaoshubao/vuex-helper-for-zed.git


### PR DESCRIPTION
 This extension provides Vuex support for Vue 2 + Vuex 2 projects through a Node-based language server.

  Features:

  - Go to Definition
  - Completion
  - Hover
  - Diagnostics

  The extension automatically installs the language server from npm:

  `@dmxiaoshubao/vuex-helper-lsp@0.1.0`

  ## Configuration

  If the Vuex store entry cannot be detected automatically, users can configure:

  ```json
  {
    "lsp": {
      "vuex-helper": {
        "settings": {
          "storeEntry": "src/store/index.js"
        }
      }
    }
  }
```
  Verification

  - Published npm package: @dmxiaoshubao/vuex-helper-lsp@0.1.0
  - Tested locally in Zed without serverPath
  - `npm run test:zed` passes
  - `npm pack --dry-run` contains only runtime LSP files