### PR TITLE
Add todos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4218,6 +4218,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todos"]
+	path = extensions/todos
+	url = https://github.com/elanandkumar/zed-todos.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4280,6 +4280,10 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todos]
+submodule = "extensions/todos"
+version = "0.1.0"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"


### PR DESCRIPTION
## Summary

  Adds the [Todos](https://github.com/elanandkumar/zed-todos) extension — task management for `.todo` files.

  ## Features

  - Syntax highlighting for task states (`[ ]` `[/]` `[x]` `[-]`), section headers, `@tags`, and comments
  - Toggle task state via code actions (`cmd+.`) — Mark Done / In Progress / Pending / Cancelled
  - Auto-insert next `[ ]` task on Enter (pending and in-progress lines only)
  - Inlay hints showing task count per section header
  - Customizable markers via LSP `initialization_options`

  ## Extension details

  - **ID:** `todos`
  - **Language server:** Node.js LSP (zero npm dependencies)
  - **License:** MIT
  - **Tested locally:** as dev extension in Zed

## Screenshots
<img width="437" height="200" alt="image" src="https://github.com/user-attachments/assets/f3a8a715-44b4-4d44-8e1c-138dd41fe13b" />

<img width="576" height="291" alt="image" src="https://github.com/user-attachments/assets/fb99a2fe-8743-4413-ac89-e2f8d7de5956" />
