### PR TITLE
Add Ars Goetia theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -190,6 +190,10 @@
 	path = extensions/arkts
 	url = https://github.com/liuyanghejerry/zed-arkts.git
 
+[submodule "extensions/ars-goetia-theme"]
+	path = extensions/ars-goetia-theme
+	url = https://github.com/rvdeguzman/ars-goetia-zed.git
+
 [submodule "extensions/arturo"]
 	path = extensions/arturo
 	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -193,6 +193,10 @@ version = "0.0.1"
 submodule = "extensions/arkts"
 version = "0.2.0"
 
+[ars-goetia-theme]
+submodule = "extensions/ars-goetia-theme"
+version = "0.0.1"
+
 [arturo]
 submodule = "extensions/arturo"
 version = "1.0.3"


### PR DESCRIPTION
  - Adds [Ars Goetia](https://github.com/rvdeguzman/ars-goetia-zed)
  - Five color palettes: Kimaris (purple+gold), Barbatos (red+rust), Gusion
  (green+plague), Vidar (blue+ice), Bael (monochrome)
  - Colors derived from the Apache 2.0-licensed [black-metal-theme-neovim](http
  s://github.com/metalelf0/black-metal-theme-neovim)

  ## Checklist

  - [x] Extension has a license (MIT)
  - [x] `extension.toml` is valid with all required fields (`id`, `name`,
  `version`, `schema_version`, `authors`, `description`, `repository`)
  - [x] Version in `extensions.toml` matches `extension.toml` (`0.0.1`)
  - [x] Ran `pnpm sort-extensions`
  - [x] Theme JSON files include `$schema` reference