### PR TITLE
Add Mac theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2138,6 +2138,10 @@
 	path = extensions/lydia
 	url = https://github.com/dimitrisnl/lydia-zed-theme
 
+[submodule "extensions/mac-theme"]
+	path = extensions/mac-theme
+	url = https://github.com/abhishek-bhatkar/mac-zed-theme.git
+
 [submodule "extensions/mach"]
 	path = extensions/mach
 	url = https://github.com/octalide/mach-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2174,6 +2174,10 @@ version = "0.6.1"
 submodule = "extensions/lydia"
 version = "0.0.4"
 
+[mac-theme]
+submodule = "extensions/mac-theme"
+version = "0.0.1"
+
 [mach]
 submodule = "extensions/mach"
 version = "0.1.0"


### PR DESCRIPTION
Adds Mac Theme, a warm neutral light and dark theme extension for Zed.\n\nValidation run:\n- scripts/validate.sh in mac-zed-theme\n- jq empty extensions/mac-theme/themes/mac-theme.json\n- node src/sort-extensions.js\n- npm run build\n- npm run test