### PR TITLE
Add AWS toolkit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4721,3 +4721,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zed-aws-toolkit"]
+	path = extensions/zed-aws-toolkit
+	url = https://github.com/clementGilardy/zed-aws-toolkit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -293,6 +293,7 @@
 [submodule "extensions/aws-toolkit"]
 	path = extensions/aws-toolkit
 	url = https://github.com/clementGilardy/zed-aws-toolkit.git
+
 [submodule "extensions/axolosin"]
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4721,6 +4721,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/zed-aws-toolkit"]
-	path = extensions/zed-aws-toolkit
+[submodule "extensions/aws-toolkit"]
+	path = extensions/aws-toolkit
 	url = https://github.com/clementGilardy/zed-aws-toolkit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -290,6 +290,9 @@
 	path = extensions/awk
 	url = https://github.com/dangh/zed-awk.git
 
+[submodule "extensions/aws-toolkit"]
+	path = extensions/aws-toolkit
+	url = https://github.com/clementGilardy/zed-aws-toolkit.git
 [submodule "extensions/axolosin"]
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git
@@ -4721,6 +4724,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/aws-toolkit"]
-	path = extensions/aws-toolkit
-	url = https://github.com/clementGilardy/zed-aws-toolkit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -294,6 +294,10 @@ version = "0.0.1"
 submodule = "extensions/awk"
 version = "0.0.1"
 
+[aws-toolkit]
+submodule = "extensions/aws-toolkit"
+version = "0.5.0"
+
 [axolosin]
 submodule = "extensions/axolosin"
 version = "1.1.1"
@@ -4698,9 +4702,6 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
-[zed-aws-toolkit]
-submodule = "extensions/zed-aws-toolkit"
-version = "0.5.0"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -297,7 +297,7 @@ version = "0.0.1"
 [aws-toolkit]
 submodule = "extensions/aws-toolkit"
 path = "extension"
-version = "0.5.0"
+version = "0.5.1"
 
 [axolosin]
 submodule = "extensions/axolosin"

--- a/extensions.toml
+++ b/extensions.toml
@@ -296,6 +296,7 @@ version = "0.0.1"
 
 [aws-toolkit]
 submodule = "extensions/aws-toolkit"
+path = "extension"
 version = "0.5.0"
 
 [axolosin]

--- a/extensions.toml
+++ b/extensions.toml
@@ -203,7 +203,7 @@ version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
-version = "0.5.1"
+version = "0.6.0"
 
 [ashen]
 submodule = "extensions/ashen"
@@ -297,7 +297,7 @@ version = "0.0.1"
 [aws-toolkit]
 submodule = "extensions/aws-toolkit"
 path = "extension"
-version = "0.5.1"
+version = "0.6.0"
 
 [axolosin]
 submodule = "extensions/axolosin"
@@ -1307,7 +1307,7 @@ version = "0.0.2"
 
 [flat-theme]
 submodule = "extensions/flat-theme"
-version = "0.5.1"
+version = "0.6.0"
 
 [flat-themes]
 submodule = "extensions/flat-themes"
@@ -4458,7 +4458,7 @@ version = "1.0.10"
 
 [vim-theme]
 submodule = "extensions/vim-theme"
-version = "0.5.1"
+version = "0.6.0"
 
 [vintergata]
 submodule = "extensions/vintergata"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4698,6 +4698,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zed-aws-toolkit]
+submodule = "extensions/zed-aws-toolkit"
+version = "0.5.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4703,7 +4703,6 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
-
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"


### PR DESCRIPTION
## AWS Toolkit for Zed

Adds the `zed-aws-toolkit` extension — an MCP context server that exposes AWS services directly in the Zed Agent Panel.

### Tools provided (22 MCP tools)
- **Auth**: `list_accounts`, `switch_account`, `sso_login`
- **S3**: `s3_list_buckets`, `s3_list_objects`, `s3_get_object`, `s3_put_object`, `s3_delete_object`, `s3_presign`
- **Lambda**: `lambda_list`, `lambda_invoke`, `lambda_get_logs`
- **CloudWatch Logs**: `logs_list_groups`, `logs_list_streams`, `logs_tail`, `logs_search`
- **ECS**: `ecs_list_clusters`, `ecs_list_services`, `ecs_list_tasks`, `ecs_describe_task`
- **ECR**: `ecr_list_repos`, `ecr_list_images`

### Architecture
WASM thin launcher + native Rust sidecar speaking MCP JSON-RPC over stdio. Multi-account AWS IAM Identity Center SSO support.

### Links
- Repo: https://github.com/clementGilardy/zed-aws-toolkit
- Release: https://github.com/clementGilardy/zed-aws-toolkit/releases/tag/v0.5.0