### PR TITLE
Add waltzing extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4689,3 +4689,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/waltzing"]
+	path = extensions/waltzing
+	url = https://github.com/awesomike/waltzing.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4522,7 +4522,7 @@ version = "0.1.1"
 [waltzing]
 submodule = "extensions/waltzing"
 path = "extensions/zed"
-version = "0.1.3"
+version = "0.1.4"
 
 [warm-burnout-theme]
 submodule = "extensions/warm-burnout-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4522,7 +4522,7 @@ version = "0.1.1"
 [waltzing]
 submodule = "extensions/waltzing"
 path = "extensions/zed"
-version = "0.1.2"
+version = "0.1.3"
 
 [warm-burnout-theme]
 submodule = "extensions/warm-burnout-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4519,6 +4519,11 @@ version = "0.1.10"
 submodule = "extensions/wakfu-theme"
 version = "0.1.1"
 
+[waltzing]
+submodule = "extensions/waltzing"
+path = "extensions/zed"
+version = "0.1.2"
+
 [warm-burnout-theme]
 submodule = "extensions/warm-burnout-theme"
 version = "1.4.2"


### PR DESCRIPTION
This PR adds the [Waltzing](https://github.com/awesomike/waltzing) template language extension.

Waltzing is a compile-time template engine for Rust, inspired by Scala's Twirl. It transforms `.wtz` files into type-safe Rust code at build time with HTML escaping, template inheritance, and component-based architecture.

The extension provides:
- **Syntax highlighting** via tree-sitter (`@if`, `@for`, `@match`, `@let`, `@fn`, `@struct`, `@format`, `@matches`, inferred enum forms, HTML elements with embedded control flow)
- **LSP integration** (`waltzing-lsp`) — auto-downloaded from GitHub releases on first launch, with fallback to local installs in `~/.cargo/bin`, `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`, or a user-specified path in Zed settings
- **MCP context server** (`waltzing-mcp`) — exposes Waltzing grammar lookups, template validation, error translation, and helper listings to Zed's Agent Panel. Same auto-download / local-fallback resolution.
- Component tag highlighting (`<@component …/>`)
- Embedded language regions for HTML, CSS, JavaScript, and JSON inside templates

The extension lives at `extensions/zed` in the upstream repo (alongside the rest of the Waltzing project), hence the `path = "extensions/zed"` entry.

- ID: `waltzing`
- Version: `0.1.4`
- Source: https://github.com/awesomike/waltzing/tree/main/extensions/zed