### PR TITLE
Add Stata language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3810,6 +3810,10 @@
 	path = extensions/starlark
 	url = https://github.com/zaucy/zed-starlark.git
 
+[submodule "extensions/stata"]
+	path = extensions/stata
+	url = https://github.com/jbearak/zed-stata.git
+
 [submodule "extensions/statamic-antlers"]
 	path = extensions/statamic-antlers
 	url = https://github.com/mynetx/zed-statamic-antlers.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3864,6 +3864,10 @@ version = "1.1.0"
 submodule = "extensions/starlark"
 version = "0.4.1"
 
+[stata]
+submodule = "extensions/stata"
+version = "0.5.3"
+
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4140,7 +4140,7 @@ version = "0.4.1"
 
 [stata]
 submodule = "extensions/stata"
-version = "0.5.3"
+version = "0.5.6"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"


### PR DESCRIPTION
Adds the `stata` extension to the Zed extension registry.

This is a clean resubmission of #4585, which I closed after several months without a final decision so I could open a fresh PR against the latest `zed-stata` release.