### PR TITLE
Add run-current-file 0.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4717,3 +4717,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/run-current-file"]
+	path = extensions/run-current-file
+	url = https://github.com/orisup1/zed-run-current-file.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4777,3 +4777,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[run-current-file]
+submodule = "extensions/run-current-file"
+version = "0.0.1"


### PR DESCRIPTION
Releases [`run-current-file`](https://github.com/orisup1/zed-run-current-file) at version `0.0.1`.

Submodule pinned at `v0.0.1` (`540db6dcb19b67fd5391b20195128df2643463d2`).