### PR TITLE
Add Zephex MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2566,6 +2566,10 @@
 	path = extensions/mcp-server-webflow
 	url = https://github.com/LoamStudios/zed-mcp-server-webflow.git
 
+[submodule "extensions/mcp-server-zephex"]
+	path = extensions/mcp-server-zephex
+	url = https://github.com/zephexMCP/mcp-server-zephex.git
+
 [submodule "extensions/mdias-oled-theme"]
 	path = extensions/mdias-oled-theme
 	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2606,6 +2606,10 @@ version = "0.2.1"
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"
 
+[mcp-server-zephex]
+submodule = "extensions/mcp-server-zephex"
+version = "0.0.1"
+
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds Zephex MCP Server — a hosted MCP server providing 10 developer tools (project context, AST code reading, BM25 search, architecture diagrams, package auditing, security headers, persistent reasoning, curated knowledge base) to Zed's Agent Panel. One API key, zero local setup.

- Repo: https://github.com/zephexMCP/mcp-server-zephex
- Site: https://zephex.dev
- Underlying server: https://www.npmjs.com/package/zephex (v2.1.10)
- Built against zed_extension_api 0.7.0 — wasm32-wasip2 target, 384 KB artifact, MIT licensed.

The extension is a thin Rust→WASM shim that uses Zed's bundled Node runtime to install the `zephex` npm package and spawns it as a stdio MCP server with the user's API key injected via env. Locally tested as a dev extension.