### PR TITLE
Add SFTP Sync extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4841,3 +4841,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sftp-sync"]
+	path = extensions/sftp-sync
+	url = https://github.com/jhs1873/zed-sftp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3806,6 +3806,10 @@ version = "0.0.1"
 submodule = "extensions/severance-theme"
 version = "0.1.1"
 
+[sftp-sync]
+submodule = "extensions/sftp-sync"
+version = "0.1.0"
+
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"
 version = "0.1.0"


### PR DESCRIPTION
 ## Summary

  Adds **SFTP Sync** extension — sync files to remote servers via SFTP / FTP / FTPS on save.

  - Repository: https://github.com/jhs1873/zed-sftp
  - Release: https://github.com/jhs1873/zed-sftp/releases/tag/v0.1.0
  - License: MIT

  ## Features

  - Auto upload on save (LSP `didSave` trigger)
  - Supports SFTP (password / SSH key), FTP, FTPS
  - Multi-profile config (dev / staging / prod) in `.zed/sftp.json`
  - Glob-based ignore patterns
  - MCP tools: upload / download / list / sync / delete — usable from Zed AI assistant
  - Connection pooling with 5-min idle timeout

  ## Architecture

  - Rust wasm extension (`src/lib.rs`) bootstraps the Node-based sync-server
  - sync-server is pre-built and published to GitHub Releases as `sync-server.tar.gz`
  - Runtime npm deps (ssh2-sftp-client, basic-ftp, vscode-languageserver, MCP SDK, etc.) installed via
  `npm_install_package`

  ## Testing

  Tested locally as a dev extension on Windows with both SFTP (password) and FTP profiles.
  End-to-end download → extract → LSP startup verified against the v0.1.0 release artifact.