### PR TITLE
Add glTF language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1482,6 +1482,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/gltf"]
+	path = extensions/gltf
+	url = https://github.com/imboni/zed-gltf-model-viewer.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1507,6 +1507,10 @@ submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.3"
 
+[gltf]
+submodule = "extensions/gltf"
+version = "0.1.0"
+
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.5"


### PR DESCRIPTION
## Summary

- Adds a `gltf` language extension to the Zed extensions index.
- Registers `https://github.com/imboni/zed-gltf-model-viewer.git` as a submodule at `extensions/gltf`.
- Provides `.gltf` file detection using the JSON tree-sitter grammar.
- Adds glTF-focused syntax highlighting for common glTF 2.0 properties.

## Notes

`.gltf` files are JSON text assets, so this extension uses the JSON grammar and adds glTF-specific highlighting. Binary `.glb` files are out of scope for this text-language extension.

## Validation

- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm sort-extensions`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm build`
- `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm test`
- `git diff --check`
- Official local validation functions for `extensions.toml`, `.gitmodules`, submodule location, manifest, and license
- `node -e "JSON.parse(require('fs').readFileSync('extensions/gltf/fixtures/triangle.gltf', 'utf8'))"`