### PR TITLE
Update islands-theme to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1856,7 +1856,7 @@ version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [isle]
 submodule = "extensions/isle"


### PR DESCRIPTION
Updates the Islands theme submodule to the latest commit and bumps the version to 0.2.0.

Changes: https://github.com/himattm/zed-islands-theme/commit/0a0f970f