### PR TITLE
Bump laravel to v0.2.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2160,7 +2160,7 @@
 
 [submodule "extensions/laravel"]
 	path = extensions/laravel
-	url = https://github.com/GeneaLabs/zed-laravel.git
+	url = https://github.com/mike-bronner/zed-laravel.git
 
 [submodule "extensions/latex"]
 	path = extensions/latex

--- a/extensions.toml
+++ b/extensions.toml
@@ -2197,7 +2197,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.1.19"
+version = "0.2.2"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.2.2.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.2.2