### PR TITLE
Add Hoon language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1694,6 +1694,10 @@
 	path = extensions/hocon
 	url = https://github.com/tomatitito/hocon-zed-extension.git
 
+[submodule "extensions/hoon"]
+	path = extensions/hoon
+	url = https://github.com/TisaneFruitRouge/hoon-zed.git
+
 [submodule "extensions/horizon"]
 	path = extensions/horizon
 	url = https://github.com/ayn2op/zed-horizon.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1720,6 +1720,10 @@ version = "0.0.1"
 submodule = "extensions/hocon"
 version = "0.2.0"
 
+[hoon]
+submodule = "extensions/hoon"
+version = "0.1.0"
+
 [horizon]
 submodule = "extensions/horizon"
 version = "0.0.1"


### PR DESCRIPTION
Adds a language extension for [Hoon](https://urbit.org), the language used by Urbit.

- Extension ID: `hoon`
- Repository: https://github.com/TisaneFruitRouge/hoon-zed
- License: MIT

### Features
- `.hoon` file association
- `::` line comments
- Bracket matching / autoclose for `{}`, `[]`, `()`, `""`, `''`
- Tree-sitter syntax highlighting via [`urbit-pilled/tree-sitter-hoon`](https://github.com/urbit-pilled/tree-sitter-hoon)

### Notes
- Ported from the existing [`famousj/hoon-vscode`](https://github.com/famousj/hoon-vscode) VSCode extension. The VSCode extension uses TextMate grammar; this Zed extension uses an existing Tree-sitter grammar that fits Zed's architecture.
- No language server is bundled. The `hoon-language-server` used by the VSCode extension talks to a running Urbit ship over HTTP rather than stdio, so it does not fit Zed's LSP launch model.
- Tested locally as a dev extension on `.hoon` files.