### PR TITLE
Add VS Code 2026 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4350,6 +4350,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vs-code-2026-theme"]
+	path = extensions/vs-code-2026-theme
+	url = https://github.com/sabari245/2026-theme-zed.git
+
 [submodule "extensions/vscode-classic-theme"]
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4411,6 +4411,10 @@ version = "1.0.0"
 submodule = "extensions/vrl"
 version = "0.1.0"
 
+[vs-code-2026-theme]
+submodule = "extensions/vs-code-2026-theme"
+version = "0.0.1"
+
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the VS Code 2026 dark and light themes as a Zed theme extension.

Extension repository: https://github.com/sabari245/2026-theme-zed

Validation performed:
- Ran `pnpm sort-extensions`
- Ran `jq empty` on `themes/2026.json`
- Validated the extension license with the repository validator
- Ran `node src/package-extensions.js vs-code-2026-theme`; registry and license validation passed, but local packaging could not complete because this clone does not include the `./zed-extension` binary.

Source/license:
- Ported from Microsoft VS Code `theme-defaults` 2026 themes, which are MIT licensed.