### PR TITLE
Update mistral-vibe to v2.10.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2629,7 +2629,7 @@ version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.10.0"
+version = "2.10.1"
 path = "distribution/zed"
 
 [mlir-tablegen]


### PR DESCRIPTION
Release notes:

https://github.com/mistralai/mistral-vibe/releases/tag/v2.10.1