### PR TITLE
Update sentry-mcp to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3632,7 +3632,7 @@ version = "0.0.2"
 
 [sentry-mcp]
 submodule = "extensions/sentry-mcp"
-version = "0.1.1"
+version = "0.1.2"
 
 [seoul256]
 submodule = "extensions/seoul256"


### PR DESCRIPTION
Release notes:

https://github.com/fabric0de/sentry-mcp-server-zed/releases/tag/v0.1.2