### PR TITLE
Update surpassone-theme to v0.3.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4137,7 +4137,7 @@ version = "0.0.3"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"
-version = "0.3.4"
+version = "0.3.5"
 
 [surrealql]
 submodule = "extensions/surrealql"


### PR DESCRIPTION
Update surpassone-theme to v0.3.5. See https://github.com/aitit-inc/zed-surpassone-theme/releases/tag/v0.3.5