### PR TITLE
Add surpassone-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4058,6 +4058,10 @@
 	path = extensions/supertheme4
 	url = https://github.com/superkacper4/supertheme4
 
+[submodule "extensions/surpassone-theme"]
+	path = extensions/surpassone-theme
+	url = https://github.com/aitit-inc/zed-surpassone-theme.git
+
 [submodule "extensions/surrealql"]
 	path = extensions/surrealql
 	url = https://github.com/siteforge-io/surql-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4118,6 +4118,10 @@ version = "0.0.20"
 submodule = "extensions/supertheme4"
 version = "0.0.3"
 
+[surpassone-theme]
+submodule = "extensions/surpassone-theme"
+version = "0.3.4"
+
 [surrealql]
 submodule = "extensions/surrealql"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds **SurpassOne**, a flat, monochrome color theme built on a coral tonal hierarchy and grayscale. Dark and Light variants are included.

- Repository: https://github.com/aitit-inc/zed-surpassone-theme
- License: MIT
- The theme JSON validates against the Zed theme schema (`v0.2.0`).

It is a port of the existing [SurpassOne theme for VS Code / Cursor](https://github.com/aitit-inc/vscode-surpassone-theme).