### PR TITLE
Add act101 MCP server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,10 @@
 	path = extensions/abysswalker-theme
 	url = https://github.com/ModusTeam/abysswalker-zed.git
 
+[submodule "extensions/act101"]
+	path = extensions/act101
+	url = https://github.com/act101-ai/act101.git
+
 [submodule "extensions/actionscript"]
 	path = extensions/actionscript
 	url = https://github.com/pngdrift/zed-actionscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -22,6 +22,10 @@ version = "0.0.1"
 submodule = "extensions/abysswalker-theme"
 version = "0.1.0"
 
+[act101]
+submodule = "extensions/act101"
+path = "zed-extension"
+
 [actionscript]
 submodule = "extensions/actionscript"
 version = "0.1.1"


### PR DESCRIPTION
Adds **act101** as an MCP (context server) extension.

[act101](https://act101.ai) gives Zed's Agent AST-aware code analysis and refactoring across 100+ languages (refactor, query, analyze) with undo/redo, preview mode, and guardrails.

- **Type:** MCP context server (`[context_servers.act101]`).
- **Binary:** the extension downloads the prebuilt `act` binary for the user's platform from [act101 GitHub Releases](https://github.com/act101-ai/act101/releases) on first use and runs `act mcp serve` — no separate install step. No language servers bundled.
- **Source:** lives in the `zed-extension/` subdirectory of the submodule (`path = "zed-extension"`).
- **License:** MIT (the extension glue); the downloaded `act` binary is a separate product.

Submodule: `act101-ai/act101` @ `zed-extension/`.