### PR TITLE
feat: add claude-review extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4701,3 +4701,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/claude-review"]
+	path = extensions/claude-review
+	url = https://github.com/k08200/zed-claude-review.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -657,6 +657,10 @@ version = "0.1.0"
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"
 
+[claude-review]
+submodule = "extensions/claude-review"
+version = "0.0.1"
+
 [claude-warm-theme]
 submodule = "extensions/claude-warm-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the **claude-review** extension: AI code review slash commands for Zed's AI assistant panel.

### Commands

| Command | Description |
|---|---|
| `/review <file>` | Review code for bugs, quality, and security |
| `/explain <file>` | Explain what the code does |
| `/improve <file>` | Suggest concrete before/after improvements |

Each command reads the file from the open worktree and injects a structured prompt into the AI context. Works with any AI provider configured in Zed (Claude, GPT-4, etc.).

### Testing

Tested locally as a dev extension. Build verified:

```
cargo test          # 5 tests pass
cargo build --target wasm32-wasip1 --release  # compiles cleanly
```

### Repository

https://github.com/k08200/zed-claude-review

- MIT license ✓
- `schema_version = 1` ✓
- Extension ID `claude-review` (no "zed"/"extension" in name) ✓
- No duplicate functionality in existing marketplace extensions ✓