### PR TITLE
Update verilog to v0.0.17

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4388,7 +4388,7 @@ version = "1.0.0"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.16"
+version = "0.0.17"
 
 [veryl]
 submodule = "extensions/veryl"


### PR DESCRIPTION
- Bumps slang-server and verible language-servers
- Moved check for local binaries to be before querying github for asset names (since the extension uses pinned language server versions)