### PR TITLE
Add mcp-server-n8n extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2362,6 +2362,10 @@
 	path = extensions/mcp-server-mysql
 	url = https://github.com/toonvd/zed-mysql-mcp.git
 
+[submodule "extensions/mcp-server-n8n"]
+	path = extensions/mcp-server-n8n
+	url = https://github.com/tmih06/zed-mcp-server-n8n.git
+
 [submodule "extensions/mcp-server-newsnow"]
 	path = extensions/mcp-server-newsnow
 	url = https://github.com/benmooo/zed-mcp-server-newsnow.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2399,6 +2399,10 @@ version = "0.3.0"
 submodule = "extensions/mcp-server-mysql"
 version = "0.0.1"
 
+[mcp-server-n8n]
+submodule = "extensions/mcp-server-n8n"
+version = "0.1.0"
+
 [mcp-server-newsnow]
 submodule = "extensions/mcp-server-newsnow"
 version = "0.0.10"


### PR DESCRIPTION
Adds the `mcp-server-n8n` extension for Zed.

Extension repository:
- https://github.com/tmih06/zed-mcp-server-n8n

This extension connects Zed to n8n MCP endpoints, including instance-level MCP URLs and MCP Server Trigger workflow URLs.