### PR TITLE
Add word-highlight language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5493,3 +5493,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/word-highlight-lsp"]
+	path = extensions/word-highlight-lsp
+	url = https://github.com/0xdea/zed-highlight.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5306,6 +5306,10 @@
 	path = extensions/woocommerce-snippets
 	url = https://github.com/renzojohnson/woocommerce-snippets.git
 
+[submodule "extensions/word-highlight-lsp"]
+	path = extensions/word-highlight-lsp
+	url = https://github.com/0xdea/zed-highlight.git
+
 [submodule "extensions/wow-toc"]
 	path = extensions/wow-toc
 	url = https://github.com/Alexayy/zed-wow-toc.git
@@ -5493,6 +5497,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/word-highlight-lsp"]
-	path = extensions/word-highlight-lsp
-	url = https://github.com/0xdea/zed-highlight.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5402,6 +5402,10 @@ version = "1.0.0"
 submodule = "extensions/woocommerce-snippets"
 version = "0.1.0"
 
+[word-highlight-lsp]
+submodule = "extensions/word-highlight-lsp"
+version = "0.1.4"
+
 [wow-toc]
 submodule = "extensions/wow-toc"
 version = "0.0.1"


### PR DESCRIPTION
Word Highlight is a language extension for the Zed editor, designed to provide word highlighting. 

It's useful for quickly identifying all occurrences of selected words in code, enhancing readability and navigation when tracing the execution flow from input sources to potential vulnerability sinks.