### PR TITLE
Add Agno theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -74,6 +74,10 @@
 	path = extensions/agnix
 	url = https://github.com/avifenesh/agnix.git
 
+[submodule "extensions/agno-theme"]
+	path = extensions/agno-theme
+	url = https://github.com/devalexandre/agno-theme.git
+
 [submodule "extensions/aiken"]
 	path = extensions/aiken
 	url = https://github.com/aiken-lang/zed-aiken.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -77,6 +77,7 @@ version = "0.17.0"
 
 [agno-theme]
 submodule = "extensions/agno-theme"
+path = "zed"
 version = "0.0.7"
 
 [aiken]

--- a/extensions.toml
+++ b/extensions.toml
@@ -75,6 +75,10 @@ submodule = "extensions/agnix"
 path = "editors/zed"
 version = "0.17.0"
 
+[agno-theme]
+submodule = "extensions/agno-theme"
+version = "0.0.7"
+
 [aiken]
 submodule = "extensions/aiken"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -78,7 +78,7 @@ version = "0.17.0"
 [agno-theme]
 submodule = "extensions/agno-theme"
 path = "zed"
-version = "0.0.7"
+version = "0.0.4"
 
 [aiken]
 submodule = "extensions/aiken"


### PR DESCRIPTION
## Summary

This PR adds the **Agno Theme** extension to the Zed extensions registry.

Agno Theme is a dark theme inspired by the visual identity of Agno, with a clean, modern color palette focused on readability and comfortable long coding sessions.

## Changes

- Adds `agno-theme` as a new extension submodule
- Registers the extension in `extensions.toml`
- Includes the initial version of the Agno Theme extension

## Extension Repository

https://github.com/devalexandre/agno-theme

## Checklist

- [x] The extension repository is public
- [x] The extension includes an `extension.toml`
- [x] The extension includes a valid license
- [x] The theme has been tested locally as a dev extension
- [x] The version in `extensions.toml` matches the version in the extension repository