### PR TITLE
Add fhir-shorthand language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1310,6 +1310,10 @@
 	path = extensions/fff-mcp
 	url = https://github.com/dl-alexandre/zed-fff.git
 
+[submodule "extensions/fhir-shorthand"]
+	path = extensions/fhir-shorthand
+	url = https://github.com/spilikin/zed-fhir-shorthand.git
+
 [submodule "extensions/fiber-snippets"]
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1330,6 +1330,10 @@ version = "0.0.11"
 submodule = "extensions/fff-mcp"
 version = "0.0.1"
 
+[fhir-shorthand]
+submodule = "extensions/fhir-shorthand"
+version = "0.1.0"
+
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
 version = "0.1.0"


### PR DESCRIPTION
Adds **FHIR Shorthand** (`fhir-shorthand`), a language extension for
[FHIR Shorthand (FSH)](https://hl7.org/fhir/uv/shorthand/) — the HL7 DSL used to
author FHIR Implementation Guides (compiled by
[SUSHI](https://github.com/FHIR/sushi)).

It provides syntax highlighting and a code outline for `.fsh` files via a
purpose-built Tree-sitter grammar ported from SUSHI's official ANTLR grammar
(FSH 3.0.0).

### Repositories
- Extension: https://github.com/spilikin/zed-fhir-shorthand
- Grammar:   https://github.com/spilikin/tree-sitter-fsh

### Tested
Installed locally via `zed: install dev extension` against the published
grammar at the pinned `rev`; highlighting and outline (`cmd-shift-o`) work
across all FSH 3.0.0 constructs (`Profile:`, `Extension:` with `Context:`,
`Logical:` with `Characteristics:`, `Instance:`, `Invariant:`, `ValueSet:`,
`CodeSystem:`, `Mapping:`, `RuleSet:`/`insert`, `Alias:`, `CodeableReference()`).

### Checklist
- [x] Extension and grammar repositories are public on GitHub
- [x] `LICENSE` at the extension repo root (MIT)
- [x] Extension ID does not contain `zed` / `Zed` / `extension`
- [x] Grammar pinned by a full commit SHA
- [x] Submodule uses an HTTPS URL
- [x] Submodule commit is on a branch (`main`), not detached
- [x] `version` matches between `extension.toml` and `extensions.toml`
- [x] `pnpm sort-extensions` and `pnpm test` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
