### PR TITLE
Add veda-pro-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4470,6 +4470,10 @@
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git
 
+[submodule "extensions/veda-pro-theme"]
+	path = extensions/veda-pro-theme
+	url = https://github.com/xqsit94/veda-pro-zed.git
+
 [submodule "extensions/vento"]
 	path = extensions/vento
 	url = https://github.com/dz4k/zed-vento

--- a/extensions.toml
+++ b/extensions.toml
@@ -4534,6 +4534,10 @@ version = "0.0.2"
 submodule = "extensions/vcard"
 version = "0.3.0"
 
+[veda-pro-theme]
+submodule = "extensions/veda-pro-theme"
+version = "0.1.0"
+
 [vento]
 submodule = "extensions/vento"
 version = "1.0.0"


### PR DESCRIPTION
Adds **Veda Pro**, a vivid One Dark Pro-inspired dark theme on a deep violet-indigo background, with a coordinated 16-color ANSI terminal palette.

- Extension id: `veda-pro-theme`
- Repository: https://github.com/xqsit94/veda-pro-zed
- Theme-only extension; `themes/veda-pro.json` validates against the v0.2.0 schema.

I have tested that my extension installs and runs in Zed via `zed --install-dev-extension .`.