### PR TITLE
Add Palette Masters theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3022,10 +3022,6 @@
 	path = extensions/palenight
 	url = https://github.com/alanmontgomery/palenight-zed.git
 
-[submodule "extensions/palette-masters"]
-	path = extensions/palette-masters
-	url = https://github.com/regnull/palette-masters-zed.git
-
 [submodule "extensions/panda-plus-theme"]
 	path = extensions/panda-plus-theme
 	url = https://github.com/lucianoratamero/panda-plus-theme-zed.git
@@ -4685,3 +4681,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/palette-masters-theme"]
+	path = extensions/palette-masters-theme
+	url = https://github.com/regnull/palette-masters-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3022,6 +3022,10 @@
 	path = extensions/palenight
 	url = https://github.com/alanmontgomery/palenight-zed.git
 
+[submodule "extensions/palette-masters"]
+	path = extensions/palette-masters
+	url = https://github.com/regnull/palette-masters-zed.git
+
 [submodule "extensions/panda-plus-theme"]
 	path = extensions/panda-plus-theme
 	url = https://github.com/lucianoratamero/panda-plus-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3510,6 +3510,10 @@
 	path = extensions/palenight
 	url = https://github.com/alanmontgomery/palenight-zed.git
 
+[submodule "extensions/palette-masters-theme"]
+	path = extensions/palette-masters-theme
+	url = https://github.com/regnull/palette-masters-zed.git
+
 [submodule "extensions/panache-language-server"]
 	path = extensions/panache-language-server
 	url = https://github.com/jolars/panache.git
@@ -5409,6 +5413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/palette-masters-theme"]
-	path = extensions/palette-masters-theme
-	url = https://github.com/regnull/palette-masters-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3064,8 +3064,8 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
-[palette-masters]
-submodule = "extensions/palette-masters"
+[palette-masters-theme]
+submodule = "extensions/palette-masters-theme"
 version = "0.0.1"
 
 [panda-plus-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3064,6 +3064,10 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
+[palette-masters]
+submodule = "extensions/palette-masters"
+version = "0.0.1"
+
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3570,6 +3570,7 @@ version = "0.0.1"
 [palette-masters-theme]
 submodule = "extensions/palette-masters-theme"
 version = "0.0.1"
+
 [panache-language-server]
 submodule = "extensions/panache-language-server"
 path = "editors/zed"


### PR DESCRIPTION
Palette Masters themes are derived from palettes used by famous painters. Includes 23 Zed editor themes, each one has dark and light variants.

Each theme uses the artist's actual palette colors for syntax highlighting, UI chrome, and terminal colors. The dark themes use the palette's darkest tones as backgrounds; the light themes blend the lightest palette color toward white, so every artist has a distinctly tinted background.

Uses palette information from [paletteinspiration.com](https://paletteinspiration.com)