### PR TITLE
Add Zenburn Transparent theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4866,6 +4866,10 @@
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
 
+[submodule "extensions/zenburn-transparent"]
+	path = extensions/zenburn-transparent
+	url = https://github.com/rockas-d/zenburn-transparent.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4866,8 +4866,8 @@
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
 
-[submodule "extensions/zenburn-transparent"]
-	path = extensions/zenburn-transparent
+[submodule "extensions/zenburn-transparent-theme"]
+	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git
 
 [submodule "extensions/zero-trust-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4933,7 +4933,7 @@ submodule = "extensions/zen-abyssal"
 version = "1.4.3"
 
 [zenburn-transparent-theme]
-submodule = "extensions/zenburn-transparent"
+submodule = "extensions/zenburn-transparent-theme"
 version = "1.0.0"
 
 [zero-trust-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4932,6 +4932,10 @@ version = "0.0.3"
 submodule = "extensions/zen-abyssal"
 version = "1.4.3"
 
+[zenburn-transparent-theme]
+submodule = "extensions/zenburn-transparent"
+version = "1.0.0"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"


### PR DESCRIPTION
Adds **Zenburn Transparent** — the classic low-contrast Zenburn palette ported faithfully, with a fully transparent / blurred UI (`background.appearance: "blurred"`). Every surface shares one uniform translucent Zenburn-grey tint.

- Extension repo: https://github.com/rockas-d/zenburn-transparent (public, HTTPS, pinned at v1.0.0)
- id: `zenburn-transparent-theme` (`-theme` suffix per docs; no collision in registry)
- License: GPL-3.0, matching upstream [zenburn-emacs](https://github.com/bbatsov/zenburn-emacs); palette credited to Bozhidar Batsov / Jani Nurminen
- Theme validates against `themes/v0.2.0.json`
- `extensions.toml` and `.gitmodules` ordered via `node src/sort-extensions.js`

Note: blur/transparency relies on Zed window-transparency (most reliable on macOS); colors degrade gracefully to opaque elsewhere.