### PR TITLE
Update greycat to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1665,7 +1665,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.4"
+version = "0.1.5"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
auto-installs `greycat-analyzer` from GitHub releases (with a 24h throttle) when it's not on `PATH`, honors `lsp.greycat.binary.path` for users who manage the binary themselves, drops the legacy `greycat-lang` PATH fallback, and bumps the `tree-sitter-greycat` grammar pin.
