### PR TITLE
Add Sashimi theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4909,3 +4909,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sashimi-theme"]
+	path = extensions/sashimi-theme
+	url = https://github.com/Matias-Sanmiguel/sashimi-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -3788,6 +3788,10 @@ version = "0.1.0"
 submodule = "extensions/salesforce"
 version = "0.0.4"
 
+[sashimi-theme]
+submodule = "extensions/sashimi-theme"
+version = "0.1.0"
+
 [scala]
 submodule = "extensions/scala"
 version = "0.2.2"


### PR DESCRIPTION
Adds the Sashimi theme — a light and dark color palette based on sashimi nigiri ingredients (Toro, Akami, Nori, Shari, Cream, Wasabi).

- Extension repo: https://github.com/Matias-Sanmiguel/sashimi-zed-theme
- Includes `Sashimi` (light) and `Sashimi Dark` variants