### PR TITLE
Add keep-a-changelog snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1970,6 +1970,10 @@
 	path = extensions/kdl
 	url = https://github.com/elkowar/zed-kdl.git
 
+[submodule "extensions/keep-a-changelog-snippets"]
+	path = extensions/keep-a-changelog-snippets
+	url = https://github.com/ssh-den/zed-keep-a-changelog-snippets.git
+
 [submodule "extensions/keepcalm"]
 	path = extensions/keepcalm
 	url = https://github.com/sgmonda/keepcalm-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2003,6 +2003,10 @@ version = "0.1.0"
 submodule = "extensions/kdl"
 version = "0.0.1"
 
+[keep-a-changelog-snippets]
+submodule = "extensions/keep-a-changelog-snippets"
+version = "0.1.0"
+
 [keepcalm]
 submodule = "extensions/keepcalm"
 version = "1.0.1"


### PR DESCRIPTION
## Summary

Add the `keep-a-changelog-snippets` extension.

Repository:
https://github.com/ssh-den/zed-keep-a-changelog-snippets

This extension provides Markdown snippets for changelogs following Keep a Changelog 1.1.0.