### PR TITLE
Update cem to v0.10.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -575,7 +575,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.10.2"
+version = "0.10.3"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
Updates cem extension to [version 0.10.3](https://github.com/bennypowers/cem/releases/tag/v0.10.3).