### PR TITLE
Add SWLS extension (Turtle, TriG, SPARQL, JSON-LD)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4681,3 +4681,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/swls"]
+	path = extensions/swls
+	url = https://github.com/SemanticWebLanguageServer/swls-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3957,6 +3957,10 @@ version = "0.0.9"
 submodule = "extensions/sway"
 version = "0.1.0"
 
+[swls]
+submodule = "extensions/swls"
+version = "0.0.1"
+
 [sweet-dracula]
 submodule = "extensions/sweet-dracula"
 version = "0.1.0"


### PR DESCRIPTION
Adds the Semantic Web Language Server (SWLS) extension, providing language support for Turtle, TriG, SPARQL, and JSON-LD.

Repository: https://github.com/SemanticWebLanguageServer/swls-zed