### PR TITLE
Add nord-deep theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4833,3 +4833,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/nord-deep"]
+	path = extensions/nord-deep
+	url = https://github.com/jxnata/zed-theme-nord-deep

--- a/extensions.toml
+++ b/extensions.toml
@@ -2933,6 +2933,10 @@ version = "0.0.2"
 submodule = "extensions/nord"
 version = "0.1.5"
 
+[nord-deep]
+submodule = "extensions/nord-deep"
+version = "1.0.0"
+
 [nordic-nvim-theme]
 submodule = "extensions/nordic-nvim-theme"
 version = "0.0.3"


### PR DESCRIPTION
Adds Nord Deep, a dark theme for Zed based on the Nord palette with a slightly deeper editor background (#1d2129).

  **Repository:** https://github.com/jxnata/zed-theme-nord-deep

  **Checklist:**
  - [x] Extension tested locally as a dev extension
  - [x] `extension.toml` includes all required fields (id, name, version,
  schema_version, authors, description, repository)
  - [x] MIT license included
  - [x] Theme JSON validates against https://zed.dev/schema/themes/v0.2.0.json
  - [x] Extension id does not contain "zed" or "extension"
  - [x] Repository is publicly accessible