### PR TITLE
Add Corn language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -758,6 +758,10 @@
 	path = extensions/cooklang
 	url = https://github.com/hugginsio/zed-cooklang.git
 
+[submodule "extensions/corn"]
+	path = extensions/corn
+	url = https://github.com/corn-config/corn-zed.git
+
 [submodule "extensions/corust-agent"]
 	path = extensions/corust-agent
 	url = https://github.com/Corust-ai/corust-agent-release.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -768,6 +768,10 @@ version = "2.0.1"
 submodule = "extensions/cooklang"
 version = "1.3.3"
 
+[corn]
+submodule = "extensions/corn"
+version = "0.1.0"
+
 [corust-agent]
 submodule = "extensions/corust-agent"
 version = "0.4.2"


### PR DESCRIPTION
Adds support for [Corn](https://cornlang.dev/), a simple and pain-free configuration language.

Currently just syntax highlighting, as Corn does not have an LSP yet.

The extension has been tested with the [Corn test-suite](https://github.com/corn-config/test-suite) locally.

Extension Repo: [corn-config/corn-zed](https://github.com/corn-config/corn-zed)
Grammar Repo: [corn-config/tree-sitter-corn](https://github.com/corn-config/tree-sitter-corn)