### PR TITLE
Add DevGlobe language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -990,6 +990,10 @@
 	path = extensions/dev-magic
 	url = https://github.com/susanta96/dev-magic.git
 
+[submodule "extensions/devglobe-activity"]
+	path = extensions/devglobe-activity
+	url = https://github.com/devglobe-xyz/zed-devglobe.git
+
 [submodule "extensions/devicetree"]
 	path = extensions/devicetree
 	url = https://github.com/anikinmd/zed_devicetree
@@ -4681,6 +4685,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/devglobe"]
-	path = extensions/devglobe
-	url = https://github.com/devglobe-xyz/zed-devglobe.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4681,3 +4681,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/devglobe"]
+	path = extensions/devglobe
+	url = https://github.com/devglobe-xyz/zed-devglobe.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -990,8 +990,8 @@
 	path = extensions/dev-magic
 	url = https://github.com/susanta96/dev-magic.git
 
-[submodule "extensions/devglobe-activity"]
-	path = extensions/devglobe-activity
+[submodule "extensions/devglobe-activity-ls"]
+	path = extensions/devglobe-activity-ls
 	url = https://github.com/devglobe-xyz/zed-devglobe.git
 
 [submodule "extensions/devicetree"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1005,6 +1005,10 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
+[devglobe]
+submodule = "extensions/devglobe"
+version = "2.0.0"
+
 [devicetree]
 submodule = "extensions/devicetree"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1005,8 +1005,8 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
-[devglobe]
-submodule = "extensions/devglobe"
+[devglobe-activity]
+submodule = "extensions/devglobe-activity"
 version = "2.0.0"
 
 [devicetree]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1005,8 +1005,8 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
-[devglobe-activity]
-submodule = "extensions/devglobe-activity"
+[devglobe-activity-ls]
+submodule = "extensions/devglobe-activity-ls"
 version = "2.0.0"
 
 [devicetree]


### PR DESCRIPTION
## DevGlobe — Coding activity tracker for developers

[DevGlobe](https://devglobe.xyz) tracks your coding time per language, repo, file and editor, and builds a public developer profile with your stats, projects and links.

It also includes a 3D globe showing developers coding live around the world, so you can discover other developers and the projects they're working on.

This extension brings DevGlobe tracking to Zed.

### How it works

- A lightweight Language Server receives `didOpen`/`didChange`/`didSave` events
- Sends a heartbeat every 30 seconds while you're actively coding
- Pauses automatically after 1 minute of inactivity
- Detects programming language, git repository (multi-provider), and city-level location
- File paths are always relative to the git repo root — never absolute home paths

### Features

- Per-language, per-repo, per-file coding time tracking
- 80+ languages supported
- Multi-provider git detection (GitHub, GitLab, Bitbucket, self-hosted Gitea, Azure DevOps)
- Status message visible on your developer profile
- Offline detection with auto-recovery
- Local privacy flags (`hide_file_names`, `hide_branch_names`, `hide_project_names`) in `~/.devglobe/config.toml`
- Public developer profile with stats, projects and links

### Requirements

- A DevGlobe API key from [devglobe.xyz/dashboard/settings](https://devglobe.xyz/dashboard/settings)

### Privacy

No source code, file contents, or keystrokes are sent. Only programming language, editor name, OS, coding time, optional git repo URL, branch, and the file path relative to your repo root.

**Repository:** https://github.com/devglobe-xyz/zed-devglobe
**License:** MIT

---

### Addressing previous feedback (from #5841)

This resubmission no longer ships the language server with the extension. The Rust extension now downloads the prebuilt `devglobe-core` binary for the user's platform from [GitHub Releases](https://github.com/Nako0/devglobe-extension/releases/tag/core-v2.0.0) at first activation, following the same pattern as `wakatime/zed-wakatime` and `sachk/aw-watcher-zed`. The previous bundled `server/` directory has been removed entirely.
