### PR TITLE
Add applescript language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -162,6 +162,10 @@
 	path = extensions/apisartisan
 	url = https://github.com/TCeason/zed-theme/
 
+[submodule "extensions/applescript"]
+	path = extensions/applescript
+	url = https://github.com/HelgeSverre/zed-applescript.git
+
 [submodule "extensions/aptos-move"]
 	path = extensions/aptos-move
 	url = https://github.com/0xbe1/aptos-move-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -166,6 +166,10 @@ path = "packages/zed"
 submodule = "extensions/apisartisan"
 version = "0.0.1"
 
+[applescript]
+submodule = "extensions/applescript"
+version = "1.9.1"
+
 [aptos-move]
 submodule = "extensions/aptos-move"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds an `applescript` extension providing AppleScript language support for Zed. Declarative-only — no Rust/WASM, no bundled language server.

- Tree-sitter grammar: [HelgeSverre/tree-sitter-applescript](https://github.com/HelgeSverre/tree-sitter-applescript), pinned by SHA in `extension.toml`
- Query files: highlights, indents, outline, brackets, textobjects, runnables, injections, overrides
- File extensions: `.applescript`, `.scpt`
- Markdown fence injection works for ` ```applescript `, ` ```AppleScript `, ` ```scpt `

## Checklist

- [x] Tested locally as a dev extension
- [x] MIT `LICENSE` file at extension root
- [x] No `zed` / `Zed` / `extension` tokens in id or name
- [x] No bundled LSP / debugger / MCP server
- [x] `extensions.toml` + `.gitmodules` sorted via `pnpm sort-extensions`
- [x] Submodule on a branch (`main`), HTTPS URL, pinned to a release tag (`v1.9.1`)

Extension repo: https://github.com/HelgeSverre/zed-applescript
Release notes: https://github.com/HelgeSverre/zed-applescript/releases/tag/v1.9.1