### PR TITLE
Add Doom One Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1086,6 +1086,10 @@
 	path = extensions/dogxi-theme
 	url = https://github.com/dogxii/dogxi-theme-zed.git
 
+[submodule "extensions/doom-one-theme"]
+	path = extensions/doom-one-theme
+	url = https://github.com/bashln/zed-doom.git
+
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
 	url = https://github.com/ozacod/zed-doxygen.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1103,6 +1103,10 @@ version = "1.0.4"
 submodule = "extensions/dogxi-theme"
 version = "0.0.2"
 
+[doom-one-theme]
+submodule = "extensions/doom-one-theme"
+version = "1.0.0"
+
 [doxygen]
 submodule = "extensions/doxygen"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the **Doom One Theme** extension to Zed. This is a clean resubmission of #6270.

### What was corrected:

- In the previous PR (#6270), the `.gitmodules` file had many unrelated modifications due to sorting inconsistencies on my local environment.
- This PR was rebuilt on top of a clean `main` branch. The submodule was added cleanly and sorted, resulting in a minimal diff that only touches `doom-one-theme`.

## Checklist

- [x] Extension has a license (MIT)
- [x] `extension.toml` is valid with all required fields (`id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`)
- [x] Version in `extensions.toml` matches `extension.toml` (`1.0.0`)
- [x] Ran `pnpm sort-extensions`
- [x] Theme JSON files include `$schema` reference

---

This PR aims to add the Doom One theme extension (doom-one-theme), which is a faithful and vibrant port of the popular Doom One theme from Doom Emacs to Zed. It includes Doom One (Dark), Doom One Darker, and Doom One Light variants.

As someone who recently transitioned from Doom Emacs to Zed, this is a theme I use daily and believe other developers can benefit from and enjoy as well.

Sorry @MrSubidubi for the issues regarding the last PR.