### PR TITLE
Add Jirac MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1898,13 +1898,13 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
-[submodule "extensions/jira-mcp-server"]
-	path = extensions/jira-mcp-server
-	url = https://github.com/mulhamna/jirac-ext.git
-
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
+
+[submodule "extensions/jirac-mcp-server"]
+	path = extensions/jirac-mcp-server
+	url = https://github.com/mulhamna/jirac-ext.git
 
 [submodule "extensions/jj-lsp"]
 	path = extensions/jj-lsp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1898,13 +1898,13 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
-[submodule "extensions/jira"]
-	path = extensions/jira
-	url = https://github.com/mulhamna/jirac-ext.git
-
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
+
+[submodule "extensions/jirac"]
+	path = extensions/jirac
+	url = https://github.com/mulhamna/jirac-ext.git
 
 [submodule "extensions/jj-lsp"]
 	path = extensions/jj-lsp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1898,13 +1898,13 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
+[submodule "extensions/jira-mcp-server"]
+	path = extensions/jira-mcp-server
+	url = https://github.com/mulhamna/jirac-ext.git
+
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
-
-[submodule "extensions/jirac"]
-	path = extensions/jirac
-	url = https://github.com/mulhamna/jirac-ext.git
 
 [submodule "extensions/jj-lsp"]
 	path = extensions/jj-lsp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1898,6 +1898,10 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
+[submodule "extensions/jira"]
+	path = extensions/jira
+	url = https://github.com/mulhamna/jirac-ext.git
+
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git
@@ -4697,6 +4701,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/jira"]
-	path = extensions/jira
-	url = https://github.com/mulhamna/jirac-ext.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/jira"]
+	path = extensions/jira
+	url = https://github.com/mulhamna/jirac-ext.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1931,13 +1931,13 @@ version = "1.0.0"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
+[jira-mcp-server]
+submodule = "extensions/jira-mcp-server"
+version = "0.1.0"
+
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
-
-[jirac]
-submodule = "extensions/jirac"
-version = "0.1.0"
 
 [jj-lsp]
 submodule = "extensions/jj-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1931,6 +1931,10 @@ version = "1.0.0"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
+[jira]
+submodule = "extensions/jira"
+version = "0.1.0"
+
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1931,13 +1931,13 @@ version = "1.0.0"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
-[jira]
-submodule = "extensions/jira"
-version = "0.1.0"
-
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
+
+[jirac]
+submodule = "extensions/jirac"
+version = "0.1.0"
 
 [jj-lsp]
 submodule = "extensions/jj-lsp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1931,13 +1931,13 @@ version = "1.0.0"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
-[jira-mcp-server]
-submodule = "extensions/jira-mcp-server"
-version = "0.1.0"
-
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"
+
+[jirac-mcp-server]
+submodule = "extensions/jirac-mcp-server"
+version = "0.1.0"
 
 [jj-lsp]
 submodule = "extensions/jj-lsp"


### PR DESCRIPTION
## Summary
- add the new `jirac-mcp-server` Zed extension as a submodule
- point it at `https://github.com/mulhamna/jirac-ext`
- use a unique published extension id and matching marketplace path

## Notes
- `jirac-ext` is the dedicated Zed-facing mirror repo for this extension
- the wrapper downloads and launches published `jirac-mcp` release artifacts from `mulhamna/jira-commands`
- the source-of-truth wrapper changes are mirrored in `jira-commands`, but this PR only adds the publishable extension to the Zed marketplace repo
