### PR TITLE
Update metal to v0.1.22

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2650,7 +2650,7 @@ version = "0.5.0"
 [metal]
 submodule = "extensions/metal"
 path = "editors/zed"
-version = "0.1.20"
+version = "0.1.22"
 
 [microscript]
 submodule = "extensions/microscript"


### PR DESCRIPTION
Release notes:

https://github.com/computer-graphics-tools/metal-analyzer/releases/tag/v0.1.22