### PR TITLE
Add GitFlowGraph 0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4685,3 +4685,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/gitflowgraph"]
+	path = extensions/gitflowgraph
+	url = https://github.com/DevEloLin/GitFlowGraph.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1478,6 +1478,10 @@ version = "1.1.0"
 submodule = "extensions/github-theme"
 version = "0.1.8"
 
+[gitflowgraph]
+submodule = "extensions/gitflowgraph"
+version = "0.1.0"
+
 [gitignore-templates]
 submodule = "extensions/gitignore-templates"
 version = "2025.08.0"


### PR DESCRIPTION
## Add GitFlowGraph 0.1.0

**Repository:** https://github.com/DevEloLin/GitFlowGraph
**Tag pinned:** [v0.1.0](https://github.com/DevEloLin/GitFlowGraph/releases/tag/v0.1.0)

GitFlowGraph is a modern Git workspace for Zed — lane-aware commit graph, semantic diff for structured formats, release analytics, and a rich Assistant-panel surface — without leaving the editor.

### What it does

**Editor-side integration (LSP)**
- `textDocument/hover` — git blame markdown for the line under the cursor (commit SHA, author, date, summary, link)
- `textDocument/inlayHint` — end-of-line ghost text per blame hunk ("3d ago · Alice — feat: …"); full markdown tooltip resolved lazily on hover
- `textDocument/codeLens` — file-level lenses linking to File History and Smart Diff

Attached to 36 common source languages out of the box: Rust, TypeScript, TSX, JavaScript, JSX, Python, Go, Ruby, PHP, Java, Kotlin, Swift, C, C++, C#, Objective-C, Markdown, YAML, JSON, JSONC, TOML, HTML, CSS, SCSS, Vue, Svelte, Shell Script, Bash, Fish, Lua, Dockerfile, Makefile, SQL, Terraform, HCL, Plain Text.

**Assistant-panel surface (slash commands)**

28 commands covering read views and git operations:

| Category | Commands |
|---|---|
| Overview | `/gitflowgraph`, `/gitflowgraph-help` |
| Read | `/gitflowgraph-status`, `-graph [n]`, `-branches`, `-tags`, `-worktrees`, `-license`, `-remotes`, `-credentials` |
| Range / release | `-diff <range>`, `-changelog <range>`, `-risk <range>`, `-launchpad <range>`, `-velocity`, `-file-history <path>` |
| Write | `-checkout <ref>`, `-cherry-pick <sha>`, `-revert <sha>`, `-merge <branch>`, `-reset <mode> <sha>`, `-fetch [remote]`, `-push <branch> [remote]` |
| Refs | `-create-branch`, `-delete-branch`, `-create-tag`, `-delete-tag`, `-trial-start` |

Slash-command argument completion is wired for refs (branches + tags) and reset modes.

**Browser companion**

The runtime also serves a React workspace at `http://localhost:<port>` for users who want the full visual experience:

- **Git Graph** — virtualised lane-aware DAG (handles 5,000+ commits smoothly), branch / tag / HEAD annotations, path / branch / date filters, right-click context menu
- **Smart Diff** — unified + side-by-side toggle, semantic diff for YAML / JSON / Terraform (shows what changed in *meaning*, not just text), working-tree / staged comparisons including untracked files
- **Release Workspace** — compare refs (ahead/behind + commit list), auto-generated Markdown changelog, release risk score with per-file factors, pre-flight checklist, Hotfix Wizard, File Timeline scoped to a release window
- **Multi-Repo** — compare HEAD across multiple repos in one screen
- **Workspace Profiles** — save / restore filter, repo set, environment compare config
- **Worktrees** — list / add / remove git worktrees
- **Remotes & Credentials** — multi-platform (GitHub / GitLab / Azure DevOps / Gitea / self-hosted GitLab) with HMAC-signed credential store
- **Environments** — compare deployment-target refs side-by-side

### Architecture

```
Zed editor ──stdio(JSON-RPC)──┐
                               ├──► gitflowgraph runtime
Browser ───HTTP(localhost)────┘    (Rust + axum + libgit2 + tokio)
                                    │
                                    └──► Embedded React + TanStack Query frontend
```

Single-binary runtime (~15 MB) bundles the HTTP API, LSP server, and the React frontend (via `include_dir!`). No external services required for local use.

### Installation flow

1. User installs the extension from this marketplace.
2. On opening a Git project for the first time, the extension downloads the platform-matched runtime binary from the [release on GitHub](https://github.com/DevEloLin/GitFlowGraph/releases/tag/v0.1.0) (~6 MB compressed, ~15 MB extracted) into the extension work directory.
3. LSP starts; binary stays cached. Subsequent opens reuse the cached binary.

This mirrors how rust-analyzer, terraform-ls, and similar extensions handle their backing tools.

### Platforms shipped

- macOS arm64 (Apple Silicon)
- Linux x86_64
- Linux arm64
- Windows x86_64

### Security model

- All persistent state is HMAC-signed with a machine-derived key (license, trial state, credentials, time-guard checkpoints)
- Atomic file writes (tempfile + rename) for crash resilience
- URI containment-checked before any filesystem access in the LSP layer; rejects `..` traversal, NUL bytes, fixes percent-decoding boundaries
- Git PATs never enter the child process' environment — written to `0o600` sidecar files and consumed via `GIT_ASKPASS`
- CORS allow-list restricts the HTTP API to the embedded UI (`localhost:<self_port>`); a dev-only mode opens the Vite dev origin
- 81 unit tests + 52-assertion edge-case suite + 24-assertion license/security suite + 6-assertion LSP smoke suite all green

### Repository structure

- `src/lib.rs` — extension entrypoint (WASM): `language_server_command`, 28 slash command handlers, argument autocompletion
- `extension.toml` — language attachment list, slash command registrations
- `docs/` — landing page (https://develolin.github.io/GitFlowGraph)
- `README.md` — user-facing intro

### Why this extension

Zed users currently switch to a browser / IDE / GitKraken for everything past `git status` + manual `git log`. GitFlowGraph keeps the visual graph, semantic diff, release analytics, and routine git operations inside the editor's flow — hover for blame, slash commands for actions, browser tab for the full visual workspace.

---

Tested on macOS arm64 with Zed 1.1.7. Happy to address any review feedback — feel free to open issues on the extension repo or comment here.
