### PR TITLE
Add Glide extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1590,6 +1590,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/glide"]
+	path = extensions/glide
+	url = https://github.com/glide-lang/zed-glide
+
 [submodule "extensions/gn"]
 	path = extensions/gn
 	url = https://github.com/dsa28s/zed-gn-language.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1614,6 +1614,10 @@ version = "0.1.0"
 submodule = "extensions/gleam-theme"
 version = "0.2.1"
 
+[glide]
+submodule = "extensions/glide"
+version = "0.3.2"
+
 [glsl]
 submodule = "extensions/zed"
 path = "extensions/glsl"


### PR DESCRIPTION
Adds language support for [Glide](https://github.com/glide-lang/Glide), a systems language that compiles to C.

The extension provides:
- Language server integration via `glide lsp` (diagnostics, hover, completion, signature help, go-to-definition, references, rename, document/workspace symbols, semantic tokens, inlay hints, code actions, formatting, call/type hierarchy).
- Tree-sitter highlighting, indents, and outline (grammar pinned from the Glide repo).
- A `/glide-routes` slash command listing `@route`'d handlers in a file.

Extension source: https://github.com/glide-lang/zed-glide

The extension resolves the `glide` binary from the worktree PATH / `~/.glide/bin`; it does not download the compiler. Validated locally with `cargo check --target wasm32-wasip1`.