### PR TITLE
Add modelfile language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/modelfile"]
+	path = extensions/modelfile
+	url = https://github.com/jackwsmth/modelfile-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2954,6 +2954,10 @@
 	path = extensions/mnemonic
 	url = https://github.com/mnemonic-theme/zed
 
+[submodule "extensions/modelfile"]
+	path = extensions/modelfile
+	url = https://github.com/jackwsmth/modelfile-zed.git
+
 [submodule "extensions/modern-icons"]
 	path = extensions/modern-icons
 	url = https://github.com/BadRat-in/zed-modern-icons.git
@@ -5409,6 +5413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/modelfile"]
-	path = extensions/modelfile
-	url = https://github.com/jackwsmth/modelfile-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2557,6 +2557,10 @@ version = "0.2.1"
 submodule = "extensions/mnemonic"
 version = "0.0.1"
 
+[modelfile]
+submodule = "extensions/modelfile"
+version = "0.0.1"
+
 [modern-icons]
 submodule = "extensions/modern-icons"
 version = "0.7.0"


### PR DESCRIPTION
This PR adds an extension to provide syntax highlighting for [Ollama](https://ollama.com)'s Modelfile. 

<img width="500" height="260" alt="image" src="https://github.com/user-attachments/assets/da710709-f443-4309-850a-c29b5a71159e" />

It also relies on [tree-sitter-modelfile](https://github.com/jackwsmth/tree-sitter-modelfile) which I am currently maintaining.

Have followed the steps on the [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions) docs page. 

Let me know if I need to update anything. 

Thanks!