### PR TITLE
Add grasp-code-architecture extension v3.20.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4697,3 +4697,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/grasp-code-architecture"]
+	path = extensions/grasp-code-architecture
+	url = https://github.com/ashfordeOU/grasp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1551,6 +1551,11 @@ version = "1.0.4"
 submodule = "extensions/graphviz"
 version = "0.2.1"
 
+[grasp-code-architecture]
+submodule = "extensions/grasp-code-architecture"
+path = "zed-extension"
+version = "3.20.0"
+
 [green-monochrome-monitor-crt-phosphor]
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"
 version = "0.1.3"


### PR DESCRIPTION
## Grasp — Code Architecture v3.20.0

**Repository:** https://github.com/ashfordeOU/grasp
**Extension dir:** `zed-extension/`
**npm:** `grasp-mcp-server@3.20.0`

Grasp gives your AI assistant a complete understanding of any codebase — dependency graph, architecture diagram, health score, and 131 MCP tools.

- License: Apache 2.0 (extension wrapper only)
- Extension ID: `grasp-code-architecture`