### PR TITLE
Add python-autodoc language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3510,8 +3510,8 @@
 	path = extensions/pytest-language-server
 	url = https://github.com/bellini666/pytest-language-server.git
 
-[submodule "extensions/python-autodoc"]
-	path = extensions/python-autodoc
+[submodule "extensions/python-autodoc-lsp"]
+	path = extensions/python-autodoc-lsp
 	url = https://github.com/eallender/zed-python-autodoc.git
 
 [submodule "extensions/python-refactoring"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -3510,6 +3510,10 @@
 	path = extensions/pytest-language-server
 	url = https://github.com/bellini666/pytest-language-server.git
 
+[submodule "extensions/python-autodoc"]
+	path = extensions/python-autodoc
+	url = https://github.com/eallender/zed-python-autodoc.git
+
 [submodule "extensions/python-refactoring"]
 	path = extensions/python-refactoring
 	url = https://github.com/rowillia/zed-python-refactoring.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3568,9 +3568,9 @@ submodule = "extensions/pytest-language-server"
 path = "extensions/zed-extension"
 version = "0.22.0"
 
-[python-autodoc]
-submodule = "extensions/python-autodoc"
-version = "0.1.0"
+[python-autodoc-lsp]
+submodule = "extensions/python-autodoc-lsp"
+version = "0.1.1"
 
 [python-refactoring]
 submodule = "extensions/python-refactoring"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3568,6 +3568,10 @@ submodule = "extensions/pytest-language-server"
 path = "extensions/zed-extension"
 version = "0.22.0"
 
+[python-autodoc]
+submodule = "extensions/python-autodoc"
+version = "0.1.0"
+
 [python-refactoring]
 submodule = "extensions/python-refactoring"
 version = "0.0.3"


### PR DESCRIPTION
Adds the python-autodoc extension to the marketplace.

This extension provides a language server that automates docstring generation for Python functions and classes.