### PR TITLE
Add todos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4346,6 +4346,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todos"]
+	path = extensions/todos
+	url = https://github.com/elanandkumar/zed-todos.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4402,13 +4402,13 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
-[submodule "extensions/todos"]
-	path = extensions/todos
-	url = https://github.com/elanandkumar/zed-todos.git
-
 [submodule "extensions/todo-highlight-language-server"]
 	path = extensions/todo-highlight-language-server
 	url = https://github.com/shionit/zed-todo-highlight.git
+
+[submodule "extensions/todos"]
+	path = extensions/todos
+	url = https://github.com/elanandkumar/zed-todos.git
 
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt

--- a/extensions.toml
+++ b/extensions.toml
@@ -4419,7 +4419,7 @@ version = "0.0.2"
 
 [todos]
 submodule = "extensions/todos"
-version = "0.1.1"
+version = "0.2.0"
 
 [todotxt]
 submodule = "extensions/todotxt"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4417,6 +4417,10 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todos]
+submodule = "extensions/todos"
+version = "0.1.0"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4474,14 +4474,14 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
-[todos]
-submodule = "extensions/todos"
-version = "0.2.0"
-
 [todo-highlight-language-server]
 submodule = "extensions/todo-highlight-language-server"
 version = "0.2.0"
 path = "extension"
+
+[todos]
+submodule = "extensions/todos"
+version = "0.2.0"
 
 [todotxt]
 submodule = "extensions/todotxt"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4419,7 +4419,7 @@ version = "0.0.2"
 
 [todos]
 submodule = "extensions/todos"
-version = "0.1.0"
+version = "0.1.1"
 
 [todotxt]
 submodule = "extensions/todotxt"


### PR DESCRIPTION
Adds the [Todos](https://github.com/elanandkumar/zed-todos) extension.

Task management for `.todo` files with syntax highlighting, code actions to toggle task state, auto-insert next task on Enter, and inlay hints showing task counts per section.

  - Tested locally as dev extension
  - LSP server published to npm (`@elanandkumar/todo-ls`) — not shipped in the extension
  - MIT licensed