### PR TITLE
Add ios-runner extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1910,6 +1910,10 @@
 	path = extensions/ion
 	url = https://github.com/tartarughina/zed-amazon-ion.git
 
+[submodule "extensions/ios-runner"]
+	path = extensions/ios-runner
+	url = https://github.com/buds520/ios-runner.git
+
 [submodule "extensions/ir-black"]
 	path = extensions/ir-black
 	url = https://github.com/sametaylak/ir-black-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1946,6 +1946,10 @@ version = "0.1.5"
 submodule = "extensions/ion"
 version = "0.1.2"
 
+[ios-runner]
+submodule = "extensions/ios-runner"
+version = "0.3.10"
+
 [ir-black]
 submodule = "extensions/ir-black"
 version = "0.0.1"


### PR DESCRIPTION
This is a clean resubmission of iOS Runner after the earlier PR got closed.

I trimmed the extension-side behavior so the registry package is just the Zed extension entrypoint plus the MCP server wiring. It no longer writes Zed tasks/keymaps on extension load and no longer commits platform binaries into the extension repository. When Zed starts the context server, the extension downloads the matching `ios-runner` binary from the tagged GitHub release.

Checked locally:

- `npm run build`
- `npm run test`
- `./scripts/preflight.sh` in the ios-runner repo

The submodule points at `buds520/ios-runner@60965b2`.
