### PR TITLE
Add Telegram Type Language (TL) extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4182,6 +4182,10 @@
 	path = extensions/tiniri
 	url = https://github.com/vladstudio/tiniri-zed.git
 
+[submodule "extensions/tl"]
+	path = extensions/tl
+	url = https://github.com/desktop-app/zed-tl.git
+
 [submodule "extensions/tla-plus"]
 	path = extensions/tla-plus
 	url = https://github.com/Akanoa/Zed-editor-TLA-syntax
@@ -4817,6 +4821,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/tl"]
-	path = extensions/tl
-	url = https://github.com/desktop-app/zed-tl.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4817,3 +4817,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/tl"]
+	path = extensions/tl
+	url = https://github.com/desktop-app/zed-tl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4243,6 +4243,10 @@ version = "0.0.1"
 submodule = "extensions/tiniri"
 version = "0.0.2"
 
+[tl]
+submodule = "extensions/tl"
+version = "0.1.0"
+
 [tla-plus]
 submodule = "extensions/tla-plus"
 version = "0.2.0"


### PR DESCRIPTION
Adds `tl`, a syntax-highlighting extension for Telegram's [Type Language](https://core.telegram.org/mtproto/TL) schema files (`*.tl`).

- Repository: https://github.com/desktop-app/zed-tl
- License: MIT

The grammar is a Tree-sitter port of the regex-based highlighter from [libprisma's `prism-tl.js`](https://github.com/desktop-app/libprisma/blob/master/components/prism-tl.js) — each Prism token category maps 1:1 to a grammar node, and `languages/tl/highlights.scm` maps those to Zed scopes. Tested locally as a dev extension against the `mtproto.tl` and `api.tl` schemas from `telegramdesktop/tdesktop`.