### PR TITLE
Add NEON (Nette Object Notation) language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2806,6 +2806,10 @@
 	path = extensions/neocmake
 	url = https://github.com/k0tran/zed_neocmake.git
 
+[submodule "extensions/neon"]
+	path = extensions/neon
+	url = https://github.com/shubhamdhaboya/zed-neon-extension.git
+
 [submodule "extensions/neon-comfy-soft-themes"]
 	path = extensions/neon-comfy-soft-themes
 	url = https://github.com/guustavocl/zed-neon-comfy-soft-themes

--- a/extensions.toml
+++ b/extensions.toml
@@ -2849,6 +2849,10 @@ version = "0.1.0"
 submodule = "extensions/neocmake"
 version = "1.0.0"
 
+[neon]
+submodule = "extensions/neon"
+version = "0.0.1"
+
 [neon-comfy-soft-themes]
 submodule = "extensions/neon-comfy-soft-themes"
 version = "0.1.0"


### PR DESCRIPTION
## Add `neon` extension

  Adds language support for [NEON](https://ne-on.org/) (Nette Object Notation) — the
  indentation-based configuration format used by the [Nette](https://nette.org) framework
  and tools like PHPStan. Files: `*.neon`.

  ### Features
  - Syntax highlighting — keys, quoted/bare strings, triple-quoted multiline strings,
    numbers (dec/hex/oct/bin), booleans, null, dates/datetimes, `@references`,
    `%parameters%`, entities, and comments
  - Bracket matching & autoclose, indentation, and document outline (mapping keys)
  - Folding via indentation

  ### Grammar
  Backed by a dedicated tree-sitter grammar with an external scanner for NEON's
  indentation: https://github.com/shubhamdhaboya/tree-sitter-neon
  (pinned by commit in `extension.toml`).

  ### Links
  - Extension: https://github.com/shubhamdhaboya/zed-neon-extension
  - Grammar: https://github.com/shubhamdhaboya/tree-sitter-neon

  ### Checklist
  - [x] Extension added as a Git submodule under `extensions/` (HTTPS URL)
  - [x] Entry added to `extensions.toml` (`[neon]`, `version = "0.0.1"`)
  - [x] Ran `pnpm sort-extensions`
  - [x] Repository includes an OSI-approved `LICENSE` (MIT)
  - [x] Extension `id` (`neon`) is unique in the registry