### PR TITLE
Add copy-json-path extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -806,6 +806,10 @@
 	path = extensions/cooklang
 	url = https://github.com/hugginsio/zed-cooklang.git
 
+[submodule "extensions/copy-json-path"]
+	path = extensions/copy-json-path
+	url = https://github.com/AlexeyVatolin/zed-copy-json-path.git
+
 [submodule "extensions/corust-agent"]
 	path = extensions/corust-agent
 	url = https://github.com/Corust-ai/corust-agent-release.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -818,6 +818,10 @@ version = "2.0.1"
 submodule = "extensions/cooklang"
 version = "1.3.3"
 
+[copy-json-path]
+submodule = "extensions/copy-json-path"
+version = "0.1.0"
+
 [corust-agent]
 submodule = "extensions/corust-agent"
 version = "0.4.2"


### PR DESCRIPTION
## Summary
Add the `copy-json-path` Zed extension to the registry.

## Changes
- add `extensions/copy-json-path` as an HTTPS submodule
- add the `copy-json-path` entry to `extensions.toml`
- point the submodule at `AlexeyVatolin/zed-copy-json-path` version `0.1.0`

## Verification
- `node src/sort-extensions.js`
- `npm run build`
- `npm test`
- extension repo verification already passed:
  - `npm test`
  - `cargo test`
  - `cargo build --target wasm32-wasip2`