### PR TITLE
Add xcode-like-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5030,6 +5030,10 @@
 	path = extensions/wxml
 	url = https://github.com/BlockLune/zed-wxml.git
 
+[submodule "extensions/xcode-like-theme"]
+	path = extensions/xcode-like-theme
+	url = https://github.com/erwin-lovecraft/xcode-like-zed-theme.git
+
 [submodule "extensions/xcode-themes"]
 	path = extensions/xcode-themes
 	url = https://github.com/skarline/zed-xcode-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5115,6 +5115,10 @@ version = "0.0.1"
 submodule = "extensions/wxml"
 version = "0.1.0"
 
+[xcode-like-theme]
+submodule = "extensions/xcode-like-theme"
+version = "0.0.2"
+
 [xcode-themes]
 submodule = "extensions/xcode-themes"
 version = "2.0.1"


### PR DESCRIPTION
## Description

This PR introduces the Xcode Light and Xcode Dark themes to Zed. These themes are designed to replicate the classic Apple developer experience, providing a familiar and comfortable aesthetic for users transitioning from or nostalgic for the Xcode environment.

## Submission requirements

- [x] Submodule added at `extensions/xcode-like-theme` pointing to https://github.com/erwin-lovecraft/xcode-like-zed-theme at tag `v0.0.1`.
- [x] Entry added alphabetically in `extensions.toml`.
- [x] `extension.toml` includes `id`, `name`, `description`, `version`, `schema_version`, `authors`, `repository`.
- [x] Themes ship under `themes/xcode-like.json`.
- [x] License: MIT.