### PR TITLE
Add yaml-sql extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/yaml-sql"]
+	path = extensions/yaml-sql
+	url = https://github.com/tinwonda/zed-yaml-sql-language-support

--- a/.gitmodules
+++ b/.gitmodules
@@ -4710,6 +4710,10 @@
 	path = extensions/yaka
 	url = https://github.com/edgarkanyes/yaka.git
 
+[submodule "extensions/yaml-sql"]
+	path = extensions/yaml-sql
+	url = https://github.com/tinwonda/zed-yaml-sql-language-support
+
 [submodule "extensions/yamura"]
 	path = extensions/yamura
 	url = https://github.com/Yxmura/yamura-zed-theme.git
@@ -4841,6 +4845,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/yaml-sql"]
-	path = extensions/yaml-sql
-	url = https://github.com/tinwonda/zed-yaml-sql-language-support

--- a/extensions.toml
+++ b/extensions.toml
@@ -4778,6 +4778,10 @@ version = "0.1.4"
 submodule = "extensions/yaka"
 version = "0.0.4"
 
+[yaml-sql]
+submodule = "extensions/yaml-sql"
+version = "0.0.1"
+
 [yamura]
 submodule = "extensions/yamura"
 version = "0.0.2"
@@ -4789,10 +4793,6 @@ version = "0.0.2"
 [yara]
 submodule = "extensions/yara"
 version = "0.0.4"
-
-[yaml-sql]
-submodule = "extensions/yaml-sql"
-version = "0.0.1"
 
 [yarn-spinner]
 submodule = "extensions/yarn-spinner"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4642,6 +4642,10 @@ version = "0.0.2"
 submodule = "extensions/yara"
 version = "0.0.4"
 
+[yaml-sql]
+submodule = "extensions/yaml-sql"
+version = "0.0.1"
+
 [yarn-spinner]
 submodule = "extensions/yarn-spinner"
 version = "0.0.9"


### PR DESCRIPTION
## Summary

Adds the `yaml-sql` Zed extension to the registry.

- **Extension ID**: `yaml-sql`
- **Repository**: https://github.com/tinwonda/zed-yaml-sql-language-support
- **Version**: `0.0.1`

## What it does

Injects SQL syntax highlighting into YAML values when either:
- The value's key contains `sql` as its own token (e.g. `sql_query`, `query_sql`)
- The value is preceded by a `#language=sql` comment annotation

## Checklist

- [x] Tested locally with "Install Dev Extension" in Zed
- [x] Open-source license included (MIT)
- [x] Extension ID does not contain "zed" or "extension"
- [x] `version` in `extensions.toml` matches `extension.toml`