### PR TITLE
Bump laravel to v0.1.16

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2053,7 +2053,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.15"
+version = "0.1.16"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.1.16.

Release notes: https://github.com/GeneaLabs/zed-laravel/releases/tag/0.1.16