### PR TITLE
Add RetroPC theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3426,6 +3426,10 @@
 	path = extensions/retrofit-theme
 	url = https://github.com/snapsnapturtle/retrofit-zed.git
 
+[submodule "extensions/retropc-theme"]
+	path = extensions/retropc-theme
+	url = https://github.com/abhishek-bhatkar/retroPC-zed-theme.git
+
 [submodule "extensions/rewrite-theme"]
 	path = extensions/rewrite-theme
 	url = https://github.com/RewriteToday/theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3476,6 +3476,10 @@ version = "0.4.4"
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"
 
+[retropc-theme]
+submodule = "extensions/retropc-theme"
+version = "0.0.1"
+
 [rewrite-theme]
 submodule = "extensions/rewrite-theme"
 path = "zed"


### PR DESCRIPTION
Adds the RetroPC amber CRT theme for Zed.\n\nRepository: https://github.com/abhishek-bhatkar/retroPC-zed-theme\n\nLocal checks run:\n- npm run sort-extensions\n- npm run build