### PR TITLE
Add Geode theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1518,6 +1518,10 @@
 	path = extensions/gentle-dark
 	url = https://github.com/gentlelionstudios/gentle-dark-zed.git
 
+[submodule "extensions/geode-theme"]
+	path = extensions/geode-theme
+	url = https://github.com/almeladev/geode-zed.git
+
 [submodule "extensions/ghost-in-the-shell-theme"]
 	path = extensions/ghost-in-the-shell-theme
 	url = https://github.com/ddoemonn/ghost-in-the-shell-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1542,6 +1542,10 @@ version = "0.2.0"
 submodule = "extensions/gentle-dark"
 version = "1.2.2"
 
+[geode-theme]
+submodule = "extensions/geode-theme"
+version = "0.1.0"
+
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds **Geode**, a gem-toned theme with dark and light variants.

- Repository: https://github.com/almeladev/geode-zed
- Extension ID: `geode-theme`
- Version: 0.1.0
- License: MIT

Geode reserves color for semantically meaningful tokens (keywords, types, functions, strings, literals) and keeps structural tokens neutral. Both variants meet WCAG AA contrast. Tested locally as a dev extension on macOS.