### PR TITLE
Update modern-icons to v0.7.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2535,7 +2535,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.6.0"
+version = "0.7.0"
 
 [modern-vesper]
 submodule = "extensions/modern-vesper"


### PR DESCRIPTION
## Summary

Bumps the [`modern-icons`](https://github.com/BadRat-in/zed-modern-icons) extension from `0.6.0` to `0.7.0`.

This is a minor release that adds directory-icon support (using Zed's `named_directory_icons`) plus a sizeable batch of new file/folder icons and matcher fixes.

## Highlights

- **Directory icons**: `named_directory_icons` for 153 directory types (folder icons render based on folder name in both light and dark themes).
- **New file/folder icons**: gemini, agents, claude, uv, .zed, .claude, .gemini, .dart_tool, .venv, drizzle, linux, web.
- **Repo reorganization**: SVGs split into `icons/file_icons/` and `icons/folder_icons/`.
- **Mapping fixes**:
  - `vite.config.{js,ts,mjs,cjs,mts,cts}` and `vitest.config.*` now use the vite/vitest icon (was falling through to `ts`/`js`).
  - `cloudbuild.{yaml,yml,json}` now use the gcloud icon (was falling through to `yaml`).
  - `.lock` files default to the package icon (yarn icon now reserved for `yarn.lock`).
  - `.spec` extension maps to the config icon.
  - `.env.production` / `.env.development` map to dotenv.
- **License variants**: enumerated `LICENSE` / `LICENCE` / `LISENSE` (and case variants) leading and trailing combinations with MIT/APACHE/BSD/GPL/LGPL/AGPL/MPL/ISC and `.md`/`.txt`.
- **Folder mappings** for `svg`/`svgs`/`icon`/`icons` directories.

## Release notes

[Compare v0.6.0…v0.7.0](https://github.com/BadRat-in/zed-modern-icons/compare/cf6fcecb...c9e0d0b) on the extension repo.