### PR TITLE
Add mq extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2814,6 +2814,10 @@
 	path = extensions/mpls
 	url = https://github.com/pnyda/zed-mpls.git
 
+[submodule "extensions/mq"]
+	path = extensions/mq
+	url = https://github.com/harehare/mq.git
+
 [submodule "extensions/msun-dark"]
 	path = extensions/msun-dark
 	url = https://github.com/mikesun/msun-dark-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2860,6 +2860,11 @@ version = "0.0.2"
 submodule = "extensions/mpls"
 version = "0.2.0"
 
+[mq]
+submodule = "extensions/mq"
+path = "editors/zed"
+version = "0.2.0"
+
 [msun-dark]
 submodule = "extensions/msun-dark"
 version = "1.0.2"


### PR DESCRIPTION
Adds mq language support for [mq](https://mqlang.org/), a jq-like command-line tool for Markdown processing.
 
- Registers the mq extension in `extensions.toml`
- Adds `harehare/zed-mq` as the extension submodule
- Downloads `mq-lsp` binary automatically from GitHub releases
- Includes Tree-sitter grammar, syntax highlighting, LSP support, and AI Assistant slash commands