### PR TITLE
Add yayamlls extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5034,6 +5034,10 @@
 	path = extensions/yarn-spinner
 	url = https://github.com/yuna0x0/zed-yarn-spinner.git
 
+[submodule "extensions/yayamlls"]
+	path = extensions/yayamlls
+	url = https://github.com/home-operations/yayamlls.git
+
 [submodule "extensions/yellowed"]
 	path = extensions/yellowed
 	url = https://github.com/Gael-Lopes-Da-Silva/YellowedZed

--- a/extensions.toml
+++ b/extensions.toml
@@ -5115,6 +5115,11 @@ version = "0.0.4"
 submodule = "extensions/yarn-spinner"
 version = "0.0.9"
 
+[yayamlls]
+submodule = "extensions/yayamlls"
+path = "editors/zed"
+version = "0.1.8"
+
 [yellowed]
 submodule = "extensions/yellowed"
 version = "0.0.3"


### PR DESCRIPTION
Adds [yayamlls](https://github.com/home-operations/yayamlls), a YAML language server written in Go. It does schema-driven diagnostics, completion, hover, and Flux variable substitution rendering.

The extension lives at `editors/zed/` in the repo and downloads the release binary from GitHub on first use.