### PR TITLE
Update datadog-mcp to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1010,7 +1010,7 @@ version = "0.3.7"
 
 [datadog-mcp]
 submodule = "extensions/datadog-mcp"
-version = "0.2.1"
+version = "0.3.0"
 
 [day-shift]
 submodule = "extensions/day-shift"


### PR DESCRIPTION
Fixes broken extension, adds support for toolsets and adds support for the new UK1 server.