### PR TITLE
Bump asciidoc to v0.5.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -216,7 +216,7 @@ version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
-version = "0.5.1"
+version = "0.5.2"
 
 [ashen]
 submodule = "extensions/ashen"


### PR DESCRIPTION
## Summary
- update `extensions/asciidoc` submodule pointer to the latest `main`
- brings in zed-asciidoc `v0.5.2`
- includes latest tree-sitter-asciidoc grammar commit (`dd042737a453599bc851b7338d9222d3bd35df53`)
