### PR TITLE
Add TypeUI extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4382,6 +4382,10 @@
 	path = extensions/typespec
 	url = https://github.com/rhodee/zed-typespec
 
+[submodule "extensions/typeui"]
+	path = extensions/typeui
+	url = https://github.com/bergside/typeui.git
+
 [submodule "extensions/typos"]
 	path = extensions/typos
 	url = https://github.com/BaptisteRoseau/zed-typos.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4449,6 +4449,11 @@ version = "0.1.0"
 submodule = "extensions/typespec"
 version = "0.0.1"
 
+[typeui]
+submodule = "extensions/typeui"
+path = "plugins/zed/typeui"
+version = "1.0.0"
+
 [typos]
 submodule = "extensions/typos"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Adds the TypeUI MCP server extension to the Zed extension registry.

TypeUI gives Zed's Agent Panel access to TypeUI design systems, UI prompts, and layout variations through the hosted TypeUI MCP server.

 Guide: https://www.typeui.sh/docs/guides/zed

 ## Changes

 - Added `https://github.com/bergside/typeui.git` as the `extensions/typeui` submodule.
 - Added the `[typeui]` entry to `extensions.toml`.
 - Uses `path = "plugins/zed/typeui"` because the Zed extension lives inside a subdirectory of the TypeUI repository.
 - Extension version: `1.0.0`.

 ## Validation

- Installed and tested the extension locally in Zed as a dev extension.
- Ran `cargo check` in the extension directory.
- Ran `cargo build --target wasm32-wasip1` in the extension directory.
- Ran `pnpm sort-extensions`.
- Ran `pnpm build`.

 ## Notes

The extension includes its own license at `plugins/zed/typeui/LICENSE.md`, as required for extensions that use the `path` field.