### PR TITLE
Update dependi to v1.9.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1018,7 +1018,7 @@ version = "0.1.1"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.8.1"
+version = "1.9.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
## Summary

• Update Dependi extension submodule to v1.9.0
• Includes pnpm workspace catalog support
• Includes latest dependency updates and Cargo parser fixes

## Type

chore
