### PR TITLE
Add quint language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3334,6 +3334,10 @@
 	path = extensions/quill
 	url = https://github.com/CraftQuill/zed-theme-quill.git
 
+[submodule "extensions/quint"]
+	path = extensions/quint
+	url = https://github.com/zdavison/zed-quint.git
+
 [submodule "extensions/r"]
 	path = extensions/r
 	url = https://github.com/ocsmit/zed-r.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3384,6 +3384,10 @@ version = "0.8.0"
 submodule = "extensions/quill"
 version = "0.2.2"
 
+[quint]
+submodule = "extensions/quint"
+version = "0.2.0"
+
 [r]
 submodule = "extensions/r"
 version = "0.2.5"


### PR DESCRIPTION
## 🤖  AI Disclosure

This extension is a port of the official [Quint VSCode extension ](https://marketplace.visualstudio.com/items?itemName=informal.quint-vscode) written 100% with `claude`.
I've been using it personally and haven't had any issues.

## Ownership

I'm not affiliated with the Quint team. This plugin is MIT licensed and if the Quint dev-team want to take it over as an official extension, that's fine with me, I'm just filling a gap for now.

## Summary

Adds the Quint specification language extension. Provides:

- Syntax highlighting via tree-sitter-quint (shallow grammar mirroring the upstream TextMate categories, plus `match`, `Map`, `->`, and capitalized-identifier highlighting that the TextMate grammar lacks)
- LSP integration via `@informalsystems/quint-language-server` (diagnostics, hover, go-to-definition, completions, rename) — the same server the official VS Code extension uses
- Markdown injection inside ```quint fenced code blocks (including literate specs with lmt-style info strings)

Repo: https://github.com/zdavison/zed-quint
Grammar: https://github.com/zdavison/tree-sitter-quint

## Test plan

- [x] Tested locally as a dev extension (`zed: install dev extension`)
- [x] Syntax highlighting works on .qnt files (tree-sitter-quint parses 255 real specs from the wild with 0 errors)
- [x] LSP diagnostics surface in Zed via quint-language-server
- [x] MIT LICENSE present at extension root