### PR TITLE
Add ejentum context server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1102,6 +1102,10 @@
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
 
+[submodule "extensions/ejentum-mcp"]
+	path = extensions/ejentum-mcp
+	url = https://github.com/ejentum/zed-ejentum-mcp.git
+
 [submodule "extensions/ejs"]
 	path = extensions/ejs
 	url = https://github.com/dangh/zed-ejs.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1120,7 +1120,7 @@ version = "0.1.1"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
-version = "0.1.0"
+version = "0.1.1"
 
 [ejs]
 submodule = "extensions/ejs"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1118,6 +1118,10 @@ version = "0.1.0"
 submodule = "extensions/eiffel-theme"
 version = "0.1.1"
 
+[ejentum-mcp]
+submodule = "extensions/ejentum-mcp"
+version = "0.1.0"
+
 [ejs]
 submodule = "extensions/ejs"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1120,7 +1120,7 @@ version = "0.1.1"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
-version = "0.1.1"
+version = "0.2.0"
 
 [ejs]
 submodule = "extensions/ejs"


### PR DESCRIPTION
## What

Adds [`ejentum-mcp v0.1.0`](https://github.com/ejentum/zed-ejentum-mcp), a Zed context server extension that wraps the [Ejentum Reasoning Harness MCP server](https://github.com/ejentum/ejentum-mcp).

## Files changed

- `extensions.toml`: new entry under \[ejentum-mcp\] (alphabetical between eiffel-theme and ejs)
- `.gitmodules`: matching submodule entry (alphabetical)
- `extensions/ejentum-mcp`: submodule pointing at v0.1.0 tag

## What the extension does

Exposes four MCP tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`). Each call returns a structured cognitive scaffold (named failure pattern, executable procedure, suppression vectors that block the obvious shortcut, falsification test for self-verification) the assistant ingests before generating, addressing attention decay, sycophantic collapse, hallucination drift, and reasoning decay.

The extension follows the `postgres-context-server` pattern: `npm_package_*` for installing the underlying `ejentum-mcp` npm package, plus a single `ejentum_api_key` setting via `ContextServerSettings`. Free tier (100 calls, no card) at https://ejentum.com/pricing.

## Local testing

- Built locally for `wasm32-wasip1` (368KB Wasm artifact, clean build)
- Installed as a dev extension in Zed; appears in Settings under "Model Context Protocol (MCP) Servers" with the configuration UI generated from the `JsonSchema` derive on `EjentumSettings`
- Manual config + toggle activation tested

## Compliance

- Extension repo (https://github.com/ejentum/zed-ejentum-mcp) is MIT-licensed, publicly accessible, with `extension.toml` matching the registry entry
- v0.1.0 tag pushed and signed (SSH signature verified by GitHub)
- Catalog commit signed
- `extensions.toml` and `.gitmodules` both alphabetically sorted around the new entry; verified with `awk` ordering check
- Schema_version 1; minimum required `extension.toml` fields present
- No other extension provides this functionality (first cognitive-scaffold MCP context server in the Zed registry)

Maintainer is me; happy to address review feedback.