### PR TITLE
Add LazyVim theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2014,6 +2014,10 @@
 	path = extensions/latte
 	url = https://github.com/josbeir/zed-latte.git
 
+[submodule "extensions/lazyvim-theme"]
+	path = extensions/lazyvim-theme
+	url = https://github.com/BadRat-in/zed-lazyvim-theme.git
+
 [submodule "extensions/lean4"]
 	path = extensions/lean4
 	url = https://github.com/blackbird314/zed-lean4.git
@@ -4653,6 +4657,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/lazyvim-theme"]
-	path = extensions/lazyvim-theme
-	url = https://github.com/BadRat-in/zed-lazyvim-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4653,3 +4653,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/lazyvim-theme"]
+	path = extensions/lazyvim-theme
+	url = https://github.com/BadRat-in/zed-lazyvim-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2047,6 +2047,10 @@ version = "0.2.3"
 submodule = "extensions/latte"
 version = "0.1.0"
 
+[lazyvim-theme]
+submodule = "extensions/lazyvim-theme"
+version = "0.1.0"
+
 [lean4]
 submodule = "extensions/lean4"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the `lazyvim-theme` extension at v0.1.0 — a Zed theme inspired by [LazyVim](https://www.lazyvim.org/) and [TokyoNight](https://github.com/folke/tokyonight.nvim). Ships two variants:

- **LazyVim Moon** (dark)
- **LazyVim Day** (light)

Source: https://github.com/BadRat-in/zed-lazyvim-theme

## Test plan

- [ ] Theme installs cleanly via the Zed extensions registry
- [ ] LazyVim Moon and LazyVim Day appear in the theme picker
- [ ] Syntax highlighting, terminal ANSI colors, and UI chrome render correctly in both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)