### PR TITLE
Add oxk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3078,6 +3078,10 @@
 	path = extensions/oxc
 	url = https://github.com/oxc-project/oxc-zed.git
 
+[submodule "extensions/oxk"]
+	path = extensions/oxk
+	url = https://github.com/harmony-contrib/oxk-zed.git
+
 [submodule "extensions/oxocarbon"]
 	path = extensions/oxocarbon
 	url = https://github.com/Takk8IS/oxocarbon-theme-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3122,6 +3122,10 @@ version = "0.0.3"
 submodule = "extensions/oxc"
 version = "0.4.7"
 
+[oxk]
+submodule = "extensions/oxk"
+version = "0.1.0"
+
 [oxocarbon]
 submodule = "extensions/oxocarbon"
 version = "0.1.3"


### PR DESCRIPTION
Add a new extension named `oxk`. 

It's a more comprehensive extension for ArkTS (`.ets` file) for OpanHarmony.

- Fully support for ArkTS Synatax(For exmaple: lazy, arkui, etc.)
- Fully support for synatax highlight by [tree-sitter-arkts](https://github.com/harmony-contrib/tree-sitter-arkts).
- Code format by [oxc-ark](https://github.com/ohos-rs/oxc-ark)
- Lint by [oxc-ark](https://github.com/ohos-rs/oxc-ark)
- Language service by [@arkts/language-server](https://github.com/ohosvscode/arkTS)