### PR TITLE
Add AutoIt language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -294,6 +294,10 @@
 	path = extensions/autohotkey
 	url = https://github.com/alfredomtx/tree-sitter-autohotkey.git
 
+[submodule "extensions/autoit"]
+	path = extensions/autoit
+	url = https://github.com/sumit-m/zed-autoit.git
+
 [submodule "extensions/autumnal-marscape"]
 	path = extensions/autumnal-marscape
 	url = https://github.com/lilyyy411/autumnal-marscape-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -301,7 +301,7 @@ version = "2.0.1"
 
 [autoit]
 submodule = "extensions/autoit"
-version = "0.3.0"
+version = "0.3.1"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"

--- a/extensions.toml
+++ b/extensions.toml
@@ -299,6 +299,10 @@ version = "0.2.1"
 submodule = "extensions/autohotkey"
 version = "2.0.1"
 
+[autoit]
+submodule = "extensions/autoit"
+version = "0.3.0"
+
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -306,7 +306,7 @@ version = "2.0.1"
 
 [autoit]
 submodule = "extensions/autoit"
-version = "0.3.1"
+version = "0.3.2"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"

--- a/extensions.toml
+++ b/extensions.toml
@@ -306,7 +306,7 @@ version = "2.0.1"
 
 [autoit]
 submodule = "extensions/autoit"
-version = "0.3.2"
+version = "0.4.0"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"

--- a/extensions.toml
+++ b/extensions.toml
@@ -306,7 +306,7 @@ version = "2.0.1"
 
 [autoit]
 submodule = "extensions/autoit"
-version = "0.4.0"
+version = "0.5.0"
 
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"


### PR DESCRIPTION
Adds the **AutoIt v3** language extension (`.au3`, `.a3x`) at v0.3.0.

- Source: https://github.com/sumit-m/zed-autoit (tag v0.3.0)
- Grammar: https://github.com/sumit-m/tree-sitter-autoit
- LSP: https://github.com/sumit-m/autoit-lsp (cross-platform Windows / Linux / macOS)
- License: MIT
- `schema_version = 1`

## Features

- Syntax highlighting (case-insensitive AutoIt v3 grammar, 182/182 grammar tests, 99.96% pass rate against the AutoIt3 Examples corpus)
- Bracket matching, indentation, outline
- 19 bundled snippets
- 7 bundled tasks (run / check / compile / launch Au3Info / launch Koda / kill — auto-discovers AutoIt install via Windows registry)
- Language server: hover for ~3,500 built-in functions, document symbols (functions, parameters, locals, regions), and Au3Check-driven edit-time diagnostics on Windows
- Cross-platform: LSP downloaded from GitHub release; hover + symbols work on Windows/Linux/macOS, diagnostics gracefully no-op when Au3Check isn't present

## Verification

End-to-end verified locally in Zed on Windows: fresh extension install → grammar clones + compiles → LSP downloads from GitHub release v0.3.0 → hover popups, diagnostics, and outline all functioning.