### PR TITLE
Add Local History extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2242,6 +2242,10 @@
 	path = extensions/llvm-ir
 	url = https://github.com/kdkasad/zed-llvm-ir-extension
 
+[submodule "extensions/local-history"]
+	path = extensions/local-history
+	url = https://github.com/neuroborus/zed-local-history.git
+
 [submodule "extensions/log"]
 	path = extensions/log
 	url = https://github.com/nervenes/zed-log.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2281,6 +2281,11 @@ version = "0.0.4"
 submodule = "extensions/llvm-ir"
 version = "0.1.1"
 
+[local-history]
+submodule = "extensions/local-history"
+path = "editors/zed"
+version = "0.1.0"
+
 [log]
 submodule = "extensions/log"
 version = "0.0.7"


### PR DESCRIPTION
Adds [Local History](https://github.com/neuroborus/zed-local-history), a filesystem-first local history/recovery extension for Zed.

Extension path: `editors/zed`
Version: `0.1.0`
Submodule: `extensions/local-history`

Local History watches file saves, stores snapshots outside the project, exposes them to the Zed Agent Panel through MCP, and can restore a previous version while creating a safety snapshot first.

