### PR TITLE
Add OC-2 theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   package:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   package:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -942,6 +942,10 @@
 	path = extensions/norrsken
 	url = https://github.com/webhooked/norrsken-zed.git
 
+[submodule "extensions/nstlgy-dark"]
+	path = extensions/nstlgy-dark
+	url = https://github.com/nstlgy/zed-nstlgy-dark
+
 [submodule "extensions/nu"]
 	path = extensions/nu
 	url = https://github.com/zed-extensions/nu.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1082,6 +1082,10 @@
 	path = extensions/norrsken
 	url = https://github.com/webhooked/norrsken-zed.git
 
+[submodule "extensions/not-material-theme"]
+	path = extensions/not-material-theme
+	url = https://github.com/iamawatermelo/zed-hct-theme-maker
+
 [submodule "extensions/nstlgy-dark"]
 	path = extensions/nstlgy-dark
 	url = https://github.com/nstlgy/zed-nstlgy-dark

--- a/.gitmodules
+++ b/.gitmodules
@@ -2866,6 +2866,10 @@
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git
 
+[submodule "extensions/oc-2-theme"]
+	path = extensions/oc-2-theme
+	url = https://github.com/nstlgy/oc-2-theme
+
 [submodule "extensions/ocaml"]
 	path = extensions/ocaml
 	url = https://github.com/zed-extensions/ocaml.git
@@ -4669,9 +4673,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
-[submodule "extensions/oc-2-theme"]
-	path = extensions/oc-2-theme
-	url = https://github.com/nstlgy/oc-2-theme
 
 [submodule "extensions/zk"]
 	path = extensions/zk

--- a/.gitmodules
+++ b/.gitmodules
@@ -1849,3 +1849,6 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+[submodule "extensions/oc-2-theme"]
+	path = extensions/oc-2-theme
+	url = https://github.com/nstlgy/oc-2-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1006,7 +1006,7 @@ version = "3.0.1"
 
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
-version = "0.0.1"
+version = "0.0.2"
 
 [nu]
 submodule = "extensions/nu"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1004,6 +1004,10 @@ version = "0.2.1"
 submodule = "extensions/norrsken"
 version = "3.0.1"
 
+[nstlgy-dark]
+submodule = "extensions/nstlgy-dark"
+version = "0.0.1"
+
 [nu]
 submodule = "extensions/nu"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1129,19 +1129,13 @@ version = "0.2.1"
 submodule = "extensions/norrsken"
 version = "3.0.1"
 
-<<<<<<< HEAD
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
 version = "0.0.2"
-=======
+
 [not-material-theme]
 submodule = "extensions/not-material-theme"
 version = "0.0.1"
-
-[nstlgy-dark]
-submodule = "extensions/nstlgy-dark"
-version = "0.0.1"
->>>>>>> 6f7f0885f9c4059712e54b6b00f0e99b86d5c030
 
 [nu]
 submodule = "extensions/nu"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1129,13 +1129,13 @@ version = "0.2.1"
 submodule = "extensions/norrsken"
 version = "3.0.1"
 
-[nstlgy-dark]
-submodule = "extensions/nstlgy-dark"
-version = "0.0.2"
-
 [not-material-theme]
 submodule = "extensions/not-material-theme"
 version = "0.0.1"
+
+[nstlgy-dark]
+submodule = "extensions/nstlgy-dark"
+version = "0.0.2"
 
 [nu]
 submodule = "extensions/nu"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1161,6 +1161,10 @@ version = "0.0.1"
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"
 
+[oc-2-theme]
+submodule = "extensions/oc-2-theme"
+version = "0.0.1"
+
 [ocaml]
 submodule = "extensions/ocaml"
 version = "0.1.4"


### PR DESCRIPTION
Adds OC-2 Theme, a light and dark Zed theme adapted from the OpenCode OC-2 palette.

Theme repository: https://github.com/nstlgy/oc-2-theme