### PR TITLE
Add SCSS Modules language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3650,6 +3650,10 @@
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git
 
+[submodule "extensions/scss-modules-lsp"]
+	path = extensions/scss-modules-lsp
+	url = https://github.com/egor-a-trubnikov-panov/zed-scss-modules.git
+
 [submodule "extensions/semgrep"]
 	path = extensions/semgrep
 	url = https://github.com/zeelsheladiya/zed-semgrep.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3705,6 +3705,10 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.2.0"
 
+[scss-modules-lsp]
+submodule = "extensions/scss-modules-lsp"
+version = "0.1.0"
+
 [semgrep]
 submodule = "extensions/semgrep"
 version = "0.0.2"


### PR DESCRIPTION
Adds the scss-modules extension for navigating from JS/TS CSS module usages to definitions in *.module.scss files.\n\nValidation run locally:\n- pnpm sort-extensions\n- pnpm build\n- pnpm test\n- cargo +stable fmt --check\n- cargo +stable check\n- cargo +stable build --target wasm32-wasip2 --release\n\nNote: pnpm package-extensions scss-modules could not complete locally because the zed-extension CLI binary is not present in this checkout.