### PR TITLE
update: Tombi extension to version 0.2.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4160,7 +4160,7 @@ version = "0.1.0"
 [tombi]
 submodule = "extensions/tombi"
 path = "editors/zed"
-version = "0.2.4"
+version = "0.2.5"
 
 [toml]
 submodule = "extensions/toml"


### PR DESCRIPTION
Related: https://github.com/tombi-toml/tombi/issues/1824

I am unable to separate LSP and other language settings in the Zed extension, which has caused Tombi to consistently fail to launch in my remote development environment.

So, I will re-add the TOML configuration to the Tombi extension.
