### PR TITLE
Add grasp-code-architecture MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4685,3 +4685,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/grasp-code-architecture"]
+	path = extensions/grasp-code-architecture
+	url = https://github.com/ashfordeOU/grasp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4745,3 +4745,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[grasp-code-architecture]
+submodule = "extensions/grasp-code-architecture"
+version = "3.19.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4748,4 +4748,5 @@ version = "0.2.0"
 
 [grasp-code-architecture]
 submodule = "extensions/grasp-code-architecture"
+path = "zed-extension"
 version = "3.19.0"


### PR DESCRIPTION
Adds the **Grasp — Code Architecture** context server extension (v3.19.0).

- **Extension ID:** `grasp-code-architecture`
- **Repository:** https://github.com/ashfordeOU/grasp
- **npm package:** `grasp-mcp-server` (130 MCP tools)

### What it does
Dependency graph, health score, security scanner, and 130 MCP analysis tools for any codebase. Works with Claude Code, Cursor, Windsurf, and all MCP-compatible agents. No data leaves the user's machine.

### Checklist
- [x] Extension ID updated to `grasp-code-architecture`
- [x] Context server installed via `zed::npm_install_package` + `zed::node_binary_path()`
- [x] `context_server_configuration` implemented with installation instructions
- [x] `zed_extension_api = "0.7.0"`
- [x] Elastic License 2.0 `LICENSE` file included
- [x] `[context_servers.grasp-code-architecture]` section in `extension.toml`
- [x] Submodule pointer added with `path = "zed-extension"` (extension lives in subdirectory)

> @cla-bot check