### PR TITLE
Add atlas-ragnarok theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4705,3 +4705,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/atlas-ragnarok"]
+	path = extensions/atlas-ragnarok
+	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -238,6 +238,10 @@
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
 
+[submodule "extensions/atlas-ragnarok"]
+	path = extensions/atlas-ragnarok
+	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git
+
 [submodule "extensions/atom-one-theme"]
 	path = extensions/atom-one-theme
 	url = https://github.com/Stelath/zed-atom-one-theme.git
@@ -4705,6 +4709,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/atlas-ragnarok"]
-	path = extensions/atlas-ragnarok
-	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -238,8 +238,8 @@
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
 
-[submodule "extensions/atlas-ragnarok"]
-	path = extensions/atlas-ragnarok
+[submodule "extensions/atlas-ragnarok-theme"]
+	path = extensions/atlas-ragnarok-theme
 	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git
 
 [submodule "extensions/atom-one-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -241,6 +241,11 @@ version = "0.1.0"
 submodule = "extensions/astro"
 version = "0.1.10"
 
+[atlas-ragnarok]
+submodule = "extensions/atlas-ragnarok"
+path = "editors/zed"
+version = "1.0.0"
+
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -241,8 +241,8 @@ version = "0.1.0"
 submodule = "extensions/astro"
 version = "0.1.10"
 
-[atlas-ragnarok]
-submodule = "extensions/atlas-ragnarok"
+[atlas-ragnarok-theme]
+submodule = "extensions/atlas-ragnarok-theme"
 path = "editors/zed"
 version = "1.0.0"
 


### PR DESCRIPTION
## Adds atlas-ragnarok

A dark theme: tech-blue thunder above, crimson fire below, pure black through the middle. Built on the syntactic structure of Vesper, with the warm-accent family remapped to a Tailwind blue gradient.

- **Repo**: https://github.com/AyoubTadlaoui/atlas-ragnarok
- **Pinned to**: [v1.2.3](https://github.com/AyoubTadlaoui/atlas-ragnarok/releases/tag/v1.2.3)
- **Theme file**: [`editors/zed/themes/atlas-ragnarok.json`](https://github.com/AyoubTadlaoui/atlas-ragnarok/blob/v1.2.3/editors/zed/themes/atlas-ragnarok.json)
- **Manifest**: [`editors/zed/extension.toml`](https://github.com/AyoubTadlaoui/atlas-ragnarok/blob/v1.2.3/editors/zed/extension.toml)
- **License**: MIT
- **Already on**: Open VSX ([listing](https://open-vsx.org/extension/AyoubTadlaoui/atlas-ragnarok))

### Checklist
- [x] I have tested the extension locally
- [x] The theme is licensed under MIT
- [x] Submodule pinned to a tagged release (v1.2.3)
- [x] Entry placed alphabetically (between `astro` and `atom-one-theme`)