### PR TITLE
Bump laravel to 0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2197,7 +2197,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.19"
+version = "0.2.1"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.2.1.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.2.1