### PR TITLE
Аdd Superset Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4298,6 +4298,10 @@
 	path = extensions/superior-green-theme
 	url = https://github.com/rm-reins/Superior-Green.git
 
+[submodule "extensions/superset-theme"]
+	path = extensions/superset-theme
+	url = https://github.com/juwain/superset-zed-theme.git
+
 [submodule "extensions/supertheme4"]
 	path = extensions/supertheme4
 	url = https://github.com/superkacper4/supertheme4

--- a/extensions.toml
+++ b/extensions.toml
@@ -4368,6 +4368,10 @@ version = "0.1.0"
 submodule = "extensions/superior-green-theme"
 version = "0.0.20"
 
+[superset-theme]
+submodule = "extensions/superset-theme"
+version = "0.0.1"
+
 [supertheme4]
 submodule = "extensions/supertheme4"
 version = "0.0.3"


### PR DESCRIPTION
## Summary
  - Adds the Superset Theme extension with dark and light theme variants.
  - Registers the extension as `superset-theme` at version `0.0.1`.

  ## Validation
  - `pnpm sort-extensions`
  - `pnpm build`
  - `pnpm test`
  - `git diff --check`
  - Zed dev extension install via UI, then selected both Superset Light and Superset Dark