### PR TITLE
Add Wasp language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4618,6 +4618,10 @@
 	path = extensions/warplabs
 	url = https://github.com/wp-labs/zed-warplabs.git
 
+[submodule "extensions/wasp"]
+	path = extensions/wasp
+	url = https://github.com/anselanza/wasp-lang-zed
+
 [submodule "extensions/wat"]
 	path = extensions/wat
 	url = https://github.com/g-plane/zed-wasm.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4683,6 +4683,10 @@ version = "0.1.1"
 submodule = "extensions/warplabs"
 version = "0.14.0"
 
+[wasp]
+submodule = "extensions/wasp"
+version = "0.0.1"
+
 [wat]
 submodule = "extensions/wat"
 version = "0.2.3"


### PR DESCRIPTION
Adds a [Wasp](https://wasp.sh/docs/general/language) DSL extension to gain syntax highlighting for `.warp` files.