### PR TITLE
Add Horizon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1706,6 +1706,10 @@
 	path = extensions/horizon-extended
 	url = https://github.com/lancewilhelm/horizon-extended.zed.git
 
+[submodule "extensions/horizon-theme"]
+	path = extensions/horizon-theme
+	url = https://codeberg.org/ava/horizon-zed.git
+
 [submodule "extensions/hot-dog-stand"]
 	path = extensions/hot-dog-stand
 	url = https://github.com/CoasterFan5/hotdog-stand-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1732,6 +1732,10 @@ version = "0.0.1"
 submodule = "extensions/horizon-extended"
 version = "0.0.1"
 
+[horizon-theme]
+submodule = "extensions/horizon-theme"
+version = "1.0.0"
+
 [hot-dog-stand]
 submodule = "extensions/hot-dog-stand"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds the Horizon theme to Zed. Two extensions for this theme already exist. However, they are either based on forked versions of the theme, or do not include the light theme variant. My extension follows the original theme to a tea and includes 6 total variants, 3 for light mode, 3 for dark mode.

## Checklist

- [x] Extension has a license (MIT)
- [x] `extension.toml` is valid with all required fields (`id`, `name`,
`version`, `schema_version`, `authors`, `description`, `repository`)
- [x] Version in `extensions.toml` matches `extension.toml` (`1.0.0`)
- [x] Ran `pnpm sort-extensions`
- [x] Theme JSON files include `$schema` reference