### PR TITLE
Add Alphabetical Sorter language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -110,6 +110,10 @@
 	path = extensions/alpental-theme
 	url = https://github.com/ascarter/zed-alpental-theme.git
 
+[submodule "extensions/alphabetical-sorter"]
+	path = extensions/alphabetical-sorter
+	url = https://github.com/AWCostabile/zed-extension-alphabetical-sorter.git
+
 [submodule "extensions/alpinejs-snippets"]
 	path = extensions/alpinejs-snippets
 	url = https://github.com/A909M/zed-alpinejs-snippets
@@ -4881,6 +4885,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/alphabetical-sorter"]
-	path = extensions/alphabetical-sorter
-	url = https://github.com/AWCostabile/zed-extension-alphabetical-sorter.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4881,3 +4881,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/alphabetical-sorter"]
+	path = extensions/alphabetical-sorter
+	url = https://github.com/AWCostabile/zed-extension-alphabetical-sorter.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -113,6 +113,10 @@ version = "2.0.2"
 submodule = "extensions/alpental-theme"
 version = "0.0.9"
 
+[alphabetical-sorter]
+submodule = "extensions/alphabetical-sorter"
+version = "0.1.0"
+
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -115,7 +115,7 @@ version = "0.0.9"
 
 [alphabetical-sorter]
 submodule = "extensions/alphabetical-sorter"
-version = "0.1.1"
+version = "0.1.0"
 
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"

--- a/extensions.toml
+++ b/extensions.toml
@@ -115,7 +115,7 @@ version = "0.0.9"
 
 [alphabetical-sorter]
 submodule = "extensions/alphabetical-sorter"
-version = "0.1.0"
+version = "0.1.1"
 
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"


### PR DESCRIPTION
A code-action extension that sorts selected text (including multi-line, comma-separated, or by assigned value), via an LSP server. Supports alphabetical, natural (1, 2, 10), and descending sort, as well as smart trailing-comma preservation. Select text, press `Ctrl`+`.` and pick from an available sort action (only shows those which could apply).

- MIT license
- Tested locally via dev extensions