### PR TITLE
Update ssh-config to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4056,7 +4056,7 @@ version = "0.0.3"
 
 [ssh-config]
 submodule = "extensions/ssh-config"
-version = "0.1.0"
+version = "0.2.0"
 
 [stakpak]
 submodule = "extensions/stakpak"


### PR DESCRIPTION
Updates ssh-config extension to v0.2.0.

It now uses the latest [tree-sitter-ssh-config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config), which allows escaped quotes in strings.