### PR TITLE
Update laravel to v0.1.19

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2061,7 +2061,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.17"
+version = "0.1.19"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.1.19.

Release notes: https://github.com/GeneaLabs/zed-laravel/releases/tag/0.1.19