### PR TITLE
Update oso to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3030,7 +3030,7 @@ version = "0.2.0"
 
 [oso]
 submodule = "extensions/oso"
-version = "0.1.1"
+version = "0.2.0"
 
 [outrun]
 submodule = "extensions/outrun"


### PR DESCRIPTION
This release:

- Fully manages the LSP binary 
- Allows for runnable tests
- Improves syntax highlighting for test assertions and nested expressions
- Updates the tree-sitter grammar