### PR TITLE
Bump veda-pro-theme to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4549,7 +4549,7 @@ version = "0.3.0"
 
 [veda-pro-theme]
 submodule = "extensions/veda-pro-theme"
-version = "0.1.0"
+version = "0.1.1"
 
 [vento]
 submodule = "extensions/vento"


### PR DESCRIPTION
Bumps `veda-pro-theme` from `0.1.0` to `0.1.1`.

## Changes

- Fix unreadable LSP diagnostic hover popovers. Previously only the bright foreground status colors (`error`, `warning`, `info`, `hint`) were emitted; without matching `<status>.background` / `<status>.border` keys, the popovers painted the bright color as their own background. v0.1.1 emits translucent tint backgrounds (`0x1A`) and borders (`0x66`) so popovers render readably on the dark editor surface.
- Apply the same treatment to git status colors (`created`, `modified`, `deleted`) so diff-hunk popovers and SCM status pills are readable.
- Emit the previously-missing top-level `modified` foreground (only `version_control.modified` was set before).

Release notes: https://github.com/xqsit94/veda-pro-zed/releases/tag/v0.1.1
Source PR (popover fix): https://github.com/xqsit94/veda-pro-zed/pull/2