### PR TITLE
Add Mojo language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2686,6 +2686,10 @@
 	path = extensions/modus-themes
 	url = https://github.com/vitallium/zed-modus-themes.git
 
+[submodule "extensions/mojo"]
+	path = extensions/mojo
+	url = https://github.com/vadim-su/zed_mojo.git
+
 [submodule "extensions/molten-theme"]
 	path = extensions/molten-theme
 	url = https://github.com/vaqxai/zed-molten-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2729,6 +2729,10 @@ version = "0.1.9"
 submodule = "extensions/modus-themes"
 version = "0.2.1"
 
+[mojo]
+submodule = "extensions/mojo"
+version = "0.0.1"
+
 [molten-theme]
 submodule = "extensions/molten-theme"
 version = "1.0.0"


### PR DESCRIPTION
Adds the Mojo language extension to the Zed extension registry.

Extension repository: https://github.com/vadim-su/zed_mojo

Includes:
- Mojo language configuration
- Tree-sitter grammar registration
- Syntax/editor queries
- LSP integration for `mojo-lsp-server`
- Snippets and runnables support

Local checks run:
- `npm run sort-extensions`
- `npm run build`
- `npm run test`
- `git diff --cached --check`