### PR TITLE
Add Evangelion theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1182,6 +1182,10 @@
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed
 
+[submodule "extensions/eva-theme"]
+	path = extensions/eva-theme
+	url = https://github.com/Oneptica/Zed-Theme-Evangelion.git
+
 [submodule "extensions/everforest"]
 	path = extensions/everforest
 	url = https://github.com/albertsko/zed-everforest.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1199,6 +1199,10 @@ version = "0.2.1"
 submodule = "extensions/esmerald-theme"
 version = "0.1.2"
 
+[eva-theme]
+submodule = "extensions/eva-theme"
+version = "0.0.1"
+
 [everforest]
 submodule = "extensions/everforest"
 version = "0.1.2"


### PR DESCRIPTION
After reading the extension publishing prerequisites, I think the ID was missing the required -theme suffix. So I renamed ID from eva to eva-theme.

https://github.com/Oneptica/Zed-Theme-Evangelion