### PR TITLE
Add inko language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1894,6 +1894,10 @@
 	path = extensions/ink
 	url = https://github.com/yuna0x0/zed-ink.git
 
+[submodule "extensions/inko"]
+	path = extensions/inko
+	url = https://github.com/inko-lang/zed.git
+
 [submodule "extensions/intellij-light-theme"]
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,6 +1929,10 @@ version = "0.0.8"
 submodule = "extensions/ink"
 version = "0.0.2"
 
+[inko]
+submodule = "extensions/inko"
+version = "0.0.1"
+
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"


### PR DESCRIPTION
Add [extension](https://github.com/inko-lang/zed) for [the Inko programming language](https://inko-lang.org).

Currently, this extension only contains tree-sitter queries. The query files are copies (with some deletions) from Helix's runtime: https://github.com/helix-editor/helix/tree/master/runtime/queries/inko. These files are relicensed from Helix's MPL-2.0 to MIT with the approval of the sole author of the query files, who is also the copyright holder listed in the LICENSE file of this extension.

 I've confirmed that the queries are working on my end:

<img width="941" height="585" alt="Screenshot 2026-05-08 20 03 59" src="https://github.com/user-attachments/assets/a65991fb-72c9-431c-a27a-3faa2812c630" />
