### PR TITLE
Add ansible-lint-win extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -130,6 +130,10 @@
 	path = extensions/ansible
 	url = https://github.com/kartikvashistha/zed-ansible
 
+[submodule "extensions/ansible-lint-win"]
+	path = extensions/ansible-lint-win
+	url = https://github.com/Ericlein/ansible-lint-win.git
+
 [submodule "extensions/anthracite-theme"]
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -132,6 +132,11 @@ version = "21.0.0"
 submodule = "extensions/ansible"
 version = "1.0.0"
 
+[ansible-lint-win]
+submodule = "extensions/ansible-lint-win"
+path = "extension"
+version = "0.1.4"
+
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"


### PR DESCRIPTION
Adds **ansible-lint-win**  a lightweight Ansible language server for Windows, written in pure Node.js (no Python, no WSL).

Source: https://github.com/Ericlein/ansible-lint-win npm: https://www.npmjs.com/package/ansible-lint-win Version: 0.1.4.

The extension uses ``npm_install_package`` to fetch the language server from npm at runtime. Provides completions, hover docs, 10 lint rules, and go-to-definition for ~8900 modules across 120+ collections."