### PR TITLE
Add ctok - Claude token estimator extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4905,3 +4905,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ctok"]
+	path = extensions/ctok
+	url = https://github.com/ctok-cli/ctok-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -878,6 +878,10 @@
 	path = extensions/ctags
 	url = https://github.com/mazurel/zed-ctags.git
 
+[submodule "extensions/ctok"]
+	path = extensions/ctok
+	url = https://github.com/ctok-cli/ctok-zed.git
+
 [submodule "extensions/cucumber"]
 	path = extensions/cucumber
 	url = https://github.com/thlcodes/zed-extension-cucumber
@@ -4905,6 +4909,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ctok"]
-	path = extensions/ctok
-	url = https://github.com/ctok-cli/ctok-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -892,6 +892,10 @@ version = "0.0.3"
 submodule = "extensions/ctags"
 version = "0.0.2"
 
+[ctok]
+submodule = "extensions/ctok"
+version = "0.1.0"
+
 [cucumber]
 submodule = "extensions/cucumber"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -894,7 +894,7 @@ version = "0.0.2"
 
 [ctok]
 submodule = "extensions/ctok"
-version = "0.1.0"
+version = "0.2.0"
 
 [cucumber]
 submodule = "extensions/cucumber"


### PR DESCRIPTION
## Summary

Adds the **ctok** extension - a Claude token estimator for Zed.

- Estimates token count and cost for any text or current file
- Refines prompts to reduce tokens while preserving intent
- Scans a project directory and reports token usage by file

## Extension details

- **ID:** `ctok`
- **Version:** 0.1.0
- **Repository:** https://github.com/ctok-cli/ctok-zed
- **License:** MIT

## Slash commands provided

| Command | Description |
|---|---|
| `/ctok-check` | Estimate token count and cost |
| `/ctok-refine` | Refine a prompt to reduce tokens |
| `/ctok-scan` | Scan project directory for token usage |

## Checklist

- [x] Extension has a valid `extension.toml` at the repo root
- [x] Extension compiles against `zed_extension_api = "0.2"`
- [x] Repository is public
- [x] Submodule added to `extensions/ctok`