### PR TITLE
Update modern-icons to v0.7.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2559,7 +2559,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.7.0"
+version = "0.7.1"
 
 [modern-vesper]
 submodule = "extensions/modern-vesper"


### PR DESCRIPTION
## Summary

Bumps `modern-icons` to v0.7.1.

## Changes since v0.7.0

- Map `.ropeproject` directories (created by Python's [rope](https://github.com/python-rope/rope) refactoring library) to the python folder icon.

## Release Notes

- modern-icons: Map `.ropeproject` directory to python folder icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)