### PR TITLE
Add remix-min-darker theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3430,6 +3430,10 @@
 	path = extensions/remedy-theme
 	url = https://github.com/andrewRCr/zed-remedy-theme.git
 
+[submodule "extensions/remix-min-darker"]
+	path = extensions/remix-min-darker
+	url = https://github.com/FernaandoJr/remix-min-darker-zed.git
+
 [submodule "extensions/replicant"]
 	path = extensions/replicant
 	url = https://github.com/pierrenel/replicant.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3480,6 +3480,10 @@ version = "0.0.5"
 submodule = "extensions/remedy-theme"
 version = "0.2.0"
 
+[remix-min-darker]
+submodule = "extensions/remix-min-darker"
+version = "0.0.1"
+
 [replicant]
 submodule = "extensions/replicant"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds the **Remix Min Darker** theme as a new extension ([FernaandoJr/remix-min-darker-zed](https://github.com/FernaandoJr/remix-min-darker-zed)).

## Checklist

- [x] Extension tested locally as a dev extension
- [x] Unique extension ID: `remix-min-darker`
- [x] `extension.toml` includes required fields and correct `repository` URL
- [x] MIT `LICENSE` at repository root
- [x] Submodule uses HTTPS URL
- [x] Ran `pnpm sort-extensions`

## Extension details

- **Kind:** theme only (`themes/remix-min-darker.json`)
- **Version:** `0.0.1` (matches `extension.toml` at pinned submodule commit)