### PR TITLE
Add ios-runner extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1862,6 +1862,10 @@
 	path = extensions/ion
 	url = https://github.com/tartarughina/zed-amazon-ion.git
 
+[submodule "extensions/ios-runner"]
+	path = extensions/ios-runner
+	url = https://github.com/buds520/ios-runner.git
+
 [submodule "extensions/ir-black"]
 	path = extensions/ir-black
 	url = https://github.com/sametaylak/ir-black-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.0"
+version = "0.3.1"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.5"
+version = "0.3.6"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1896,6 +1896,10 @@ version = "0.1.3"
 submodule = "extensions/ion"
 version = "0.1.2"
 
+[ios-runner]
+submodule = "extensions/ios-runner"
+version = "0.1.0"
+
 [ir-black]
 submodule = "extensions/ir-black"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.1"
+version = "0.3.2"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.2.0"
+version = "0.2.1"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.9"
+version = "0.3.10"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.8"
+version = "0.3.9"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.2.5"
+version = "0.3.0"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.2.1"
+version = "0.2.2"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.7"
+version = "0.3.8"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.4"
+version = "0.3.5"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.6"
+version = "0.3.7"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.1.0"
+version = "0.2.0"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.3"
+version = "0.3.4"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.2.2"
+version = "0.2.3"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.3.2"
+version = "0.3.3"
 
 [ir-black]
 submodule = "extensions/ir-black"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1898,7 +1898,7 @@ version = "0.1.2"
 
 [ios-runner]
 submodule = "extensions/ios-runner"
-version = "0.2.3"
+version = "0.2.5"
 
 [ir-black]
 submodule = "extensions/ir-black"


### PR DESCRIPTION
## Summary

Adds **iOS-Runner**: a Zed extension for building and running local Xcode projects from Zed.

It is intentionally scoped as a lightweight Xcode launcher, not a debugger or replacement build system:

- Detects `.xcodeproj` / `.xcworkspace` projects, including CocoaPods workspaces
- Lets users configure scheme and destination from Zed
- Runs Build / Run / Doctor / Pod Install / Resolve Swift Packages tasks
- Supports iOS Simulator, physical iOS devices, and macOS app destinations
- Streams app logs in the Zed task terminal when launching simulator/device apps

## Architecture

- Zed extension: WASM bootstrap layer
- CLI: Rust binary installed to `~/.ios-runner/bin/ios-runner`
- Build/run engine: local Apple tools (`xcodebuild`, `xcrun simctl`, `xcrun devicectl`)

Marketplace releases bundle macOS CLI binaries under `bin/`, so normal users do not need Rust or a first-run CLI build.

## Safety / Privacy

- No telemetry
- No project source upload
- No remote build service
- Project build/run stays on the user's Mac
- Writes only documented local config/task/cache files

Details: https://github.com/buds520/ios-runner/blob/main/docs/SECURITY_AND_PRIVACY.md

## Current Review State

- Latest release in this PR: `v0.3.10`
- Checks passing: package, danger, CLA
- CLA signed
- PR is mergeable

## Test Plan

- [x] Tested locally as a Zed Dev Extension on macOS
- [x] Tested Xcode `.xcodeproj` detection
- [x] Tested CocoaPods `.xcworkspace` flow with the bundled `CocoaPodsDemo`
- [x] Tested `ios-runner doctor`, `ensure`, `build`, `run`, and `switch`
- [x] Release CI attaches both macOS CLI assets:
  - `ios-runner-aarch64-apple-darwin`
  - `ios-runner-x86_64-apple-darwin`

## User Flow

1. Install **iOS Runner** from Zed Extensions
2. Open the user's app project folder
3. Press `Cmd+Shift+U` to set up
4. Press `Cmd+Shift+I` to choose scheme/device when needed
5. Press `Cmd+Shift+R` to run

## License

MIT
