### PR TITLE
Add Akhdar by aramb-dev theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,6 +86,10 @@
 	path = extensions/aizen-theme
 	url = https://github.com/vivy-company/zed-aizen-theme.git
 
+[submodule "extensions/akhdar-by-aramb-dev-theme"]
+	path = extensions/akhdar-by-aramb-dev-theme
+	url = https://github.com/aramb-dev/akhdar-by-aramb-dev-theme.git
+
 [submodule "extensions/alabaster"]
 	path = extensions/alabaster
 	url = https://github.com/tsimoshka/zed-theme-alabaster.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -88,6 +88,10 @@ version = "1.0.0"
 submodule = "extensions/aizen-theme"
 version = "0.1.0"
 
+[akhdar-by-aramb-dev-theme]
+submodule = "extensions/akhdar-by-aramb-dev-theme"
+version = "0.0.1"
+
 [alabaster]
 submodule = "extensions/alabaster"
 version = "0.0.3"


### PR DESCRIPTION
## Summary

- Adds **Akhdar by aramb-dev** (`akhdar-by-aramb-dev-theme`), a green-accented dark and light theme for Zed
- Brand green: `#15803d` (Tailwind green-700)
- Includes two variants: **Akhdar Dark** and **Akhdar Light**
- MIT licensed

## Extension repo

https://github.com/aramb-dev/akhdar-by-aramb-dev-theme