### PR TITLE
Add golens language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1594,6 +1594,10 @@
 	path = extensions/golangci-lint
 	url = https://github.com/zed-extensions/golangci-lint.git
 
+[submodule "extensions/golens"]
+	path = extensions/golens
+	url = https://github.com/riflowth/zed-golens.git
+
 [submodule "extensions/gosum"]
 	path = extensions/gosum
 	url = https://github.com/kartikvashistha/zed-gosum.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1594,8 +1594,8 @@
 	path = extensions/golangci-lint
 	url = https://github.com/zed-extensions/golangci-lint.git
 
-[submodule "extensions/golens"]
-	path = extensions/golens
+[submodule "extensions/golens-lsp"]
+	path = extensions/golens-lsp
 	url = https://github.com/riflowth/zed-golens.git
 
 [submodule "extensions/gosum"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1623,6 +1623,10 @@ version = "1.3.0"
 submodule = "extensions/golangci-lint"
 version = "0.2.0"
 
+[golens]
+submodule = "extensions/golens"
+version = "1.0.0"
+
 [gosum]
 submodule = "extensions/gosum"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1623,8 +1623,8 @@ version = "1.3.0"
 submodule = "extensions/golangci-lint"
 version = "0.2.0"
 
-[golens]
-submodule = "extensions/golens"
+[golens-lsp]
+submodule = "extensions/golens-lsp"
 version = "1.0.0"
 
 [gosum]


### PR DESCRIPTION
## Summary

This PR adds the **golens language server** extension to the Zed extensions registry.

Golens enhances [Go](https://go.dev/) CodeLens support by integrating with the [GoLens](https://github.com/vectier/golens) language server.

## Changes

- Adds `golens` as a new extension submodule
- Registers the extension in `extensions.toml`
- Includes the initial version of the golens language server extension

## Extension Repository

https://github.com/riflowth/zed-golens

## Checklist

- [x] The extension repository is public
- [x] The extension includes an `extension.toml`
- [x] The extension includes a valid license
- [x] The language server has been tested locally as a dev extension
- [x] The version in `extensions.toml` matches the version in the extension repository