### PR TITLE
Add Solarized Osaka Deep theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4685,3 +4685,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/solarized-osaka-theme"]
+	path = extensions/solarized-osaka-theme
+	url = https://github.com/mauriciord/zed-solarized-osaka-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3780,6 +3780,10 @@ version = "0.2.0"
 submodule = "extensions/solarized-fp"
 version = "0.0.1"
 
+[solarized-osaka-theme]
+submodule = "extensions/solarized-osaka-theme"
+version = "0.0.1"
+
 [solid-typescript-snippets]
 submodule = "extensions/solid-typescript-snippets"
 version = "0.1.0"


### PR DESCRIPTION
## Solarized Osaka Deep

Adds a new dark theme inspired by [craftzdog/solarized-osaka.nvim](https://github.com/craftzdog/solarized-osaka.nvim), based on Ethan Schoonover's [Solarized](https://ethanschoonover.com/solarized/) palette with deeper, more saturated background tones.

Renamed from `solarized-osaka-theme` to `solarized-osaka-deep-theme` because upstream already merged a different `solarized-osaka-theme` extension.

### Highlights

- Deep teal backgrounds (`#0f1419` editor, `#002b36` surfaces)
- Solarized accent palette: cyan strings, blue functions/properties, yellow types, green keywords/tags
- Italic comments and control-flow keywords
- High-contrast red caret (`#ff0000ca`) for visibility against the dark background
- Full Solarized ANSI terminal palette

### Repository

https://github.com/mauriciord/zed-solarized-osaka-theme

### Checklist

- [x] Extension ID ends with `-theme`
- [x] `extension.toml` schema_version 1, version 0.0.1
- [x] MIT LICENSE at repository root
- [x] No "zed" / "Zed" in the ID or name
- [x] `extensions.toml` and `.gitmodules` re-sorted alphabetically
- [x] Tested locally as a dev extension