### PR TITLE
Add REST Client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4653,3 +4653,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/rest-client"]
+	path = extensions/rest-client
+	url = https://github.com/AlbertoBarrago/zed-rest-client.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4713,3 +4713,6 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+[rest-client]
+submodule = "extensions/rest-client"
+version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4715,4 +4715,4 @@ submodule = "extensions/zwirn"
 version = "0.2.0"
 [rest-client]
 submodule = "extensions/rest-client"
-version = "0.1.0"
+version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5403,4 +5403,4 @@ submodule = "extensions/zwirn"
 version = "0.2.0"
 [rest-client]
 submodule = "extensions/rest-client"
-version = "0.1.1"
+version = "0.1.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5403,4 +5403,4 @@ submodule = "extensions/zwirn"
 version = "0.2.0"
 [rest-client]
 submodule = "extensions/rest-client"
-version = "0.1.2"
+version = "0.1.3"


### PR DESCRIPTION
Adds support for `.rest` and `.http` files in Zed.

- Syntax highlighting via the `rest-nvim/tree-sitter-http` grammar
- Runnable tasks to execute HTTP requests directly from the editor (via a standalone `rest-runner` binary)
- Response chaining: reuse values from previous responses using JSONPath expressions

Repository: https://github.com/AlbertoBarrago/zed-rest-client