### PR TITLE
Add chalice theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -582,8 +582,8 @@
 	path = extensions/chai-theme
 	url = https://github.com/rushabhcodes/zed-chai-theme
 
-[submodule "extensions/chalice"]
-	path = extensions/chalice
+[submodule "extensions/chalice-theme"]
+	path = extensions/chalice-theme
 	url = https://github.com/huangkairan/chalice-theme-zed.git
 
 [submodule "extensions/chanterelle"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -582,6 +582,10 @@
 	path = extensions/chai-theme
 	url = https://github.com/rushabhcodes/zed-chai-theme
 
+[submodule "extensions/chalice"]
+	path = extensions/chalice
+	url = https://github.com/huangkairan/chalice-theme-zed.git
+
 [submodule "extensions/chanterelle"]
 	path = extensions/chanterelle
 	url = https://github.com/steffenhaug/chanterelle-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -589,9 +589,9 @@ version = "0.2.12"
 submodule = "extensions/chai-theme"
 version = "0.0.2"
 
-[chalice]
-submodule = "extensions/chalice"
-version = "0.1.0"
+[chalice-theme]
+submodule = "extensions/chalice-theme"
+version = "0.1.1"
 
 [chanterelle]
 submodule = "extensions/chanterelle"

--- a/extensions.toml
+++ b/extensions.toml
@@ -589,6 +589,10 @@ version = "0.2.12"
 submodule = "extensions/chai-theme"
 version = "0.0.2"
 
+[chalice]
+submodule = "extensions/chalice"
+version = "0.1.0"
+
 [chanterelle]
 submodule = "extensions/chanterelle"
 version = "0.0.1"


### PR DESCRIPTION
Adds **Chalice**, a minimalistic dark/light color theme port of [Artem Laman's Chalice for VSCode](https://github.com/artlaman/chalice-color-theme) (MIT-licensed) to Zed.

## What's in this PR

- New submodule `extensions/chalice` pinned to v0.1.0 (`huangkairan/chalice-theme-zed`)
- New entry in `extensions.toml`

## Variants

- **Chalice Dark** — low-contrast teal / green / violet on near-black
- **Chalice Light** — earthy browns / blues on warm off-white

Chalice highlights only strings, numbers, comments, and global definitions; everything else uses the editor foreground (no italics, no bold). The goal is to reduce visual noise.

## Checks

- [x] Repository contains an MIT `LICENSE` file
- [x] `pnpm sort-extensions` run
- [x] `pnpm test` passes locally (111/111)
- [x] Local validation script passes for both theme JSON files
- [x] Source repo tagged `v0.1.0`