### PR TITLE
Add Rux language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3530,6 +3530,10 @@
 	path = extensions/rust-snippets
 	url = https://github.com/bobbymannino/rust-snippets-for-zed.git
 
+[submodule "extensions/rux"]
+	path = extensions/rux
+	url = https://github.com/rux-lang/Zed.git
+
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3582,6 +3582,10 @@ version = "1.0.3"
 submodule = "extensions/rust-snippets"
 version = "0.0.4"
 
+[rux]
+submodule = "extensions/rux"
+version = "0.1.0"
+
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
 version = "1.0.3"


### PR DESCRIPTION
Adds the [Rux](https://rux-lang.dev) language extension for [Zed](https://zed.dev). This extension provides syntax highlighting and language configuration for `.rux` files using the Tree-sitter grammar from `rux-lang/Zed`. Tested locally in Zed as a dev extension with sample `.rux` files.

Initial version: `0.1.0`
Repository: https://github.com/rux-lang/Zed
License: MIT
