### PR TITLE
Add react-lain-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3374,6 +3374,10 @@
 	path = extensions/react-snippets-es7
 	url = https://github.com/shonebinu/zed-react-snippets.git
 
+[submodule "extensions/react-snippets-zed"]
+	path = extensions/react-snippets-zed
+	url = https://github.com/oldfarmer96/react-snippets-zed.git
+
 [submodule "extensions/react-type-kit-snippets"]
 	path = extensions/react-type-kit-snippets
 	url = https://github.com/MiguelMachado-dev/ReactTypeKit.git
@@ -4669,6 +4673,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/react-snippets-zed"]
-	path = extensions/react-snippets-zed
-	url = https://github.com/oldfarmer96/react-snippets-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4669,3 +4669,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/react-snippets-zed"]
+	path = extensions/react-snippets-zed
+	url = https://github.com/oldfarmer96/react-snippets-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3570,6 +3570,10 @@ version = "1.0.3"
 submodule = "extensions/rust-snippets"
 version = "0.0.4"
 
+[react-lain-snippets]
+submodule = "extensions/react-snippets-zed"
+version = "0.1.0"
+
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
 version = "1.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3416,6 +3416,10 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
+[react-lain-snippets]
+submodule = "extensions/react-snippets-zed"
+version = "0.1.0"
+
 [react-snippets]
 submodule = "extensions/react-snippets"
 version = "1.0.6"
@@ -3569,10 +3573,6 @@ version = "1.0.3"
 [rust-snippets]
 submodule = "extensions/rust-snippets"
 version = "0.0.4"
-
-[react-lain-snippets]
-submodule = "extensions/react-snippets-zed"
-version = "0.1.0"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"


### PR DESCRIPTION
Adds the `react-lain-snippets` extension — React snippets for TSX and JSX files without automatic imports.

Includes snippets for:
- `rafce` — React Arrow Function Component + export default
- `rfc` — React Functional Component + export default
- `us` — useState
- `ue` — useEffect

Supports `.tsx` (via `snippets/tsx.json`) and `.jsx` (via `snippets/javascript.json`).

Repository: https://github.com/oldfarmer96/react-snippets-zed