### PR TITLE
Add VSCode 2026 theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4578,6 +4578,11 @@
 	path = extensions/vscode-monokai-charcoal
 	url = https://github.com/d1y/vscode-monokaicharcoal.zed.git
 
+[submodule "extensions/vscode2026-theme"]
+	path = extensions/vscode2026-theme
+	url = https://github.com/tbxark/vscode2026-theme-zed.git
+	branch = master
+
 [submodule "extensions/vue"]
 	path = extensions/vue
 	url = https://github.com/zed-extensions/vue.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4642,6 +4642,10 @@ version = "0.1.2"
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"
 
+[vscode2026-theme]
+submodule = "extensions/vscode2026-theme"
+version = "0.1.0"
+
 [vue]
 submodule = "extensions/vue"
 version = "0.3.4"


### PR DESCRIPTION
Adds the VSCode 2026 theme extension by tbxark.\n\nExtension repository: https://github.com/tbxark/vscode2026-theme-zed\nVersion: 0.1.0