### PR TITLE
Add 1c-bsl extension v0.1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/1c-bsl"]
+	path = extensions/1c-bsl
+	url = https://github.com/Nesterland/zed-1c-bsl.git
+
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme
@@ -4701,6 +4705,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/1c-bsl"]
-	path = extensions/1c-bsl
-	url = https://github.com/Nesterland/zed-1c-bsl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/1c-bsl"]
+	path = extensions/1c-bsl
+	url = https://github.com/Nesterland/zed-1c-bsl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,6 @@
 	path = extensions/a-distant-hope-theme
 	url = https://github.com/chrislockard/a-distant-hope-theme.git
 
-
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/1c-bsl"]
+	path = extensions/1c-bsl
+	url = https://github.com/Nesterland/zed-1c-bsl.git
+
 [submodule "extensions/8008-theme"]
 	path = extensions/8008-theme
 	url = https://github.com/Paulo-Camacho/zed-8008.git
@@ -21,6 +25,7 @@
 [submodule "extensions/a-distant-hope-theme"]
 	path = extensions/a-distant-hope-theme
 	url = https://github.com/chrislockard/a-distant-hope-theme.git
+
 
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
@@ -5749,6 +5754,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/1c-bsl"]
-	path = extensions/1c-bsl
-	url = https://github.com/Nesterland/zed-1c-bsl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/1c-bsl"]
+	path = extensions/1c-bsl
+	url = https://github.com/Nesterland/zed-1c-bsl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -12,7 +12,7 @@ version = "0.1.3"
 
 [1c-bsl]
 submodule = "extensions/1c-bsl"
-version = "0.0.3"
+version = "0.1.2"
 
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,14 +10,12 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
-<<<<<<< HEAD
 [1c-bsl]
 
 
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"
 version = "0.1.0"
->>>>>>> upstream/main
 
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[1c-bsl]
+submodule = "extensions/1c-bsl"
+version = "0.0.3"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -11,7 +11,8 @@ submodule = "extensions/1984-theme"
 version = "0.1.3"
 
 [1c-bsl]
-
+submodule = "extensions/1c-bsl"
+version = "0.1.2"
 
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -12,8 +12,7 @@ version = "0.1.3"
 
 <<<<<<< HEAD
 [1c-bsl]
-submodule = "extensions/1c-bsl"
-version = "0.1.2"
+
 
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -16,7 +16,7 @@ version = "0.1.3"
 
 [1c-bsl]
 submodule = "extensions/1c-bsl"
-version = "0.0.3"
+version = "0.1.2"
 
 [8008-theme]
 submodule = "extensions/8008-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -15,7 +15,8 @@ submodule = "extensions/1984-theme"
 version = "0.1.3"
 
 [1c-bsl]
-
+submodule = "extensions/1c-bsl"
+version = "0.1.2"
 
 [8008-theme]
 submodule = "extensions/8008-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -14,6 +14,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[1c-bsl]
+submodule = "extensions/1c-bsl"
+version = "0.0.3"
+
 [8008-theme]
 submodule = "extensions/8008-theme"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -15,8 +15,7 @@ submodule = "extensions/1984-theme"
 version = "0.1.3"
 
 [1c-bsl]
-submodule = "extensions/1c-bsl"
-version = "0.1.2"
+
 
 [8008-theme]
 submodule = "extensions/8008-theme"


### PR DESCRIPTION
## 1C BSL extension for Zed

[1C BSL](https://github.com/Nesterland/zed-1c-bsl) — language support for 1C:Enterprise BSL, OneScript and SDBL.

### Features
- **Syntax highlighting** for BSL, SDBL, and embedded SDBL within BSL strings
- **Auto-indentation** for procedures, conditions, loops, exceptions, preprocessor
- **Outline** (procedures, functions, preprocessor regions)
- **~50 snippets** (procedures, functions, conditions, loops, full query with result traversal, Russian full-word triggers)
- **Bracket matching** and text objects
- **LSP support** via bsl-language-server (manual setup, documented)
- **~220 built-in functions** highlighted (strings, numbers, dates, types, files, JSON, XML, transactions, etc.)
- **Object properties** highlighted (`Объект.Свойство`)
- **Type after `Новый`** highlighted (`Новый Структура`)

### Tech
- Tree-sitter grammar: [alkoleft/tree-sitter-bsl](https://github.com/alkoleft/tree-sitter-bsl)
- Version: **0.1.2**

### Testing
- ✅ Tested locally in Zed via `Install Dev Extension`
- ✅ Syntax highlighting works (keywords, parameters, Export, built-in functions)
- ✅ Auto-indentation works
- ✅ Snippets trigger correctly (including `запрос`, `процедура`, `функция`)
- ✅ Outline shows structure

### Repository
https://github.com/Nesterland/zed-1c-bsl