### PR TITLE
Add mcp-server-signoz extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2526,6 +2526,10 @@
 	path = extensions/mcp-server-shortcut
 	url = https://github.com/useshortcut/zed-extension-mcp-server-shortcut.git
 
+[submodule "extensions/mcp-server-signoz"]
+	path = extensions/mcp-server-signoz
+	url = https://github.com/gkarthi-signoz/zed-mcp-server-signoz.git
+
 [submodule "extensions/mcp-server-slack"]
 	path = extensions/mcp-server-slack
 	url = https://github.com/semioz/zed-slack-mcp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2566,6 +2566,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-shortcut"
 version = "0.0.1"
 
+[mcp-server-signoz]
+submodule = "extensions/mcp-server-signoz"
+version = "0.0.1"
+
 [mcp-server-slack]
 submodule = "extensions/mcp-server-slack"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

- Adds the **SigNoz MCP Server** extension (\`mcp-server-signoz\`)
- Bridges Zed's Agent Panel to [SigNoz](https://signoz.io) observability data via the SigNoz Cloud hosted MCP endpoint (\`https://mcp.<region>.signoz.cloud/mcp\`)
- Uses \`npx mcp-remote\` as a stdio↔HTTP bridge — no binary to ship. Invoked via \`zsh -lc\` to ensure the user's login PATH is available regardless of Node.js install method (nvm, homebrew, system, etc.)
- Supports SigNoz Cloud regions (\`us\`, \`us2\`, \`eu\`, \`eu2\`, \`in\`, \`in2\`), self-hosted instances via \`url\`, and headless API key auth
- Extension source: https://github.com/gkarthi-signoz/zed-mcp-server-signoz
- License: Apache-2.0

## Test plan

- [x] Built extension locally with \`cargo build --release --target wasm32-wasip1\`
- [x] Installed as dev extension in Zed and verified it rebuilds cleanly
- [x] Verified MCP server connects to SigNoz Cloud and OAuth flow works
- [x] Tested with nvm-managed Node.js — \`zsh -lc\` wrapper ensures npx is found
- [x] \`extension.toml\` has correct \`id\`, \`name\`, \`version\`, \`schema_version\`, \`authors\`, \`description\`, \`repository\`
- [x] \`[context_servers.mcp-server-signoz]\` declared in \`extension.toml\`
- [x] Apache-2.0 LICENSE file present
- [x] Extension ID contains no "zed" or "extension"

🤖 Generated with [Claude Code](https://claude.com/claude-code)