### PR TITLE
Add Efa Dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1098,6 +1098,10 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/efa-dark-theme"]
+	path = extensions/efa-dark-theme
+	url = https://github.com/valyefimov/zed-theme-efa-dark.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1114,6 +1114,10 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
+[efa-dark-theme]
+submodule = "extensions/efa-dark-theme"
+version = "1.0.0"
+
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.1.1"


### PR DESCRIPTION
Adds the efa-dark-theme submodule to the project. This includes updating the .gitmodules and extensions.toml files.