### PR TITLE
Add Makinda Themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2182,6 +2182,10 @@
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
 
+[submodule "extensions/makinda-themes"]
+	path = extensions/makinda-themes
+	url = https://github.com/makindajack/makinda-zed.git
+
 [submodule "extensions/mako"]
 	path = extensions/mako
 	url = https://github.com/ron0studios/mako-zed.git
@@ -4701,6 +4705,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/makinda-themes"]
-	path = extensions/makinda-themes
-	url = https://github.com/makindajack/makinda-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4681,3 +4681,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/makinda-themes"]
+	path = extensions/makinda-themes
+	url = https://github.com/makindajack/makinda-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2202,6 +2202,10 @@ version = "0.1.0"
 submodule = "extensions/make"
 version = "1.1.2"
 
+[makinda-themes]
+submodule = "extensions/makinda-themes"
+version = "1.0.3"
+
 [mako]
 submodule = "extensions/mako"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2220,7 +2220,7 @@ version = "1.1.2"
 
 [makinda-themes]
 submodule = "extensions/makinda-themes"
-version = "1.0.3"
+version = "1.0.4"
 
 [mako]
 submodule = "extensions/mako"


### PR DESCRIPTION
## Description

Adds **Makinda Themes** — a premium light + dark theme family with warm orange accents and excellent readability, ported from the same palette used across the [Makinda Themes family](https://github.com/makindajack/makinda-themes) (VS Code, JetBrains, Sublime, etc.).

## Submission requirements

- [x] Submodule added at `extensions/makinda-themes` pointing to https://github.com/makindajack/makinda-zed at tag `v1.0.3`.
- [x] Entry added alphabetically in `extensions.toml`.
- [x] `extension.toml` includes `id`, `name`, `description`, `version`, `schema_version`, `authors`, `repository`.
- [x] Themes ship under `themes/makinda.json`, providing both `Makinda Light` and `Makinda Dark`.
- [x] License: MIT.