### PR TITLE
Add Yulang language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4586,6 +4586,10 @@
 	path = extensions/yugen
 	url = https://github.com/frank-vdm/yugen
 
+[submodule "extensions/yulang"]
+	path = extensions/yulang
+	url = https://github.com/momota1029/yulang-zed.git
+
 [submodule "extensions/zabby"]
 	path = extensions/zabby
 	url = https://github.com/arne-fuchs/zabby

--- a/extensions.toml
+++ b/extensions.toml
@@ -4650,6 +4650,10 @@ version = "1.2.1"
 submodule = "extensions/yugen"
 version = "0.0.1"
 
+[yulang]
+submodule = "extensions/yulang"
+version = "0.0.3"
+
 [zabby]
 submodule = "extensions/zabby"
 version = "0.0.3"


### PR DESCRIPTION
Adds a highlighting-only Yulang language extension.

The extension uses the tree-sitter-yulang grammar and intentionally does not start a language server yet.

Checks run locally:
- npm test
- npm run build
