### PR TITLE
Add Nuxt extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2834,6 +2834,10 @@
 	path = extensions/nunjucks
 	url = https://github.com/stormwarning/zed-nunjucks.git
 
+[submodule "extensions/nuxt"]
+	path = extensions/nuxt
+	url = https://github.com/pratik7368patil/nuxt-zed-extension.git
+
 [submodule "extensions/nvim-nightfox"]
 	path = extensions/nvim-nightfox
 	url = https://github.com/cange/nightfox.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2874,6 +2874,10 @@ version = "0.0.1"
 submodule = "extensions/nunjucks"
 version = "0.0.1"
 
+[nuxt]
+submodule = "extensions/nuxt"
+version = "0.1.0"
+
 [nvim-nightfox]
 submodule = "extensions/nvim-nightfox"
 version = "0.9.0"


### PR DESCRIPTION
## Summary

Adds the `nuxt` extension to the Zed extension registry.

The extension is a Nuxt companion extension for Vue single-file components. It detects Nuxt worktrees, starts Volar-compatible Vue tooling, and warns when generated `.nuxt` type files are missing so users can run `nuxt prepare` or `nuxt dev`.

## Validation

- `cargo check --target wasm32-wasip1` in `nuxt-zed-extension`
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (111 tests passed)
- `pnpm package-extensions nuxt` reached packaging but local checkout does not include the CI `./zed-extension` binary, so it failed with `spawn ./zed-extension ENOENT`
