### PR TITLE
Update modern-icons to v0.7.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2583,7 +2583,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.7.1"
+version = "0.7.2"
 
 [modern-vesper]
 submodule = "extensions/modern-vesper"


### PR DESCRIPTION
## Summary

Bumps `modern-icons` to v0.7.2.

## Changes since v0.7.1

- Add Wails icon and map `wails.json` to it (Golang [Wails](https://wails.io) framework config file).

## Release Notes

- modern-icons: Add Wails icon for `wails.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)