### PR TITLE
Add LOOS Monokai theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2266,6 +2266,10 @@
 	path = extensions/looped-themes
 	url = https://github.com/loopedautomation/editor-themes.git
 
+[submodule "extensions/loos-monokai-theme"]
+	path = extensions/loos-monokai-theme
+	url = https://github.com/ddryo/loos-monokai.git
+
 [submodule "extensions/lotus-theme"]
 	path = extensions/lotus-theme
 	url = https://github.com/skylissh/lotus-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2306,6 +2306,11 @@ submodule = "extensions/looped-themes"
 version = "1.0.4"
 path = "zed"
 
+[loos-monokai-theme]
+submodule = "extensions/loos-monokai-theme"
+path = "zed"
+version = "0.1.0"
+
 [lotus-theme]
 submodule = "extensions/lotus-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds **LOOS Monokai**, a customized Monokai dark theme for Zed
(refined syntax, diff, diagnostics, and terminal colors).

- **Repository:** https://github.com/ddryo/loos-monokai
- **Extension ID:** `loos-monokai-theme`
- **Path:** `zed` (monorepo — the Zed extension lives in the `zed/` subdirectory)
- **License:** MIT

### Checklist
- [x] Tested locally as a dev extension
- [x] Added as a Git submodule via HTTPS
- [x] Added an entry to `extensions.toml` and ran `pnpm sort-extensions`
- [x] An accepted license (MIT) is included at the extension path
