### PR TITLE
Add Bruno language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -494,6 +494,10 @@
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git
 
+[submodule "extensions/bruno"]
+	path = extensions/bruno
+	url = https://github.com/byeval/bruno-zed.git
+
 [submodule "extensions/bsl"]
 	path = extensions/bsl
 	url = https://github.com/dlyubanevich/zed-bsl-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -494,6 +494,10 @@
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git
 
+[submodule "extensions/bruno"]
+	path = extensions/bruno
+	url = https://github.com/byeval/bruno-zed
+
 [submodule "extensions/bsl"]
 	path = extensions/bsl
 	url = https://github.com/dlyubanevich/zed-bsl-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -500,6 +500,10 @@ version = "0.0.4"
 submodule = "extensions/browser-tools-context-server"
 version = "0.0.2"
 
+[bruno]
+submodule = "extensions/bruno"
+version = "0.1.0"
+
 [bsl]
 submodule = "extensions/bsl"
 version = "0.0.2"


### PR DESCRIPTION
## Summary
- Add the Bruno extension as `extensions/bruno`.
- Register `bruno` in `extensions.toml` at version `0.1.0`.
- Point the extension at the public `byeval/bruno-zed` repository, which uses `byeval/tree-sitter-bru` for the grammar.
- Include the second-stage YAML runner updates:
  - OpenCollection `.yml/.yaml` requests run without requiring PyYAML.
  - YAML request output prints HTTP status, elapsed time, response headers, and decoded response bodies.
  - YAML requests support `{{variable}}`, `{{process.env.NAME}}`, root `.env`, `--env`, `--env-file`, `--env-var`, collection variables, folder variables, and request variables.

## Validation
- `npm run check` in `byeval/bruno-zed`
- `./bin/bru-zed-yaml-run /Volumes/iDev/workspace/2d/super-playwright/playwright/parse-html.yml --dry-run`
- `./bin/bru-zed-yaml-run --collection /Volumes/iDev/workspace/2d/super-playwright/playwright/parse-html.yml --dry-run`
- `./bin/bru-zed-yaml-run --help`
- `pnpm sort-extensions`
- `pnpm test`