### PR TITLE
Add Monokai Remastered theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2562,6 +2562,10 @@
 	path = extensions/monokai-pro-ce
 	url = https://github.com/monokai-pro/zed
 
+[submodule "extensions/monokai-remastered-theme"]
+	path = extensions/monokai-remastered-theme
+	url = https://github.com/jowch/zed-monokai-remastered.git
+
 [submodule "extensions/monokai-reversed"]
 	path = extensions/monokai-reversed
 	url = https://github.com/everdrone/zed-monokai-reversed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2601,6 +2601,10 @@ version = "0.1.0"
 submodule = "extensions/monokai-pro-ce"
 version = "1.0.1"
 
+[monokai-remastered-theme]
+submodule = "extensions/monokai-remastered-theme"
+version = "0.1.0"
+
 [monokai-reversed]
 submodule = "extensions/monokai-reversed"
 version = "0.0.2"


### PR DESCRIPTION
## Monokai Remastered

A port of the **Monokai Remastered** color scheme to Zed, faithful to the version shipped with [Ghostty](https://ghostty.org). The palette derives from [mbadolato/iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes) (MIT-licensed) and is byte-identical to Ghostty's bundled theme file. Extended across Zed's full UI surface — editor, gutter, tabs, panels, diffs, diagnostics, terminal ANSI, and a 44-rule syntax map.

Source: https://github.com/jowch/zed-monokai-remastered

## Palette

| Role | Hex |
|------|-----|
| Background | `#0c0c0c` |
| Foreground | `#d9d9d9` |
| Comments | `#625e4c` italic |
| Strings | `#e0d561` |
| Numbers, constants | `#9d65ff` |
| Keywords, operators, tags | `#f4005f` |
| Functions | `#98e024` |
| Types, properties | `#58d1eb` italic |
| Parameters | `#fd971f` italic |
| Cursor | `#fc971f` |

## Pre-flight

- [x] Extension ID is unique and suffixed with `-theme` (`monokai-remastered-theme`)
- [x] No `zed` / `Zed` / `extension` in ID
- [x] License is MIT, at root of extension repo
- [x] `extension.toml` has all required fields (`id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`)
- [x] Theme JSON adheres to `https://zed.dev/schema/themes/v0.2.0.json`
- [x] Tested locally in Zed (`zed: install dev extension`)
- [x] `extensions.toml` and `.gitmodules` sorted via `pnpm sort-extensions`