### PR TITLE
Add languagetool language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2138,6 +2138,10 @@
 	path = extensions/kvs-cyberpunk-2077
 	url = https://github.com/notKvS/2077-zed.git
 
+[submodule "extensions/languagetool"]
+	path = extensions/languagetool
+	url = https://github.com/mschuwalow/languagetool-zed-extension.git
+
 [submodule "extensions/laravel"]
 	path = extensions/laravel
 	url = https://github.com/GeneaLabs/zed-laravel.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2175,6 +2175,10 @@ version = "0.0.1"
 submodule = "extensions/kvs-cyberpunk-2077"
 version = "1.0.3"
 
+[languagetool]
+submodule = "extensions/languagetool"
+version = "0.1.0"
+
 [laravel]
 submodule = "extensions/laravel"
 version = "0.1.19"


### PR DESCRIPTION
Adds the LanguageTool extension for Zed.

This extension provides grammar and style checking through LanguageTool by running `languagetool-lsp` as a language server. It supports local or cloud LanguageTool backends, publishes diagnostics, and provides quick fixes for LanguageTool replacements.

Supported languages include:
- Plain Text
- Markdown
- MDX
- HTML
- Python
- Rust
- JavaScript / TypeScript
- Java
- Scala
- Nix

The extension prefers an existing `languagetool-lsp` binary on `PATH`, otherwise it downloads the latest compatible release from GitHub.

Repository: https://github.com/mschuwalow/languagetool-zed-extension
Language Server Repository: https://github.com/mschuwalow/languagetool-lsp