### PR TITLE
Update greycat to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1549,7 +1549,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.0"
+version = "0.1.1"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
Bumps the greycat extension submodule to ccb2200 (grammar update).