### PR TITLE
Add Markdown Preview Enhanced extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2218,6 +2218,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdown-preview-enhanced"]
+	path = extensions/markdown-preview-enhanced
+	url = https://github.com/harris1111/markdown-enhanced.git
+
 [submodule "extensions/markdown-snippets"]
 	path = extensions/markdown-snippets
 	url = https://github.com/bobbymannino/markdown-snippets-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2254,6 +2254,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-preview-enhanced]
+submodule = "extensions/markdown-preview-enhanced"
+version = "0.1.0"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.0.7"


### PR DESCRIPTION
## Summary

Adds the `markdown-preview-enhanced` extension to the Zed extension registry.

- Extension repo: https://github.com/harris1111/markdown-enhanced
- Version: `0.1.0`
- License: MIT at repository root
- Functionality: task-based external browser preview for saved Markdown files, powered by a local Node CLI server with rich copy and sanitized HTML export

## Validation

Source extension repository:
- `npm run lint` passed
- `npm run typecheck` passed
- `npm run build` passed
- `npm run test` passed
- `npm pack --dry-run` passed
- `npm run smoke:package` passed
- Local dev-extension/manual workflow: user confirmed it works

Registry repository:
- `pnpm sort-extensions` ran
- `pnpm build` passed
- `pnpm test` passed: 111 tests

## Notes

This first release intentionally uses an external browser preview because Zed does not provide VS Code-style webviews. Code chunk execution and public preview binding are disabled by default in `0.1.0`.