### PR TITLE
Add Wattle extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4694,6 +4694,10 @@
 	path = extensions/wat
 	url = https://github.com/g-plane/zed-wasm.git
 
+[submodule "extensions/wattle"]
+	path = extensions/wattle
+	url = https://github.com/zmscode/wattle-lang.git
+
 [submodule "extensions/wc-language-server"]
 	path = extensions/wc-language-server
 	url = https://github.com/wc-toolkit/wc-language-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4762,6 +4762,11 @@ version = "0.14.0"
 submodule = "extensions/wat"
 version = "0.2.3"
 
+[wattle]
+submodule = "extensions/wattle"
+path = "editors/zed"
+version = "0.2.0"
+
 [wc-language-server]
 submodule = "extensions/wc-language-server"
 path = "packages/zed"


### PR DESCRIPTION
Adds the **Wattle** language extension.

Wattle is a systems programming language (Zig-flavored syntax, Rust-style toolchain; compiled, no GC, errors-as-values, comptime metaprogramming).

The extension provides:
- Syntax highlighting via the tree-sitter grammar at https://github.com/zmscode/tree-sitter-wattle
- LSP support (diagnostics, hover, go-to-definition) by spawning `wattle lsp` from the user's PATH.

Extension source: https://github.com/zmscode/wattle-lang (`editors/zed/`). License: MIT OR Apache-2.0.