### PR TITLE
Add Gregorio language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1514,6 +1514,10 @@
 	path = extensions/green-theme
 	url = https://github.com/ningfangbin/zed_code_green.git
 
+[submodule "extensions/gregorio"]
+	path = extensions/gregorio
+	url = https://github.com/AISCGre-BR/zed-gregorio.git
+
 [submodule "extensions/gren"]
 	path = extensions/gren
 	url = https://github.com/johanalkstal/gren-lang-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1539,6 +1539,10 @@ version = "0.1.3"
 submodule = "extensions/green-theme"
 version = "0.0.3"
 
+[gregorio]
+submodule = "extensions/gregorio"
+version = "0.3.1"
+
 [gren]
 submodule = "extensions/gren"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1557,7 +1557,7 @@ version = "0.0.3"
 
 [gregorio]
 submodule = "extensions/gregorio"
-version = "0.3.1"
+version = "0.8.0"
 
 [gren]
 submodule = "extensions/gren"


### PR DESCRIPTION
This PR adds the **Gregorio GABC** extension for [GABC/NABC](https://gregorio-project.github.io/) notation — the file format used by [Gregorio](https://gregorio-project.github.io/) to typeset Gregorian chant in LaTeX.

## Extension

- **ID:** `gregorio`
- **Repository:** https://github.com/AISCGre-BR/zed-gregorio
- **Version:** 0.8.0

## Features

- **Syntax highlighting** — headers, pitches, clefs, neumes, bars, alterations, style tags, NABC notation, and comments.
- **LaTeX injection** — TeX code inside `<v>…</v>` tags and verbatim attributes (`[nv:…]`, `[gv:…]`, `[ev:…]`) gets LaTeX highlighting.
- **Bracket matching** — auto-matching for `()`, `[]`, `{}`, and `<>`.
- **Code outline** — headers appear in the document outline/symbols panel.
- **Language server** — diagnostics, hover, completion, and document symbols via [gregorio-lsp](https://github.com/aiscgre-br/gregorio-lsp).
- **Document formatting** — Format Document (`Alt+Shift+F` / `⌥⇧F`) and format-on-save via `gregorio-lsp` ≥ 0.9.0 (powered by the embedded `grefmt` formatter).

## Grammar

Uses [tree-sitter-gregorio](https://github.com/AISCGre-BR/tree-sitter-gregorio) v0.5.2 — a complete tree-sitter grammar for GABC+NABC notation, compatible with Gregorio 6.2.0.