### PR TITLE
Add SemiDark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3722,6 +3722,10 @@
 	path = extensions/semgrep
 	url = https://github.com/zeelsheladiya/zed-semgrep.git
 
+[submodule "extensions/semidark-theme"]
+	path = extensions/semidark-theme
+	url = https://github.com/iskrant/semidarkTheme.git
+
 [submodule "extensions/sentry-mcp"]
 	path = extensions/sentry-mcp
 	url = https://github.com/fabric0de/sentry-mcp-server-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3778,6 +3778,11 @@ version = "0.2.0"
 submodule = "extensions/semgrep"
 version = "0.0.2"
 
+[semidark-theme]
+submodule = "extensions/semidark-theme"
+path = "packages/zed"
+version = "0.0.1"
+
 [sentry-mcp]
 submodule = "extensions/sentry-mcp"
 version = "0.1.2"


### PR DESCRIPTION
Adds the SemiDark theme extension.

Repository: https://github.com/iskrant/semidarkTheme
Extension path: packages/zed
Version: 0.0.1
