### PR TITLE
Add bun-debugger extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -526,6 +526,10 @@
 	path = extensions/bugstalker-dap
 	url = https://github.com/godzie44/BugStalker.git
 
+[submodule "extensions/bun-debugger"]
+	path = extensions/bun-debugger
+	url = https://github.com/barnesoir/zed-bun-debugger.git
+
 [submodule "extensions/bun-docs-mcp"]
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -533,6 +533,11 @@ submodule = "extensions/bugstalker-dap"
 version = "0.1.0"
 path = "extension/zed"
 
+[bun-debugger]
+submodule = "extensions/bun-debugger"
+version = "0.1.0"
+path = "extension"
+
 [bun-docs-mcp]
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"


### PR DESCRIPTION
Adds the Bun Debugger extension for debugging Bun applications via DAP bridge.

Repository: https://github.com/barnesoir/zed-bun-debugger
Version: 0.1.0