### PR TITLE
Add canipls language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/call-trans-opt-received
 	url = https://github.com/takk8is/call-trans-opt-received-2-19-98-13-24-18-rec-log-theme-for-zed.git
 
+[submodule "extensions/canipls-lint"]
+	path = extensions/canipls-lint
+	url = https://github.com/taylorplewe/canipls-zed.git
+
 [submodule "extensions/capnp"]
 	path = extensions/capnp
 	url = https://github.com/cmackenzie1/zed-capnp.git
@@ -4841,6 +4845,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/canipls-lint"]
-	path = extensions/canipls-lint
-	url = https://github.com/taylorplewe/canipls-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4841,3 +4841,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/canipls-lint"]
+	path = extensions/canipls-lint
+	url = https://github.com/taylorplewe/canipls-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -566,6 +566,10 @@ version = "0.1.1"
 submodule = "extensions/call-trans-opt-received"
 version = "0.1.1"
 
+[canipls-lint]
+submodule = "extensions/canipls-lint"
+version = "0.0.1"
+
 [capnp]
 submodule = "extensions/capnp"
 version = "0.0.1"


### PR DESCRIPTION
(Pronounced "can I please", á la [gopls](https://go.dev/gopls/).)

[canipls](https://github.com/taylorplewe/canipls) is a language server that shows global support percentages for web features from [caniuse.com](https://caniuse.com), hence the name. As of now, it provides low-support warning diagnostics as well as hover documentation showing features' global support percentage (and caniuse feature link) for top-level HTML tags and attributes, CSS properties and pseudo-selectors, and JavaScript APIs and builtins. This extension fetches the latest canipls release version on startup.

The [Extension Publishing Prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites) state
> Your extension ID should provide some information on what your extension tries to accomplish. E.g. for themes, it should be suffixed with `-theme`, snippet extensions should be suffixed with `-snippets` and so on. An exception to that rule are extension that provide support for languages or popular tooling that people would expect to find under that ID.

If needs be, I can rename it to `canipls-linter`.

Proof of the extension working on Windows:

https://github.com/user-attachments/assets/b8a756b7-b000-4c99-9753-3f5f26221b60

The extension, language server, and this pull request were all written by hand.