### PR TITLE
Add astral-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -226,6 +226,10 @@
 	path = extensions/asteroid
 	url = https://github.com/webhooked/asteroid-zed
 
+[submodule "extensions/astral-theme"]
+	path = extensions/astral-theme
+	url = https://github.com/leofernandesbh/astral-zed-theme.git
+
 [submodule "extensions/astro"]
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -229,6 +229,10 @@ version = "0.1.0"
 submodule = "extensions/asteroid"
 version = "0.0.1"
 
+[astral-theme]
+submodule = "extensions/astral-theme"
+version = "0.1.0"
+
 [astro]
 submodule = "extensions/astro"
 version = "0.1.10"


### PR DESCRIPTION
Adds Astral Themes, a polished collection of balanced dark and light themes for Zed.

Themes included:
- Astral Eclipse
- Astral Luna
- Astral Solstice
- Astral Aura
- Astral Clair

Repository: https://github.com/leofernandesbh/astral-zed-theme

Tested locally with Install Dev Extension in Zed.