### PR TITLE
Add csharp-ls language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -842,6 +842,10 @@
 	path = extensions/csharp
 	url = https://github.com/zed-extensions/csharp.git
 
+[submodule "extensions/csharp-ls"]
+	path = extensions/csharp-ls
+	url = https://github.com/rbstp/zed-csharp-ls.git
+
 [submodule "extensions/csharp-snippets"]
 	path = extensions/csharp-snippets
 	url = https://github.com/kenBinary/csharp-zed-snippets.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -854,6 +854,10 @@ version = "0.0.1"
 submodule = "extensions/csharp"
 version = "1.0.4"
 
+[csharp-ls]
+submodule = "extensions/csharp-ls"
+version = "0.1.0"
+
 [csharp-snippets]
 submodule = "extensions/csharp-snippets"
 version = "0.1.0"


### PR DESCRIPTION
[csharp-ls](https://github.com/razzmatazz/csharp-language-server) is a lightweight F#-based language server for C#, distributed as a `dotnet tool` NuGet package. It is **unrelated** to the deprecated `SofusA/csharp-language-server` wrapper referenced by zed-extensions/csharp#11 and zed-extensions/csharp#57 ; the upstream project markets itself as csharp-ls precisely to reduce that confusion.

### Existing `csharp` extension

The existing [`csharp`](https://github.com/zed-extensions/csharp) extension provides OmniSharp and Roslyn, but it does not provide csharp-ls. csharp-ls is a different language server that provides a much faster cold start and feels faster generally.

The publishing guidelines say: "only create a new one if upstream is unresponsive." zed-extensions/csharp#77 (opened 2026-05-04) added csharp-ls as a third option in the existing extension and has had no maintainer engagement for 3 weeks. Submitting here as a standalone extension lets users opt into csharp-ls without further blocking on that upstream review.

### Install model

The extension is detect-only, it does not bundle or auto-download the server. If `csharp-ls` is not found on `PATH`, the extension surfaces a hint pointing at:
    `dotnet tool install --global csharp-ls`

### Evidence

I have been using it locally for a few weeks without any issues, and it is much snappier.
<img width="641" height="131" alt="csharp-ls running in Zed" src="https://github.com/user-attachments/assets/13d4a254-9809-4277-a81d-8a0db7664bd5" />