### PR TITLE
Add hujson language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4689,3 +4689,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/hujson"]
+	path = extensions/hujson
+	url = https://github.com/ggfevans/zed-hujson.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1882,6 +1882,10 @@
 	path = extensions/huff
 	url = https://github.com/Niraj-Kamdar/zed-huff.git
 
+[submodule "extensions/hujson"]
+	path = extensions/hujson
+	url = https://github.com/ggfevans/zed-hujson.git
+
 [submodule "extensions/hurl"]
 	path = extensions/hurl
 	url = https://github.com/tommy/zed-hurl
@@ -4989,6 +4993,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/hujson"]
-	path = extensions/hujson
-	url = https://github.com/ggfevans/zed-hujson.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1765,6 +1765,10 @@ version = "1.0.0"
 submodule = "extensions/huff"
 version = "0.0.1"
 
+[hujson]
+submodule = "extensions/hujson"
+version = "0.1.0"
+
 [hurl]
 submodule = "extensions/hurl"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1921,7 +1921,7 @@ version = "0.0.1"
 
 [hujson]
 submodule = "extensions/hujson"
-version = "0.1.0"
+version = "1.0.0"
 
 [hurl]
 submodule = "extensions/hurl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1921,7 +1921,7 @@ version = "0.0.1"
 
 [hujson]
 submodule = "extensions/hujson"
-version = "1.0.0"
+version = "1.0.1"
 
 [hurl]
 submodule = "extensions/hurl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1933,7 +1933,7 @@ version = "0.0.1"
 
 [hujson]
 submodule = "extensions/hujson"
-version = "1.0.2"
+version = "1.1.0"
 
 [hurl]
 submodule = "extensions/hurl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1921,7 +1921,7 @@ version = "0.0.1"
 
 [hujson]
 submodule = "extensions/hujson"
-version = "1.0.1"
+version = "1.0.2"
 
 [hurl]
 submodule = "extensions/hurl"


### PR DESCRIPTION
Adds a Zed extension for HuJSON (JWCC): JSON with comments and trailing commas.
- Grammar lives at https://github.com/ggfevans/tree-sitter-hujson, pinned by commit in extension.toml.
- Tested as a dev extension locally; sample document at examples/sample.hujson.
- LICENSE present at submodule root.

Closes #153 [#131](https://github.com/hjson/hjson/issues/131)