### PR TITLE
Update design-tokens to v0.3.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -999,7 +999,7 @@ version = "1.0.1"
 [design-tokens]
 submodule = "extensions/design-tokens"
 path = "extensions/zed"
-version = "0.3.0"
+version = "0.3.1"
 
 [desktop]
 submodule = "extensions/desktop"


### PR DESCRIPTION
Updates design-tokens extension to [version 0.3.1](https://github.com/bennypowers/asimonim/releases/tag/v0.3.1).