### PR TITLE
Bump laravel to v0.1.17

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2057,7 +2057,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.16"
+version = "0.1.17"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.1.17.

Release notes: https://github.com/GeneaLabs/zed-laravel/releases/tag/0.1.17