### PR TITLE
Add PLC Structured Text extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3198,6 +3198,10 @@
 	path = extensions/playdate
 	url = https://github.com/notpeter/playdate-zed-extension.git
 
+[submodule "extensions/plc-structured-text"]
+	path = extensions/plc-structured-text
+	url = https://github.com/ArthurkaX/zed-plc-structured-text.git
+
 [submodule "extensions/po"]
 	path = extensions/po
 	url = https://git.disroot.org/gemmaro/zed-po.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3241,6 +3241,10 @@ version = "0.0.1"
 submodule = "extensions/playdate"
 version = "0.1.2"
 
+[plc-structured-text]
+submodule = "extensions/plc-structured-text"
+version = "0.0.3"
+
 [po]
 submodule = "extensions/po"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the `plc-structured-text` Zed extension to the extension registry.

The extension provides IEC 61131-3 Structured Text syntax highlighting for `.st` and `.iecst` files, focused on CODESYS-style PLC projects. It intentionally ships without LSP support for the first release.

## Context

This was built to support external editing workflows around [`cds-text-sync`](https://github.com/ArthurkaX/cds-text-sync), which exports CODESYS projects into Git-friendly text projections. It should also be useful for other Zed users working with CODESYS and IEC 61131-3 Structured Text projects.

## Validation

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test`