### PR TITLE
Add mojom language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2522,6 +2522,10 @@
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git
 
+[submodule "extensions/mojom"]
+	path = extensions/mojom
+	url = https://github.com/dsa28s/zed-mojom-language.git
+
 [submodule "extensions/molten-theme"]
 	path = extensions/molten-theme
 	url = https://github.com/vaqxai/zed-molten-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2561,6 +2561,10 @@ version = "0.1.9"
 submodule = "extensions/modus-themes"
 version = "0.1.8"
 
+[mojom]
+submodule = "extensions/mojom"
+version = "1.4.0"
+
 [molten-theme]
 submodule = "extensions/molten-theme"
 version = "1.0.0"


### PR DESCRIPTION
### Summary
Adds `zed-mojom-language` extension to the Zed extensions registry.

- [x] Registers the extensions/zed-mojom-language submodule
- [x] Adds the extension entry to extensions.toml
