### PR TITLE
Add Latitude extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2154,6 +2154,11 @@
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git
 
+[submodule "extensions/latitude"]
+	path = extensions/latitude
+	url = https://github.com/latitude-dev/latitude-zed.git
+	branch = main
+
 [submodule "extensions/latte"]
 	path = extensions/latte
 	url = https://github.com/josbeir/zed-latte.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2191,6 +2191,10 @@ version = "0.1.19"
 submodule = "extensions/latex"
 version = "0.2.3"
 
+[latitude]
+submodule = "extensions/latitude"
+version = "0.1.0"
+
 [latte]
 submodule = "extensions/latte"
 version = "0.1.0"


### PR DESCRIPTION
Adds the Latitude Zed extension as a marketplace extension.

- Adds the public latitude-zed repository as a submodule under extensions/latitude
- Registers version 0.1.0 in extensions.toml
- Ran pnpm sort-extensions, pnpm build, and pnpm test
