### PR TITLE
Add Mdias OLED theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2446,6 +2446,10 @@
 	path = extensions/mcp-server-webflow
 	url = https://github.com/LoamStudios/zed-mcp-server-webflow.git
 
+[submodule "extensions/mdias-oled-theme"]
+	path = extensions/mdias-oled-theme
+	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git
+
 [submodule "extensions/mdx"]
 	path = extensions/mdx
 	url = https://github.com/srazzak/zed-mdx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2483,6 +2483,10 @@ version = "0.2.1"
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"
 
+[mdias-oled-theme]
+submodule = "extensions/mdias-oled-theme"
+version = "0.1.0"
+
 [mdx]
 submodule = "extensions/mdx"
 version = "0.4.0"


### PR DESCRIPTION
## Mdias OLED

OLED-friendly Zed theme inspired by vaporwave aesthetics. Pure black `#000000` background, marine teal primary, vibrant green-cyan accent, hot pink highlights, soft gray text, italic comments.

This is the Zed counterpart to [opencode-vaporware-oled-theme](https://github.com/mcdays94/opencode-vaporware-oled-theme) so both editors share the same color vocabulary.

## Palette

| Role | Hex |
|------|-----|
| Background | `#000000` |
| Foreground | `#d4d4d4` |
| Primary (strings, success) | `#56b6c2` (marine teal) |
| Accent (types, links, info) | `#00d9a0` (vibrant green-cyan) |
| Highlight (warnings, numbers, headings) | `#ff2094` (hot pink) |
| Comments | `#5c6370` italic |
| Keywords | `#c678dd` magenta |
| Functions, tags | `#61afef` blue |
| Properties, variables, errors | `#e06c75` soft red |

## Pre-flight

- [x] Extension ID is unique and suffixed with `-theme`
- [x] No `zed` / `Zed` / `extension` in ID
- [x] License is MIT, at root of extension repo
- [x] `extension.toml` has all required fields (`id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`)
- [x] Theme JSON adheres to `https://zed.dev/schema/themes/v0.2.0.json`
- [x] Tested locally in Zed
- [x] `extensions.toml` and `.gitmodules` sorted via `node src/sort-extensions.js`

Source: https://github.com/mcdays94/zed-vaporware-oled-theme