### PR TITLE
Add mcp-server-vercel extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2450,6 +2450,10 @@
 	path = extensions/mcp-server-threadbridge
 	url = https://github.com/dereklei12/zed-mcp-server-threadbridge.git
 
+[submodule "extensions/mcp-server-vercel"]
+	path = extensions/mcp-server-vercel
+	url = https://github.com/Charles-pyt/mcp-server-vercel
+
 [submodule "extensions/mcp-server-webflow"]
 	path = extensions/mcp-server-webflow
 	url = https://github.com/LoamStudios/zed-mcp-server-webflow.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2487,6 +2487,10 @@ version = "0.0.2"
 submodule = "extensions/mcp-server-threadbridge"
 version = "0.2.1"
 
+[mcp-server-vercel]
+submodule = "extensions/mcp-server-vercel"
+version = "0.1.0"
+
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: true
+  esbuild: true


### PR DESCRIPTION
Connect the official Vercel MCP server to Zed's Agent Panel.
Manage your deployments, projects, domains and environment
variables directly from the AI chat.