### PR TITLE
Update greycat to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1569,7 +1569,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.1"
+version = "0.1.2"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
Update greycat to v0.1.2 (checks for `greycat-analyzer` first, then fallback to the legacy `greycat-lang` if not found)