### PR TITLE
Add todo-highlight language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4218,6 +4218,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todo-highlighter"]
+	path = extensions/todo-highlighter
+	url = https://github.com/shionit/zed-todo-highlighter.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git
@@ -4841,6 +4845,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/todo-highlighter"]
-	path = extensions/todo-highlighter
-	url = https://github.com/shionit/zed-todo-highlighter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4841,3 +4841,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/todo-highlighter"]
+	path = extensions/todo-highlighter
+	url = https://github.com/shionit/zed-todo-highlighter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4218,9 +4218,9 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
-[submodule "extensions/todo-highlighter"]
-	path = extensions/todo-highlighter
-	url = https://github.com/shionit/zed-todo-highlighter.git
+[submodule "extensions/todo-highlight"]
+	path = extensions/todo-highlight
+	url = https://github.com/shionit/zed-todo-highlight.git
 
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt

--- a/.gitmodules
+++ b/.gitmodules
@@ -4262,8 +4262,8 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
-[submodule "extensions/todo-highlight"]
-	path = extensions/todo-highlight
+[submodule "extensions/todo-highlight-language-server"]
+	path = extensions/todo-highlight-language-server
 	url = https://github.com/shionit/zed-todo-highlight.git
 
 [submodule "extensions/todotxt"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4280,9 +4280,9 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
-[todo-highlighter]
-submodule = "extensions/todo-highlighter"
-version = "0.1.0"
+[todo-highlight]
+submodule = "extensions/todo-highlight"
+version = "0.2.0"
 path = "extension"
 
 [todotxt]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4280,6 +4280,11 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todo-highlighter]
+submodule = "extensions/todo-highlighter"
+version = "0.1.0"
+path = "extension"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4326,8 +4326,8 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
-[todo-highlight]
-submodule = "extensions/todo-highlight"
+[todo-highlight-language-server]
+submodule = "extensions/todo-highlight-language-server"
 version = "0.2.0"
 path = "extension"
 


### PR DESCRIPTION
## Extension: TODO Highlight

Highlights TODO, FIXME, HACK, NOTE, WARN, BUG and other keywords across all file types using a dedicated LSP server that emits semantic tokens.

### Details

- **Extension ID**: `todo-highlight-language-server`
- **Repository**: https://github.com/shionit/zed-todo-highlight
- **Version**: 0.2.0
- **License**: MIT

### How it works

The extension ships a lightweight LSP server (`todo-highlight-lsp`) that scans buffers and emits semantic tokens for keyword highlighting. Pre-built binaries are downloaded from GitHub Releases on first use, covering macOS (aarch64, x86_64), Linux (aarch64, x86_64), and Windows (x86_64, aarch64).

### Testing

Tested locally as a dev extension in Zed with keywords highlighting correctly across Rust, Markdown, YAML, and other file types.