### PR TITLE
Add Tokyo Nebula

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4226,6 +4226,10 @@
 	path = extensions/tokyo-maple-theme
 	url = https://github.com/Cateds/Tokyo-Maple-Theme.git
 
+[submodule "extensions/tokyo-nebula"]
+	path = extensions/tokyo-nebula
+	url = https://github.com/juanarrow-io/tokyo-nebula-zed.git
+
 [submodule "extensions/tokyo-night"]
 	path = extensions/tokyo-night
 	url = https://github.com/ssaunderss/zed-tokyo-night.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4289,6 +4289,10 @@ submodule = "extensions/tokyo-maple-theme"
 version = "1.3.0"
 path = "packages/zed"
 
+[tokyo-nebula]
+submodule = "extensions/tokyo-nebula"
+version = "0.1.0"
+
 [tokyo-night]
 submodule = "extensions/tokyo-night"
 version = "0.8.0"


### PR DESCRIPTION
## Tokyo Nebula

A five-variant dark theme family fusing Andromeda's vibrant syntax highlighting with Tokyo Night's palette.

### Variants

- **Tokyo Nebula Andromeda** — violet signature
- **Tokyo Nebula Aurora** — green signature with italic accents
- **Tokyo Nebula Eclipse** — cyan signature, deeper background
- **Tokyo Nebula Solstice** — yellow signature, warm background
- **Tokyo Nebula Polaris** — blue signature, deepest navy background

All five variants share a unified five-hue family vocabulary (violet / green / cyan / yellow / blue), with each variant carrying one signature hue that dominates its keywords, button/link accents, and bracket highlights. Diagnostic and terminal ANSI palettes are shared across variants for consistency.

### Source

- Theme repo: https://github.com/juanarrow-io/tokyo-nebula-zed
- Tag: `v0.1.0`
- License: MIT

### Checks

- [x] `extension.toml` at repo root with all required fields
- [x] Submodule added at `extensions/tokyo-nebula/` using HTTPS URL
- [x] Submodule HEAD on `main` (not detached)
- [x] Entry added to `extensions.toml` and `.gitmodules` in correct alphabetical position
- [x] Theme tested locally via `zed: install dev extension`