### PR TITLE
Update mistral-vibe to v2.9.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2546,7 +2546,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.9.4"
+version = "2.9.5"
 path = "distribution/zed"
 
 [mlir-tablegen]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.9.5