### PR TITLE
Add edusites theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1166,8 +1166,8 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
-[submodule "extensions/edusites"]
-	path = extensions/edusites
+[submodule "extensions/edusites-theme"]
+	path = extensions/edusites-theme
 	url = https://github.com/eduardolecdt/edusites-theme-zed.git
 
 [submodule "extensions/eiffel-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4885,6 +4885,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/edusites"]
-	path = extensions/edusites
-	url = https://github.com/eduardolecdt/edusites-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1162,6 +1162,10 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/edusites"]
+	path = extensions/edusites
+	url = https://github.com/eduardolecdt/edusites-theme-zed.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -4881,3 +4885,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/edusites"]
+	path = extensions/edusites
+	url = https://github.com/eduardolecdt/edusites-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1190,15 +1190,13 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
-<<<<<<< add-edusites-theme
 [submodule "extensions/edusites-theme"]
 	path = extensions/edusites-theme
 	url = https://github.com/eduardolecdt/edusites-theme-zed.git
-=======
+
 [submodule "extensions/effect-language-service-tsgo"]
 	path = extensions/effect-language-service-tsgo
 	url = https://github.com/RATIU5/zed-effect-tsgo.git
->>>>>>> main
 
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1184,8 +1184,8 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
-[edusites]
-submodule = "extensions/edusites"
+[edusites-theme]
+submodule = "extensions/edusites-theme"
 version = "1.0.0"
 
 [eiffel-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1180,6 +1180,10 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
+[edusites]
+submodule = "extensions/edusites"
+version = "1.0.0"
+
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.1.1"


### PR DESCRIPTION
Adds the **EduSites** theme extension.

- Repository: https://github.com/eduardolecdt/edusites-theme-zed
- Two variants: **EduSites Dark** and **EduSites Light**
- Brand palette built around purple `#6217EC`
- Conforms to schema `https://zed.dev/schema/themes/v0.2.0.json`
- License: MIT (present at the repository root)

Checklist:
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml` (alphabetical)
- [x] `extension.toml` includes id, name, version, schema_version, authors, description, repository
- [x] Repository is public with a tagged release (v1.0.0)