### PR TITLE
Update phpmd to v0.1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3300,7 +3300,7 @@
 
 [submodule "extensions/phpmd"]
 	path = extensions/phpmd
-	url = https://github.com/GeneaLabs/zed-phpmd-lsp.git
+	url = https://github.com/mike-bronner/zed-phpmd-lsp.git
 
 [submodule "extensions/pica200"]
 	path = extensions/pica200

--- a/extensions.toml
+++ b/extensions.toml
@@ -3347,7 +3347,7 @@ version = "0.4.1"
 
 [phpmd]
 submodule = "extensions/phpmd"
-version = "0.1.0"
+version = "0.1.2"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
Bumps `phpmd` to v0.1.2.

Release notes: https://github.com/mike-bronner/zed-phpmd-lsp/releases/tag/0.1.2