### PR TITLE
Add Feral language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1302,6 +1302,10 @@
 	path = extensions/fedaykin-themes
 	url = https://github.com/btriapitsyn/zed-fedaykin-themes.git
 
+[submodule "extensions/feral"]
+	path = extensions/feral
+	url = https://github.com/Feral-Lang/Zed.git
+
 [submodule "extensions/ferret"]
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1322,6 +1322,10 @@ version = "0.2.0"
 submodule = "extensions/fedaykin-themes"
 version = "1.0.0"
 
+[feral]
+submodule = "extensions/feral"
+version = "0.0.1"
+
 [ferret]
 submodule = "extensions/ferret"
 version = "0.0.11"


### PR DESCRIPTION
Implement syntax highlighting extension for my programming language [Feral](https://github.com/Feral-Lang/Feral).
The extension is MIT licensed.
Tested it locally.