### PR TITLE
Add Markdown PDF extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2338,6 +2338,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdown-pdf"]
+	path = extensions/markdown-pdf
+	url = https://github.com/0xPatryk/zed-markdown-pdf.git
+
 [submodule "extensions/markdown-snippets"]
 	path = extensions/markdown-snippets
 	url = https://github.com/bobbymannino/markdown-snippets-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2378,6 +2378,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-pdf]
+submodule = "extensions/markdown-pdf"
+version = "0.1.1"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.0.8"


### PR DESCRIPTION
Adds **Markdown PDF**, an extension that exports Markdown files to styled PDFs from inside Zed.

- **ID:** `markdown-pdf`
- **Repository:** https://github.com/0xPatryk/zed-markdown-pdf
- **License:** MIT (at the extension root)
- **Version:** 0.1.1 (matches `extension.toml` at the pinned commit)

### What it does
Adds an **Export Markdown to PDF** code action (`cmd-.`) on Markdown buffers that writes `<filename>.pdf` next to the source file. Supports syntax highlighting, KaTeX math, Mermaid diagrams, task lists, footnotes, tables, custom CSS, page size, and margins.

### How it works
Because the extension runs in the `wasm32-wasip2` sandbox and can't spawn a browser, the WASM coordinator launches a native Node.js LSP sidecar (downloaded from this repo's GitHub Releases, per the documented `latest_github_release` + `download_file` pattern). The sidecar renders Markdown → HTML (`markdown-it`) and prints with headless Chromium (`puppeteer-core`), preferring a locally installed Chrome/Edge/Brave and falling back to a lazy `chrome-headless-shell` download. Requires Node.js 18+ on PATH.

`extensions.toml` and `.gitmodules` were sorted with `pnpm sort-extensions`.