### PR TITLE
Add Grafana Alloy language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1502,6 +1502,10 @@
 	path = extensions/gotmpl
 	url = https://github.com/hjr265/zed-gotmpl.git
 
+[submodule "extensions/grafana-alloy"]
+	path = extensions/grafana-alloy
+	url = https://github.com/lenstr/zed-grafana-alloy.git
+
 [submodule "extensions/graphene"]
 	path = extensions/graphene
 	url = https://github.com/adinack/graphene.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1527,6 +1527,10 @@ version = "0.0.2"
 submodule = "extensions/gotmpl"
 version = "0.0.1"
 
+[grafana-alloy]
+submodule = "extensions/grafana-alloy"
+version = "0.0.1"
+
 [graphene]
 submodule = "extensions/graphene"
 version = "0.2.1"


### PR DESCRIPTION
Adds Grafana Alloy language support for `.alloy` files.

The extension is syntax-only and uses `mattsre/tree-sitter-alloy` for Tree-sitter parsing. The extension repo includes an MIT license at the root as required by the registry.

Validation run locally:
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test`
- registry manifest/submodule/license validation against `src/lib/validation.js`