### PR TITLE
Add atlassian-rovo-mcp-server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -254,6 +254,10 @@
 	path = extensions/atlas-ragnarok-theme
 	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git
 
+[submodule "extensions/atlassian-rovo-mcp-server"]
+	path = extensions/atlassian-rovo-mcp-server
+	url = https://github.com/mgoodness/zed-mcp-server-atlassian-rovo.git
+
 [submodule "extensions/atom-one-theme"]
 	path = extensions/atom-one-theme
 	url = https://github.com/Stelath/zed-atom-one-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -261,7 +261,7 @@ version = "1.0.0"
 
 [atlassian-rovo-mcp-server]
 submodule = "extensions/atlassian-rovo-mcp-server"
-version = "0.0.1"
+version = "0.1.0"
 
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -259,6 +259,10 @@ submodule = "extensions/atlas-ragnarok-theme"
 path = "editors/zed"
 version = "1.0.0"
 
+[atlassian-rovo-mcp-server]
+submodule = "extensions/atlassian-rovo-mcp-server"
+version = "0.0.1"
+
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds a thin Zed extension that connects Zed to Atlassian's hosted Rovo MCP server via `mcp-remote`.

## What it does

- Registers an MCP context server (`atlassian-rovo`) in Zed's Agent Panel
- At first use, auto-installs `mcp-remote@0.1.37` into an extension-local `node_modules` via Zed's npm APIs
- Launches the bridge: `node dist/proxy.js https://mcp.atlassian.com/v1/mcp/authv2`
- Completes OAuth 2.1 via the system browser — no stored credentials
- Exposes Jira and Confluence tools (list issues, search pages, etc.) to Zed AI

## Checklist

- [x] Unique extension ID (`atlassian-rovo-mcp-server`) not already in the marketplace
- [x] ID and name contain neither "zed" nor "extension"
- [x] Apache 2.0 license included
- [x] MCP server is not shipped — downloaded at runtime via npm / served remotely by Atlassian
- [x] Tested locally as a dev extension
- [x] Version in `extensions.toml` matches `extension.toml` (`0.1.0`)
- [x] Submodule uses HTTPS URL