### PR TITLE
Add wasm-decompile language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4466,6 +4466,10 @@
 	path = extensions/warplabs
 	url = https://github.com/wp-labs/zed-warplabs.git
 
+[submodule "extensions/wasm-decompile"]
+	path = extensions/wasm-decompile
+	url = https://git.sr.ht/~applejag/zed-wasm-decompile
+
 [submodule "extensions/wat"]
 	path = extensions/wat
 	url = https://github.com/g-plane/zed-wasm.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4528,6 +4528,10 @@ version = "0.1.1"
 submodule = "extensions/warplabs"
 version = "0.14.0"
 
+[wasm-decompile]
+submodule = "extensions/wasm-decompile"
+version = "1.0.0"
+
 [wat]
 submodule = "extensions/wat"
 version = "0.2.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5383,7 +5383,7 @@ version = "0.17.0"
 
 [wasm-decompile]
 submodule = "extensions/wasm-decompile"
-version = "1.0.0"
+version = "0.1.0"
 
 [wat]
 submodule = "extensions/wat"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: true
+  esbuild: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,0 @@
-allowBuilds:
-  core-js: true
-  esbuild: true


### PR DESCRIPTION
New extension, for a new tree-sitter grammar: https://git.sr.ht/~applejag/zed-wasm-decompile

Provides syntax highlighting for the WebAssembly Binary Toolkit wasm-decompile pseudo-language https://github.com/WebAssembly/wabt/blob/HEAD@%7B2026-05-10T00:09:45Z%7D/docs/decompiler.md
