### PR TITLE
Add Air Icons

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4833,3 +4833,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/air-icons"]
+	path = extensions/air-icons
+	url = https://github.com/franzgollhammer/air-icons-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -82,6 +82,10 @@
 	path = extensions/air
 	url = https://github.com/posit-dev/air.git
 
+[submodule "extensions/air-icons"]
+	path = extensions/air-icons
+	url = https://github.com/franzgollhammer/air-icons-zed.git
+
 [submodule "extensions/aira"]
 	path = extensions/aira
 	url = https://github.com/talison-cardoso/aira-zed
@@ -4833,6 +4837,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/air-icons"]
-	path = extensions/air-icons
-	url = https://github.com/franzgollhammer/air-icons-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -84,6 +84,10 @@ submodule = "extensions/air"
 path = "editors/zed"
 version = "0.1.0"
 
+[air-icons]
+submodule = "extensions/air-icons"
+version = "0.1.1"
+
 [aira]
 submodule = "extensions/aira"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -91,7 +91,7 @@ version = "0.1.0"
 
 [air-icons]
 submodule = "extensions/air-icons"
-version = "0.1.1"
+version = "0.2.0"
 
 [aira]
 submodule = "extensions/aira"

--- a/extensions.toml
+++ b/extensions.toml
@@ -91,7 +91,7 @@ version = "0.1.0"
 
 [air-icons]
 submodule = "extensions/air-icons"
-version = "0.4.0"
+version = "0.5.0"
 
 [aira]
 submodule = "extensions/aira"

--- a/extensions.toml
+++ b/extensions.toml
@@ -91,7 +91,7 @@ version = "0.1.0"
 
 [air-icons]
 submodule = "extensions/air-icons"
-version = "0.2.0"
+version = "0.4.0"
 
 [aira]
 submodule = "extensions/aira"


### PR DESCRIPTION
Adds the `air-icons` extension: two icon themes for Zed.

- **Air Icons** — 112 clean, minimal file icons inspired by JetBrains New UI (Air), monochrome-accent style, dark + light variants
- **Air Material Icons** — full [Material Icon Theme](https://github.com/material-extensions/vscode-material-icon-theme) catalog (1245 icons, 1368 file suffixes, 2124 file stems, 4648 named folders), dark + light variants

- Repository: https://github.com/franzgollhammer/air-icons-zed
- Tag: `v0.4.0`
- License: Apache 2.0 (Air Icons derived from JetBrains intellij-community; Air Material Icons from Material Icon Theme by Material Extensions, MIT)
- Provides: `Air Icons Dark`, `Air Icons Light`, `Air Material Icons Dark`, `Air Material Icons Light`

Pairs with companion color theme [air-theme-zed](https://github.com/franzgollhammer/air-theme-zed) (already published as `air` in this registry).

Tested locally as a dev extension in Zed.