### PR TITLE
Add zed-jetbrains-air-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4598,6 +4598,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-jetbrains-air-theme"]
+	path = extensions/zed-jetbrains-air-theme
+	url = https://github.com/ArjunKhunti/zed-jetbrains-air-theme.git
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4658,6 +4658,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zed-jetbrains-air-theme]
+submodule = "extensions/zed-jetbrains-air-theme"
+version = "0.0.1"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"


### PR DESCRIPTION
This PR adds the `zed-jetbrains-air-theme` extension to the registry. 

It brings a clean, JetBrains-inspired aesthetic to Zed, designed for high readability and a familiar developer experience.

### Checks

- [x] The `id` in `extension.toml` matches the repository name.
- [x] The `version` in `extension.toml` matches the version in the registry manifest.
- [x] The repository includes a valid Open Source License.
- [x] The extension has been tested locally using `zed: Install Dev Extension` and loads successfully.
- [x] `pnpm sort-extensions` has been run to ensure alphabetical ordering in `extensions.toml` and `.gitmodules`.
