### PR TITLE
Add Birds of Paradise theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -402,6 +402,10 @@
 	path = extensions/biome
 	url = https://github.com/biomejs/biome-zed.git
 
+[submodule "extensions/birds-of-paradise"]
+	path = extensions/birds-of-paradise
+	url = https://github.com/LoganBresnahan/birds-of-paradise-zed.git
+
 [submodule "extensions/bison"]
 	path = extensions/bison
 	url = https://github.com/fanwenlin/bison-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -402,8 +402,8 @@
 	path = extensions/biome
 	url = https://github.com/biomejs/biome-zed.git
 
-[submodule "extensions/birds-of-paradise"]
-	path = extensions/birds-of-paradise
+[submodule "extensions/birds-of-paradise-theme"]
+	path = extensions/birds-of-paradise-theme
 	url = https://github.com/LoganBresnahan/birds-of-paradise-zed.git
 
 [submodule "extensions/bison"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -407,8 +407,8 @@ version = "1.2.2"
 submodule = "extensions/biome"
 version = "0.3.0"
 
-[birds-of-paradise]
-submodule = "extensions/birds-of-paradise"
+[birds-of-paradise-theme]
+submodule = "extensions/birds-of-paradise-theme"
 version = "0.1.0"
 
 [bison]

--- a/extensions.toml
+++ b/extensions.toml
@@ -407,6 +407,10 @@ version = "1.2.2"
 submodule = "extensions/biome"
 version = "0.3.0"
 
+[birds-of-paradise]
+submodule = "extensions/birds-of-paradise"
+version = "0.1.0"
+
 [bison]
 submodule = "extensions/bison"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the **Birds of Paradise** theme — a warm, brown-based, light-on-dark theme.

Port of Joe Bergantine's original theme (created for Panic's Coda, later adapted to TextMate as [textmate/Birds-of-Paradise-for-TextMate](https://github.com/textmate/Birds-of-Paradise-for-TextMate)) to Zed's `v0.2.0` theme schema.

- Repo: https://github.com/LoganBresnahan/birds-of-paradise-zed
- License: BSD-3-Clause (inherited from upstream; Bergantine's original copyright preserved)
- Version: `0.1.0`

## Test plan

- [x] Theme loads in Zed and is selectable from the theme picker
- [x] `extension.toml` validates
- [x] `themes/birds-of-paradise.json` validates against `https://zed.dev/schema/themes/v0.2.0.json`
- [x] Submodule is on `main` branch (non-detached) and uses HTTPS
- [x] `node src/sort-extensions.js` produces no further changes
- [x] LICENSE present at repo root (BSD-3-Clause, accepted license)

🤖 Generated with [Claude Code](https://claude.com/claude-code)