### PR TITLE
Update phpcs to v0.4.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3296,7 +3296,7 @@
 
 [submodule "extensions/phpcs"]
 	path = extensions/phpcs
-	url = https://github.com/GeneaLabs/zed-phpcs-lsp.git
+	url = https://github.com/mike-bronner/zed-phpcs-lsp.git
 
 [submodule "extensions/phpmd"]
 	path = extensions/phpmd

--- a/extensions.toml
+++ b/extensions.toml
@@ -3343,7 +3343,7 @@ version = "0.1.0"
 
 [phpcs]
 submodule = "extensions/phpcs"
-version = "0.4.1"
+version = "0.4.3"
 
 [phpmd]
 submodule = "extensions/phpmd"


### PR DESCRIPTION
Bumps `phpcs` to v0.4.3.

Release notes: https://github.com/mike-bronner/zed-phpcs-lsp/releases/tag/0.4.3