### PR TITLE
Add Varlock Schema extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4418,6 +4418,10 @@
 	path = extensions/vapor-theme
 	url = https://github.com/felipetesc/vapor-theme.git
 
+[submodule "extensions/varlock-schema"]
+	path = extensions/varlock-schema
+	url = https://github.com/petercr/varlock-zed-extension.git
+
 [submodule "extensions/vcard"]
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4481,6 +4481,10 @@ version = "1.0.0"
 submodule = "extensions/vapor-theme"
 version = "0.0.2"
 
+[varlock-schema]
+submodule = "extensions/varlock-schema"
+version = "0.1.3"
+
 [vcard]
 submodule = "extensions/vcard"
 version = "0.3.0"


### PR DESCRIPTION
## Summary

Adds the Varlock Schema extension to the Zed extension registry.

The extension provides `.env.schema` language support for Varlock schema files, including a Varlock-aware tree-sitter grammar and bundled language server.

## Validation

- Confirmed `petercr/varlock-zed-extension` is pushed at `58504c67f057b8fa8147ecdf0a7440b6435f388e`.
- Confirmed extension version is `0.1.3`.
- Confirmed extension grammar is pinned to commit `7659c2f0014abf8cfe8992b9c5e4ed25b98433d3`.
- Confirmed GitHub release `v0.1.3` exists and includes `env-spec-language-server.js`.
- Ran `pnpm sort-extensions`.
- Ran `pnpm build`.
- Installed the official `zed-extension` CLI used by CI and ran `pnpm package-extensions varlock-schema` under WSL with Rust `1.90.0` and `wasm32-wasip2`.
