### PR TITLE
Add Markdown Preview Enhanced extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2218,6 +2218,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdown-preview-enhanced"]
+	path = extensions/markdown-preview-enhanced
+	url = https://github.com/aitan111121/markdown-enhanced.git
+
 [submodule "extensions/markdown-snippets"]
 	path = extensions/markdown-snippets
 	url = https://github.com/bobbymannino/markdown-snippets-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2254,6 +2254,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-preview-enhanced]
+submodule = "extensions/markdown-preview-enhanced"
+version = "0.1.0"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.0.7"


### PR DESCRIPTION
Adds the Markdown Preview Enhanced extension.

- Extension ID: markdown-preview-enhanced
- Version: 0.1.0
- Source repository: https://github.com/aitan111121/markdown-enhanced
- Submodule commit: 2affe5d

Validation:
- pnpm sort-extensions
- pnpm build
- pnpm test (111 passed)

This supersedes the earlier submission from the blocked account.