### PR TITLE
Bump devglobe-activity-ls to v2.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1044,7 +1044,7 @@ version = "0.0.1"
 
 [devglobe-activity-ls]
 submodule = "extensions/devglobe-activity-ls"
-version = "2.0.0"
+version = "2.0.1"
 
 [devicetree]
 submodule = "extensions/devicetree"


### PR DESCRIPTION
Updates the DevGlobe extension to 2.0.1.

This release fixes the `repository` URL in the manifest (the previous
value pointed to a repo under a namespace that doesn't exist; fixed
to https://github.com/devglobe-xyz/zed-devglobe).

No code changes.