### PR TITLE
Add zmk language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4810,6 +4810,10 @@
 	path = extensions/zk
 	url = https://github.com/srivtx/zk-zed.git
 
+[submodule "extensions/zmk"]
+	path = extensions/zmk
+	url = https://github.com/dimao/zed-zmk.git
+
 [submodule "extensions/zoegi-theme"]
 	path = extensions/zoegi-theme
 	url = https://github.com/nikitapashinsky/zoegi-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4873,6 +4873,10 @@ version = "0.0.1"
 submodule = "extensions/zk"
 version = "0.0.1"
 
+[zmk]
+submodule = "extensions/zmk"
+version = "0.1.0"
+
 [zoegi-theme]
 submodule = "extensions/zoegi-theme"
 version = "0.4.3"


### PR DESCRIPTION

   Adds a new language extension that provides syntax highlighting for ZMK Firmware
   keymaps and Zephyr Devicetree files (`.keymap`, `.overlay`, `.dts`, `.dtsi`,
   `.dtso`, `.its`).

   It wraps the [`tree-sitter-devicetree`](https://github.com/joelspadin/tree-sitter-devicetree)
   grammar (the same parser used by the [zmk-tools](https://github.com/joelspadin/zmk-tools)
   VSCode extension)
 