### PR TITLE
Add grasp extension v3.20.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4685,3 +4685,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/grasp-code-architecture"]
+	path = extensions/grasp-code-architecture
+	url = https://github.com/ashfordeOU/grasp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1547,7 +1547,12 @@ version = "1.0.4"
 submodule = "extensions/graphviz"
 version = "0.2.1"
 
+
 [green-monochrome-monitor-crt-phosphor]
+[grasp-code-architecture]
+submodule = "extensions/grasp"
+path = "zed-extension"
+version = "3.20.0"
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"
 version = "0.1.3"
 


### PR DESCRIPTION
## Grasp — Code Architecture v3.20.0

**Repository:** https://github.com/ashfordeOU/grasp  
**Extension dir:** `zed-extension/`  
**npm:** [`grasp-mcp-server@3.20.0`](https://www.npmjs.com/package/grasp-mcp-server/v/3.20.0)  
**Release:** https://github.com/ashfordeOU/grasp/releases/tag/v3.20.0

### What is Grasp?

Grasp gives your AI assistant a complete understanding of any codebase — dependency graph, architecture diagram, health score, and 131 MCP tools. Paste a GitHub/GitLab URL → instant analysis. No data leaves the user's machine.

### What's new in v3.20.0

- **5-layer security scanner:** NIST NVD (container CVEs), Socket.dev behavioral analysis, supply-chain integrity (lockfile hash coverage, go.sum/Cargo.lock presence, pip --hash= pinning), OSV database, Semgrep SAST
- **`grasp_vuln_watch`** — scheduled re-scanning with CVE diff and history stored in brain.db
- **131 MCP tools** total (↑1 from v3.19.0)

### Extension contents (`zed-extension/`)

- `extension.toml` — id: `grasp-code-architecture`, schema_version 1
- `LICENSE` — Elastic License 2.0
- `Cargo.toml` / `src/lib.rs` — Rust context server wrapper
- `README.md` — full tool reference, architecture, configuration guide