### PR TITLE
Add loi-paper-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2162,6 +2162,10 @@
 	path = extensions/logstash
 	url = https://github.com/StrongTheDev/logstash-for-zed
 
+[submodule "extensions/loi-paper-theme"]
+	path = extensions/loi-paper-theme
+	url = https://github.com/aliaksei-loi/zed-loi-paper-theme.git
+
 [submodule "extensions/lonely-planet"]
 	path = extensions/lonely-planet
 	url = https://github.com/Jbonez87/lonely-planet-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2197,6 +2197,10 @@ version = "0.0.1"
 submodule = "extensions/logstash"
 version = "0.0.2"
 
+[loi-paper-theme]
+submodule = "extensions/loi-paper-theme"
+version = "0.3.1"
+
 [lonely-planet]
 submodule = "extensions/lonely-planet"
 version = "0.0.1"


### PR DESCRIPTION
Adds **Loi Paper**, a community Zed theme with a warm-paper aesthetic.

### What it adds
- `Loi Paper Light` — warm cream background (`#faf9f5`), soft warm dark text, coral accent (`#c96442`)
- `Loi Paper Dark` — warm charcoal background (`#262624`), cream text, soft coral accent (`#d97757`)

Coral accents are reserved for cursor, links, syntax tags, and emphasis — focus/selection borders are kept neutral so the editor stays calm. Both variants are tuned together.

### Source
- Extension id: `loi-paper-theme` (`-theme` suffix per publishing prerequisites)
- Repo: https://github.com/aliaksei-loi/zed-loi-paper-theme
- Version: 0.3.1 (tagged)
- License: MIT
- Tested locally as a dev extension

### Checks
- `pnpm test` passes (111 tests)
- `pnpm sort-extensions` is a no-op (entry inserted alphabetically between `logstash` and `lonely-planet`)
- License file present at repo root
- All required `extension.toml` fields filled (id, name, version, schema_version, authors, description, repository)