### PR TITLE
Add Imba language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1858,6 +1858,10 @@
 	path = extensions/idris2
 	url = https://github.com/dylanbraithwaite/zed-idris2-lsp
 
+[submodule "extensions/imba"]
+	path = extensions/imba
+	url = https://github.com/HeapVoid/imba-lsp.git
+
 [submodule "extensions/immigrant"]
 	path = extensions/immigrant
 	url = https://github.com/deltarocks/zed-immigrant.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1892,6 +1892,10 @@ version = "1.2.0"
 submodule = "extensions/idris2"
 version = "0.0.1"
 
+[imba]
+submodule = "extensions/imba"
+version = "0.0.1"
+
 [immigrant]
 submodule = "extensions/immigrant"
 version = "0.1.2"


### PR DESCRIPTION
Adds Imba language support for Zed.

- Registers the Imba extension in `extensions.toml`
- Adds `HeapVoid/imba-lsp` as the extension submodule
- Uses `imba-lsp@0.0.1` from npm for the language server
- Includes Tree-sitter grammar, highlighting, semantic tokens, completions, and diagnostics