### PR TITLE
Add device tree source language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1050,6 +1050,10 @@
 	path = extensions/dream
 	url = https://github.com/arturonegrete-dev/Dream-zed
 
+[submodule "extensions/dts"]
+	path = extensions/dts
+	url = https://github.com/Altair-Bueno/zed-dts
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1065,6 +1065,10 @@ version = "1.0.0"
 submodule = "extensions/dream"
 version = "1.0.0"
 
+[dts]
+submodule = "extensions/dts"
+version = "0.1.0"
+
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"


### PR DESCRIPTION
Although there is an existing devicetree extension, zed-dts uses a different LSP (https://github.com/igor-prusov/dts-lsp vs https://github.com/kylebonnici/dts-lsp). The latter is the same zed-dts uses, and it is the same LSP the [VSCode extension uses](https://marketplace.visualstudio.com/items?itemName=KyleMicallefBonnici.dts-lsp)

This extension is meant to bridge feature parity with VScode. The other pre-existing extension (zed-devicetree) is simpler to use, but it is not as feature-full as this one (due to the LSP implementation). As an alternative, I could modify zed-devicetree to use a different LSP, but I consider it too much of a breaking change for existing users.


<img width="632" height="658" alt="image" src="https://github.com/user-attachments/assets/41b686dc-c227-495b-8ba1-0b74306ef6c2" />
