### PR TITLE
Add Token-themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4250,6 +4250,10 @@
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git
 
+[submodule "extensions/token-themes"]
+	path = extensions/token-themes
+	url = https://github.com/mrzzmrzz/token-themes.git
+
 [submodule "extensions/tokyo-maple-theme"]
 	path = extensions/tokyo-maple-theme
 	url = https://github.com/Cateds/Tokyo-Maple-Theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4313,6 +4313,10 @@ version = "0.0.2"
 submodule = "extensions/todotxt"
 version = "0.2.3"
 
+[token-themes]
+submodule = "extensions/token-themes"
+version = "0.0.1"
+
 [tokyo-maple-theme]
 submodule = "extensions/tokyo-maple-theme"
 version = "1.3.0"


### PR DESCRIPTION
## Summary

- Adds `mrzzmrzz/token-themes` as a new theme extension submodule.
- Registers `token-themes` at version `0.0.1`.
- Provides Token Light and Token Dark for Zed.

## Validation

- `bun run build`
- `bun run test`
- `bun run sort-extensions && git diff --exit-code -- extensions.toml .gitmodules`
- custom registry validation for `extensions.toml`, `.gitmodules`, manifest, and license
- Zed theme JSON schema validation against `https://zed.dev/schema/themes/v0.2.0.json`
