### PR TITLE
Add atomic dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,10 @@
 	path = extensions/atom-one-theme
 	url = https://github.com/Stelath/zed-atom-one-theme.git
 
+[submodule "extensions/atomic-dark-theme"]
+	path = extensions/atomic-dark-theme
+	url = https://github.com/thekodeking/zed-atomic-dark-theme.git
+
 [submodule "extensions/atomize"]
 	path = extensions/atomize
 	url = https://github.com/zhouyuxiang0/atomize.zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -288,7 +288,7 @@
 
 [submodule "extensions/atomic-dark-theme"]
 	path = extensions/atomic-dark-theme
-	url = https://github.com/thekodeking/zed-atomic-dark-theme.git
+	url = https://github.com/atomic-dark/zed.git
 
 [submodule "extensions/atomize"]
 	path = extensions/atomize

--- a/extensions.toml
+++ b/extensions.toml
@@ -241,6 +241,10 @@ version = "0.1.10"
 submodule = "extensions/atom-one-theme"
 version = "0.1.0"
 
+[atomic-dark-theme]
+submodule = "extensions/atomic-dark-theme"
+version = "0.0.1"
+
 [atomize]
 submodule = "extensions/atomize"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -295,7 +295,7 @@ version = "0.1.0"
 
 [atomic-dark-theme]
 submodule = "extensions/atomic-dark-theme"
-version = "0.0.1"
+version = "0.1.0"
 
 [atomize]
 submodule = "extensions/atomize"


### PR DESCRIPTION
### Description:

#### Overview

Introducing a new dark theme for zed with popular variants, Atomic Dark is an OLED optimised theme family for the Zed editor featuring multiple syntax flavours designed for deep blacks and vibrant, readable code.

The theme brings along, Atomic Dark (atom theme style but darker), Atomic Dark Catppuccin, Atomic Dark Afterglow and Atomic Dark Material. 

#### Goal

The point was that I was not able to settle with a theme on zed and wanted something not too contrasty but dark enough with my favourite theme style but couldn't find anything closer than [one-dark-darkened](https://github.com/pavles6/one-dark-darkened). Hence I built my own theme and thought some other devs might be interested to try it out!

#### Checklist

- [x] extension is licensed under MIT.
- [x] added extension submodule to extensions directory with this format `extensions/{extension-id}`.
- [x] updated `extensions.toml` 
- [x] ran `pnpm sort-extensions` to order the files.

PS: created the PR while sipping on some coffee, and I love the editor!
  