### PR TITLE
Add Papyrus SSE language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3206,6 +3206,10 @@
 	path = extensions/papercolor
 	url = https://github.com/emirror-de/papercolor-zed.git
 
+[submodule "extensions/papyrus-sse"]
+	path = extensions/papyrus-sse
+	url = https://github.com/Silent-City-Projects/zed-papyrus-sse.git
+
 [submodule "extensions/paraiso"]
 	path = extensions/paraiso
 	url = https://github.com/treffynnon/zed-Paraiso.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3252,6 +3252,10 @@ version = "1.0.0"
 submodule = "extensions/papercolor"
 version = "0.2.0"
 
+[papyrus-sse]
+submodule = "extensions/papyrus-sse"
+version = "0.0.3"
+
 [paraiso]
 submodule = "extensions/paraiso"
 version = "1.0.2"


### PR DESCRIPTION
Papyrus is a scripting language used in Bethesda Softworks games. This extension targets specifically the version of Papyrus used in Skyrim Special Edition (SSE).

The extension currently implements a tree-sitter parser for the language and some snippets.