### PR TITLE
Add OneDarkPro2026 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4909,3 +4909,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/bayaraa-onedarkpro-theme"]
+	path = extensions/bayaraa-onedarkpro-theme
+	url = https://github.com/bayaraa/OneDarkPro2026Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -376,6 +376,10 @@ version = "0.0.3"
 submodule = "extensions/batsignal-theme"
 version = "0.0.1"
 
+[bayaraa-onedarkpro-theme]
+submodule = "extensions/bayaraa-onedarkpro-theme"
+version = "0.0.1"
+
 [beancount]
 submodule = "extensions/beancount"
 version = "0.1.2"


### PR DESCRIPTION
Adds the OneDarkPro2026 dark theme for Zed.

Extension ID: `bayaraa-onedarkpro-theme`
Version: `0.0.1`
Repository: https://github.com/bayaraa/OneDarkPro2026Zed