### PR TITLE
Add build2 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -494,6 +494,10 @@
 	path = extensions/bugstalker-dap
 	url = https://github.com/godzie44/BugStalker.git
 
+[submodule "extensions/build2"]
+	path = extensions/build2
+	url = https://codeberg.org/wreedb/zed-build2.git
+
 [submodule "extensions/bun-docs-mcp"]
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -500,6 +500,10 @@ submodule = "extensions/bugstalker-dap"
 version = "0.1.0"
 path = "extension/zed"
 
+[build2]
+submodule = "extensions/build2"
+version = "0.1.0"
+
 [bun-docs-mcp]
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -607,12 +607,12 @@ submodule = "extensions/bugstalker-dap"
 version = "0.1.0"
 path = "extension/zed"
 
-[buisson-theme]
-submodule = "extensions/buisson-theme"
-version = "0.1.0"
-
 [build2]
 submodule = "extensions/build2"
+version = "0.1.0"
+
+[buisson-theme]
+submodule = "extensions/buisson-theme"
 version = "0.1.0"
 
 [bun-docs-mcp]


### PR DESCRIPTION
This adds an extension to support [build2](https://build2.org) `buildfile` and `manifest` file-type syntaxes. It uses two tree-sitter grammars, [tree-sitter-build2](https://codeberg.org/wreedb/tree-sitter-build2) and [tree-sitter-build2-manifest](https://codeberg.org/wreedb/tree-sitter-build2-manifest), and provides a task for building a users project with the `b` command.