### PR TITLE
Add Metal Shading Language extension

### DIFF
--- a/extensions/metal-shading-language/metal-shading-language.toml
+++ b/extensions/metal-shading-language/metal-shading-language.toml
@@ -1,0 +1,4 @@
+[id]
+name = "metal-shading-language"
+repository = "https://github.com/limoncc/msl-zed-extension"
+version = "0.1.0"


### PR DESCRIPTION

Adds [Metal Shading Language](https://github.com/limoncc/msl-zed-extension)
extension for .metal file support.