### PR TITLE
Add Bundle Size

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -498,6 +498,10 @@
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git
 
+[submodule "extensions/bundle-size"]
+	path = extensions/bundle-size
+	url = https://github.com/Randagio13/zed-bundle-size.git
+
 [submodule "extensions/c3"]
 	path = extensions/c3
 	url = https://github.com/AineeJames/c3-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -504,6 +504,10 @@ path = "extension/zed"
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"
 
+[bundle-size]
+submodule = "extensions/bundle-size"
+version = "0.1.0"
+
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"


### PR DESCRIPTION
## Bundle Size

Displays the minified + gzipped size of npm packages inline in JavaScript and TypeScript import statements via LSP inlay hints and hover cards.

**Features:**
- ⚡ Inline inlay hints — shows `12.3 kB (4.1 kB gzipped)` after each import
- �� Hover card — detailed per-module breakdown table on hover
- 🚀 esbuild-powered — fast, in-memory bundling with no file writing
- 📦 Smart exclusions — peer dependencies and Node.js builtins excluded automatically

**Supported languages:** JavaScript, TypeScript, JSX, TSX

**Tested:** Installed and validated locally as a dev extension in Zed.

**Checklist:**
- [x] `pnpm sort-extensions` run — `extensions.toml` and `.gitmodules` are sorted
- [x] Extension has a `LICENSE` file (MIT)
- [x] Extension ID, name, and version pass validation rules