### PR TITLE
Add Neon MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2514,6 +2514,10 @@
 	path = extensions/mcp-server-mysql
 	url = https://github.com/toonvd/zed-mysql-mcp.git
 
+[submodule "extensions/mcp-server-neon"]
+	path = extensions/mcp-server-neon
+	url = https://github.com/jordan-jakisa/mcp-server-neon.git
+
 [submodule "extensions/mcp-server-newsnow"]
 	path = extensions/mcp-server-newsnow
 	url = https://github.com/benmooo/zed-mcp-server-newsnow.git
@@ -4881,6 +4885,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/mcp-server-neon"]
-	path = extensions/mcp-server-neon
-	url = https://github.com/jordan-jakisa/mcp-server-neon.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4881,3 +4881,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-server-neon"]
+	path = extensions/mcp-server-neon
+	url = https://github.com/jordan-jakisa/mcp-server-neon.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2555,6 +2555,10 @@ version = "0.3.0"
 submodule = "extensions/mcp-server-mysql"
 version = "0.0.1"
 
+[mcp-server-neon]
+submodule = "extensions/mcp-server-neon"
+version = "0.0.1"
+
 [mcp-server-newsnow]
 submodule = "extensions/mcp-server-newsnow"
 version = "0.0.10"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2557,7 +2557,7 @@ version = "0.0.1"
 
 [mcp-server-neon]
 submodule = "extensions/mcp-server-neon"
-version = "0.0.1"
+version = "0.1.0"
 
 [mcp-server-newsnow]
 submodule = "extensions/mcp-server-newsnow"


### PR DESCRIPTION
Adds the Neon MCP extension, which bundles the official [`@neondatabase/mcp-server-neon`](https://www.npmjs.com/package/@neondatabase/mcp-server-neon) so users can manage Neon Postgres projects, branches, and databases from Zed's assistant.

- Extension repo: https://github.com/jordan-jakisa/mcp-server-neon
- Pinned tag: `v0.0.1`
- License: Apache-2.0

### Checklist
- [x] Tested locally as a dev extension (`zed: install dev extension`)
- [x] Extension repo includes an accepted license
- [x] `extensions.toml` entry added alphabetically
- [x] Submodule pinned to the released tag
- [x] Followed the [Publishing Your Extension](https://zed.dev/docs/extensions/developing-extensions#publishing-your-extension) steps

### Configuration
Users set their Neon API key in Zed settings:

```json
"context_servers": {
  "mcp-server-neon": {
    "settings": { "neon_api_key": "napi_..." }
  }
}