### PR TITLE
Add answer-set-programming language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -130,6 +130,10 @@
 	path = extensions/ansible
 	url = https://github.com/kartikvashistha/zed-ansible
 
+[submodule "extensions/answer-set-programming"]
+	path = extensions/answer-set-programming
+	url = https://github.com/tlyphed/zed-answer-set-programming
+
 [submodule "extensions/anthracite-theme"]
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -132,6 +132,10 @@ version = "21.0.0"
 submodule = "extensions/ansible"
 version = "1.0.0"
 
+[answer-set-programming]
+submodule = "extensions/answer-set-programming"
+version = "0.1.0"
+
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"


### PR DESCRIPTION
This adds basic language support for Answer Set Programming using the clingo tree sitter grammar.

License is MIT as included in the [extension repo](https://github.com/tlyphed/zed-answer-set-programming).

`pnpm sort-extensions` was run to sort the relevant files

