### PR TITLE
Bump napalm-theme to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2807,7 +2807,7 @@ version = "0.1.0"
 
 [napalm]
 submodule = "extensions/napalm"
-version = "0.0.2"
+version = "0.1.0"
 
 [navi]
 submodule = "extensions/navi"


### PR DESCRIPTION
This PR bumps the `napalm-theme` extension to v0.1.0.

Release notes: https://github.com/napalmpapalam/napalm-theme-zed/releases/tag/0.1.0

Changes:
- Upgraded theme schema to v0.2.0
- Expanded syntax highlighting coverage (functions, keywords, variables, types, markup, punctuation)
- Added git status colors, diff backgrounds, icon palette, and accent palette
- Retuned syntax colors to match VSCode Dark+ more closely
- Aligned UI surfaces with GitHub Dark UI