### PR TITLE
Add todos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4218,6 +4218,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todos"]
+	path = extensions/todos
+	url = https://github.com/elanandkumar/zed-todos.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4280,6 +4280,10 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todos]
+submodule = "extensions/todos"
+version = "0.1.0"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"


### PR DESCRIPTION
## Summary

  Adds the [Todos](https://github.com/elanandkumar/zed-todos) extension — task management for `.todo` files.

  ## Features

  - Syntax highlighting for task states (`[ ]` `[/]` `[x]` `[-]`), section headers, `@tags`, and comments
  - Toggle task state via code actions (`cmd+.`) — Mark Done / In Progress / Pending / Cancelled
  - Auto-insert next `[ ]` task on Enter (pending and in-progress lines only)
  - Inlay hints showing task count per section header
  - Customizable markers via LSP `initialization_options`

## Configuration

  Override default markers in `settings.json`:

  ```json
  {
    "lsp": {
        "todo-ls": {
            "initialization_options": {
                "markers": {
                "pending":     "☐",
                "done":        "✔",
                "in_progress": "◑",
                "cancelled":   "✗"
                }
            }
        }
    }
}
```

  ## Extension details

  - **ID:** `todos`
  - **Language server:** Node.js LSP (zero npm dependencies)
  - **License:** MIT
  - **Tested locally:** as dev extension in Zed

## Screenshots
<img width="552" height="247" alt="image" src="https://github.com/user-attachments/assets/ee18e2d4-da24-4168-9393-6ea4999ed885" />

With default zed code action shortcut (`Cmd + .`):

<img width="552" height="294" alt="image" src="https://github.com/user-attachments/assets/9eaca8cf-70bb-4de7-91e6-e6bc6c7bc1fb" />

