### PR TITLE
Add Monokai Vibrant theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2686,6 +2686,10 @@
 	path = extensions/monokai-vibrant-amped
 	url = https://github.com/Ceebox/zed-monokai-vibrant-amped.git
 
+[submodule "extensions/monokai-vibrant-theme"]
+	path = extensions/monokai-vibrant-theme
+	url = https://github.com/AlexanderHeffernan/monokai-vibrant-zed.git
+
 [submodule "extensions/monokuro-theme"]
 	path = extensions/monokuro-theme
 	url = https://github.com/KawaneNamito/zed-monokuro-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2728,6 +2728,10 @@ version = "1.0.1"
 submodule = "extensions/monokai-vibrant-amped"
 version = "0.0.3"
 
+[monokai-vibrant-theme]
+submodule = "extensions/monokai-vibrant-theme"
+version = "0.1.0"
+
 [monokuro-theme]
 submodule = "extensions/monokuro-theme"
 version = "0.0.2"


### PR DESCRIPTION
Adds [Monokai Vibrant](https://github.com/AlexanderHeffernan/monokai-vibrant-zed), a Zed port of [Dylan Marsh's Monokai Vibrant](https://github.com/dylantmarsh/monokai-vibrant) VS Code theme.
- MIT licensed, with attribution to the original author in extension.toml and the theme JSON.
- Tested locally as a dev extension.
- No existing port of this theme is in the registry. The existing "Monokai Vibrant Amped" extension is a port of a different VS Code theme.