### PR TITLE
Add Awsum language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/awsum"]
+	path = extensions/awsum
+	url = https://github.com/awsum-lang/awsum-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -286,6 +286,10 @@
 	path = extensions/awk
 	url = https://github.com/dangh/zed-awk.git
 
+[submodule "extensions/awsum"]
+	path = extensions/awsum
+	url = https://github.com/awsum-lang/awsum-zed.git
+
 [submodule "extensions/axolosin"]
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git
@@ -4701,6 +4705,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/awsum"]
-	path = extensions/awsum
-	url = https://github.com/awsum-lang/awsum-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -290,6 +290,10 @@ version = "0.0.1"
 submodule = "extensions/awk"
 version = "0.0.1"
 
+[awsum]
+submodule = "extensions/awsum"
+version = "0.0.4"
+
 [axolosin]
 submodule = "extensions/axolosin"
 version = "1.1.1"


### PR DESCRIPTION
## Add Awsum extension

Adds support for [Awsum](https://awsum-lang.org) — a small functional language that compiles to LLVM, JVM, CLR, WASM, and JS with identical stdout on every target.

### Extension

- Source: [awsum-lang/awsum-zed](https://github.com/awsum-lang/awsum-zed)
- Pinned to tag [v0.0.4](https://github.com/awsum-lang/awsum-zed/releases/tag/v0.0.4)
- License: MIT (in the repo root)
- Extension ID: `awsum` (does not contain `zed` / `Zed` / `extension`)

### Features

Thin LSP client to `awsum lsp --stdio` (subcommand of the `awsum` compiler binary). Every editor feature is computed inside the compiler and pushed over LSP:

- Syntax highlighting via [`awsum-lang/tree-sitter-awsum`](https://github.com/awsum-lang/tree-sitter-awsum) (commit-pinned in `extension.toml`)
- Format on save
- Inline diagnostics (errors + warnings)
- Quick fixes (compiler-supplied code actions)
- Document outline / breadcrumbs
- Workspace symbol search

### Runtime dependency

Per the «language extensions must not ship the language server itself» rule: the extension does not bundle the LSP server. It shells out via the Zed Extension API to the `awsum` compiler binary, which users install separately from [awsum-lang/awsum](https://github.com/awsum-lang/awsum). The README documents this prerequisite.

### Checklist

- [x] Submodule at `extensions/awsum` (extension id does **not** contain `zed`/`Zed`/`extension`), pinned to `v0.0.4`
- [x] Submodule URL is HTTPS, repo is public, commit is on `main`
- [x] Entry in `extensions.toml` under `[awsum]`, sorted (`pnpm sort-extensions` clean)
- [x] MIT LICENSE at the extension repo root
- [x] No theme / icon-theme bundled
- [x] LSP server not shipped — extension shells out to user-installed `awsum`
- [x] Tested locally via `zed: install dev extension`; `cargo build --target wasm32-wasip2 --release` passes; CI (`fmt-check` + `clippy -D warnings` + build) green on tag
