### PR TITLE
Add Air theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,10 @@
 	path = extensions/air
 	url = https://github.com/posit-dev/air.git
 
+[submodule "extensions/air-theme"]
+	path = extensions/air-theme
+	url = https://github.com/franzgollhammer/air-theme-zed.git
+
 [submodule "extensions/aira"]
 	path = extensions/aira
 	url = https://github.com/talison-cardoso/aira-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -84,6 +84,10 @@ submodule = "extensions/air"
 path = "editors/zed"
 version = "0.1.0"
 
+[air-theme]
+submodule = "extensions/air-theme"
+version = "0.1.0"
+
 [aira]
 submodule = "extensions/aira"
 version = "1.0.0"


### PR DESCRIPTION
Adds Air Theme — Zed port of [JetBrains Air](https://github.com/franzgollhammer/air-theme-vscode).

## Variants

- Air Dark
- Air Dark Italic (bold functions, italic params + strings)
- Air Light
- Air Light Italic

## Palette

Lavender keywords, pink strings, amber numbers, green types.

Repo: https://github.com/franzgollhammer/air-theme-zed