### PR TITLE
Add helixql extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1654,6 +1654,10 @@
 	path = extensions/helios-theme
 	url = https://github.com/heliosgraphics/helios-theme.git
 
+[submodule "extensions/helixql"]
+	path = extensions/helixql
+	url = https://github.com/floscom/zed-helixql.git
+
 [submodule "extensions/helm"]
 	path = extensions/helm
 	url = https://github.com/cabrinha/helm.zed.git
@@ -4697,6 +4701,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/helixql"]
-	path = extensions/helixql
-	url = https://github.com/floscom/zed-helixql.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/helixql"]
+	path = extensions/helixql
+	url = https://github.com/floscom/zed-helixql.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1679,6 +1679,10 @@ version = "0.1.0"
 submodule = "extensions/helios-theme"
 version = "0.0.8"
 
+[helixql]
+submodule = "extensions/helixql"
+version = "0.0.1"
+
 [helm]
 submodule = "extensions/helm"
 version = "0.0.2"


### PR DESCRIPTION
Adds syntax highlighting for [HelixDB](https://helix-db.com)'s **HelixQL** query language (`.hx` / `.hql`).

- **Extension repo:** https://github.com/floscom/zed-helixql
- **Tree-sitter grammar:** [`benwoodward/tree-sitter-helixql`](https://github.com/benwoodward/tree-sitter-helixql) (MIT) — pinned to commit `259d2b68c56ae40ef7d190919ed49e0f17d1f3ee`
- **Scope:** highlight-only (no language server) — covers schema declarations (`N::` / `E::` / `V::`), `QUERY` blocks, traversal & creation steps, comparison operators, primitive types, and literals.

## Test plan
- [ ] `zed: install dev extension` succeeds locally against `floscom/zed-helixql`
- [ ] `.hx` / `.hql` files highlight (schema, QUERY, traversals, types, strings, numbers, comments)
- [ ] `cmd-/` toggles `//` line comments
- [ ] Outline panel lists `QUERY`, `N::`, `E::`, `V::` items