### PR TITLE
Add Crossplane YAML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -806,6 +806,10 @@
 	path = extensions/crimson-theme
 	url = https://github.com/kaem-e/zed-crimson-theme.git
 
+[submodule "extensions/crossplane-yaml"]
+	path = extensions/crossplane-yaml
+	url = https://github.com/io41/crossplane-yaml.git
+
 [submodule "extensions/crystal"]
 	path = extensions/crystal
 	url = https://github.com/crystal-lang-tools/zed-crystal.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -835,7 +835,7 @@ version = "0.0.4"
 
 [crossplane-yaml]
 submodule = "extensions/crossplane-yaml"
-version = "0.0.2"
+version = "0.0.3"
 
 [crystal]
 submodule = "extensions/crystal"

--- a/extensions.toml
+++ b/extensions.toml
@@ -817,6 +817,10 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.4"
 
+[crossplane-yaml]
+submodule = "extensions/crossplane-yaml"
+version = "0.0.2"
+
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"


### PR DESCRIPTION
## Summary

A [Crossplane YAML language extension](https://github.com/io41/crossplane-yaml) for Zed, adding `Crossplane YAML` syntax highlighting for:

`Go-Templating` embedded in `inline pipeline YAML` embedded in `Go-Templating` embedded `Crossplane Composition YAML`

## Checks
- `node src/sort-extensions.js`
- `npm run build`
- `npm test`
- `git diff --check`

## Notes
- The extension repository is public and includes a root MIT license.
- The extension supports an early stage `vibe-xpls` language server (alternative to upbound's language server); it does not bundle the server binary, but follows similar patterns as other zed language extensions