### PR TITLE
Update mistral-vibe to v2.10.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2578,7 +2578,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.9.6"
+version = "2.10.0"
 path = "distribution/zed"
 
 [mlir-tablegen]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.10.0