### PR TITLE
Add kanagawa-like-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1930,6 +1930,10 @@
 	path = extensions/kamui-dark-theme
 	url = https://gitlab.com/kamuiqf/zed-kamui-theme.git
 
+[submodule "extensions/kanagawa-like-theme"]
+	path = extensions/kanagawa-like-theme
+	url = https://github.com/Dunlag/kanagawa-like-zed-theme
+
 [submodule "extensions/kanagawa-themes"]
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1963,6 +1963,10 @@ version = "1.0.1"
 submodule = "extensions/kamui-dark-theme"
 version = "0.0.1"
 
+[kanagawa-like-theme]
+submodule = "extensions/kanagawa-like-theme"
+version = "0.1.0"
+
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
 version = "0.1.2"


### PR DESCRIPTION
Adds Kanagawa Like, a Kanagawa-inspired dark theme for Zed with two variants: Wave and Dragon.