### PR TITLE
Update markdown-snippets to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2256,7 +2256,7 @@ version = "0.0.5"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
-version = "0.0.7"
+version = "0.0.8"
 
 [markdownlint]
 submodule = "extensions/markdownlint"


### PR DESCRIPTION
Release notes:

https://github.com/bobbymannino/markdown-snippets-for-zed/releases/tag/v0.0.8