### PR TITLE
Add Weixin WXML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4706,6 +4706,10 @@
 	path = extensions/webidl
 	url = https://github.com/padenot/zed-webidl.git
 
+[submodule "extensions/weixin-wxml"]
+	path = extensions/weixin-wxml
+	url = https://github.com/zscumt123/wxml-zed.git
+
 [submodule "extensions/wgsl"]
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4775,6 +4775,11 @@ version = "0.0.1"
 submodule = "extensions/webidl"
 version = "0.0.2"
 
+[weixin-wxml]
+submodule = "extensions/weixin-wxml"
+path = "packages/zed"
+version = "0.3.0"
+
 [wgsl]
 submodule = "extensions/wgsl"
 version = "0.0.1"


### PR DESCRIPTION
Adds `weixin-wxml`, a WXML extension for WeChat Mini Program development.

  This provides a fuller language experience than the existing syntax-only `wxml` extension:
  
  - Tree-sitter WXML highlighting, outline, snippets, and textobjects
  - WXML project-graph–backed diagnostics (missing local components, undefined event handlers / expression refs, dead component
  bindings; live overlay on unsaved edits)
  - Go to definition: components, import/include, external WXS modules, event handlers, data/property refs, WXS cross-references, and
  `wx:for` bindings
  - Hover: data/property refs, WXS modules, event handlers, components, and `wx:for` bindings (use-site and declaration)
  - Completion: built-in tags, resolved components, static templates, common attributes, event handlers, expression refs, and
  cursor-scoped `wx:for` bindings
  - The language server is distributed as an external Node artifact downloaded from this project's GitHub Releases (pinned to the
  extension version and cached locally; works offline after first fetch) — it is **not** bundled in the extension.
  
  The extension code lives under `packages/zed`, so this registry entry uses `path = "packages/zed"`, where the extension `LICENSE` and
  `NOTICE` are present.
  
  **Why a separate extension rather than contributing to `wxml`:** the existing `wxml` extension is syntax-only and built on a different
  architecture (vendored grammar, no language server). This extension adds a full Node-based LSP stack; folding that into `wxml` would
  be a ground-up rewrite of another author's published extension. We publish separately to avoid an unconsented maintainer takeover,
  while preserving the original MIT attribution (see `NOTICE`, which credits the upstream WXML grammar/extension baseline). We're glad
  to coordinate with the `wxml` maintainer or reconsider consolidation if the Zed team prefers.

  Tested locally as a dev extension in Zed against a real WeChat Mini Program project: the language server downloads and starts from the
  release artifact, and go-to-definition navigates from WXML (`bindsubmit="onSubmit"`) to the backing JS method.