### PR TITLE
Add rose-pine-recast-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3666,6 +3666,10 @@
 	path = extensions/ron
 	url = https://github.com/onbjerg/zed-ron.git
 
+[submodule "extensions/rose-pine-recast-theme"]
+	path = extensions/rose-pine-recast-theme
+	url = https://github.com/ng-hai/zed-rose-pine-recast.git
+
 [submodule "extensions/rose-pine-theme"]
 	path = extensions/rose-pine-theme
 	url = https://github.com/rose-pine/zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3724,6 +3724,10 @@ version = "0.0.6"
 submodule = "extensions/ron"
 version = "0.0.1"
 
+[rose-pine-recast-theme]
+submodule = "extensions/rose-pine-recast-theme"
+version = "0.0.1"
+
 [rose-pine-theme]
 submodule = "extensions/rose-pine-theme"
 version = "1.3.2"


### PR DESCRIPTION
Resubmits #5813 with the rename @MrSubidubi and I discussed there.

**What changed since #5813:** renamed from **Rosé Pine (No Italics)** to **Rosé Pine Recast**, and the repo moved to [`ng-hai/zed-rose-pine-recast`](https://github.com/ng-hai/zed-rose-pine-recast). The old "No Italics" name undersold it as the official theme with italics toggled off — it isn't. It ports the **VSCode** Rosé Pine syntax token-to-color mapping to Zed (20+ scopes mapped differently from the official Zed port, plus a few the Zed port doesn't define) and removes italics from code. The canonical Rosé Pine palette is unchanged.

Ships as a standalone theme alongside — not a replacement for — the official `rose-pine-theme`.

- Extension id: `rose-pine-recast-theme`
- Variants: Rosé Pine Recast / Recast Moon / Recast Dawn
- CLA: already signed (under #5813)

Supersedes #5813.
