### PR TITLE
Update lisette to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2180,7 +2180,7 @@ version = "0.1.0"
 [lisette]
 submodule = "extensions/lisette"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.1.1"
 
 [little-league-theme]
 submodule = "extensions/little-league-theme"


### PR DESCRIPTION
Catches the Zed extension up on Lisette grammar additions since v0.1.0.