### PR TITLE
Update oceanic-next-theme to v1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2920,7 +2920,7 @@ version = "0.0.1"
 
 [oceanic-next]
 submodule = "extensions/oceanic-next"
-version = "1.0.0"
+version = "1.1.0"
 
 [oceans-of-andromeda-theme]
 submodule = "extensions/oceans-of-andromeda-theme"


### PR DESCRIPTION
Fixes some issues with merge conflict colors and adds some minor improvements to status popovers (hint, info, error, etc.). 

Addresses the poor button contrast of non-native dialogs reported [here](https://github.com/rkunev/oceanic-next/issues/3) (theme specific issue, but would love to see Zed adding some UI polish to custom dialogs). 