### PR TITLE
Add Ziex language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4882,6 +4882,10 @@
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git
 
+[submodule "extensions/ziex"]
+	path = extensions/ziex
+	url = https://github.com/ziex-dev/ziex.git
+
 [submodule "extensions/zig"]
 	path = extensions/zig
 	url = https://github.com/zed-extensions/zig.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4948,6 +4948,11 @@ version = "1.0.0"
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"
 
+[ziex]
+submodule = "extensions/ziex"
+version = "0.1.0-dev.1068"
+path = "ide/zed"
+
 [zig]
 submodule = "extensions/zig"
 version = "0.4.2"


### PR DESCRIPTION
This extension adds support for `.zx` and partial support for `.mdzx` file. `.zx` file is an extension to Zig language file with support for HTML like syntax. The extension currently provides syntax highlighting and LSP support to .zx file.

Repository: https://github.com/ziex-dev/ziex

<img width="1327" height="909" alt="image" src="https://github.com/user-attachments/assets/eedb76c2-9076-4bcc-b54c-711c1565050f" />

There was a PR opened before for this:
https://github.com/zed-industries/extensions/pull/4122
