### PR TITLE
Update aptos-move to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -159,7 +159,7 @@ version = "0.0.1"
 
 [aptos-move]
 submodule = "extensions/aptos-move"
-version = "0.0.1"
+version = "0.0.2"
 
 [aquaflow-theme]
 submodule = "extensions/aquaflow-theme"


### PR DESCRIPTION
## Summary
- update the aptos-move extension registry version to 0.0.2
- bump the aptos-move submodule to 0xbe1/aptos-move-zed-extension@4ceeee9
- include the TOML grammar needed by the new Move.toml language support

## Validation
- pnpm sort-extensions
- pnpm build
- pnpm test

## Notes
- Local `pnpm package-extensions aptos-move` is blocked because this checkout does not include a runnable `./zed-extension` packaging binary for macOS; the previous CI failure was reproduced from logs and fixed by adding the missing TOML grammar declaration.