### PR TITLE
Add latex2arxiv MCP server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2146,6 +2146,10 @@
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git
 
+[submodule "extensions/latex2arxiv"]
+	path = extensions/latex2arxiv
+	url = https://github.com/YuZh98/latex2arxiv-zed.git
+
 [submodule "extensions/latte"]
 	path = extensions/latte
 	url = https://github.com/josbeir/zed-latte.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2183,6 +2183,10 @@ version = "0.1.19"
 submodule = "extensions/latex"
 version = "0.2.3"
 
+[latex2arxiv]
+submodule = "extensions/latex2arxiv"
+version = "0.1.0"
+
 [latte]
 submodule = "extensions/latte"
 version = "0.1.0"


### PR DESCRIPTION
## What

Adds [latex2arxiv](https://github.com/YuZh98/latex2arxiv) as an MCP server extension. It exposes two tools to Zed's Agent Panel:

- **validate_submission** — Run arXiv pre-flight checks on a LaTeX project
- **clean_submission** — Produce an arXiv-ready zip

## How it works

The extension launches `latex2arxiv-mcp` (installed via `pip install "latex2arxiv[mcp]"`) as a stdio MCP server. No binary is bundled — the user must have the CLI on PATH.

## Testing

Tested locally as a dev extension in Zed. The MCP server launches correctly and returns validation results through the Agent Panel.

## Links

- Extension repo: https://github.com/YuZh98/latex2arxiv-zed
- Main project: https://github.com/YuZh98/latex2arxiv (PyPI: [latex2arxiv](https://pypi.org/project/latex2arxiv/))
- License: MIT