### PR TITLE
Add Atmos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,10 @@
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
 
+[submodule "extensions/atmos"]
+	path = extensions/atmos
+	url = https://github.com/jgibbarduk/zed-atmos-extension.git
+
 [submodule "extensions/atom-one-theme"]
 	path = extensions/atom-one-theme
 	url = https://github.com/Stelath/zed-atom-one-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -241,6 +241,10 @@ version = "0.1.0"
 submodule = "extensions/astro"
 version = "0.1.10"
 
+[atmos]
+submodule = "extensions/atmos"
+version = "0.3.0"
+
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

This PR adds the Atmos (https://atmos.tools) extension to the Zed marketplace.

## Extension details

- **Name**: Atmos
- **ID**: `atmos`
- **Version**: 0.3.0
- **Repository**: https://github.com/jgibbarduk/zed-atmos-extension

## Features

- Go-to-definition for imports, component names, `metadata.component`, `metadata.inherits`, and `!terraform.state` references
- Hover tooltips showing resolved imports, accumulated variables, component definitions, and computed stack names from `atmos.yaml` `name_template`
- Go template expression resolution (`{{ .vars.namespace }}`, `{{ .atmos_component }}`, etc.)
- Rename support for component references across the workspace
- Code actions to generate component scaffolds for missing components
- Completion suggestions for dependency component names, template variables, and import paths
- 20+ diagnostics including unresolvable imports, duplicate components, missing dependencies, unquoted versions, circular imports, invalid backend types, and abstract components with no inheritors

## Language server

The extension bundles a Go-based LSP bridge (`atmos-lsp-bridge`) that handles all LSP methods directly and proxies unsupported methods to the downstream `atmos lsp start --transport stdio` process.

## Checklist

- [x] Tested locally as a dev extension
- [x] Valid open-source LICENSE (MIT)
- [x] No `zed` / `Zed` / `extension` in ID or name
- [x] Extension ID valid (`^[a-z0-9\-]+$`)
- [x] Grammar repos use HTTPS
- [x] `extension.wasm` not committed to git
- [x] `Cargo.lock` committed
- [x] CI workflow exists and passes
- [x] README covers features, install, requirements
- [x] `extension.toml` has all required fields
- [x] Extension code implements `Extension` trait
- [x] Binary is NOT bundled inside extension WASM
- [x] WASM target updated to `wasm32-wasip2`