### PR TITLE
Add HTTP Client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1874,6 +1874,10 @@
 	path = extensions/http
 	url = https://github.com/tie304/zed-http.git
 
+[submodule "extensions/http-client"]
+	path = extensions/http-client
+	url = https://github.com/gozenc/zed-http-client.git
+
 [submodule "extensions/hubl"]
 	path = extensions/hubl
 	url = https://github.com/blueambr/zed-hubl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1911,6 +1911,10 @@ version = "0.1.0"
 submodule = "extensions/http"
 version = "0.0.1"
 
+[http-client]
+submodule = "extensions/http-client"
+version = "0.1.0"
+
 [hubl]
 submodule = "extensions/hubl"
 version = "1.0.0"


### PR DESCRIPTION
## Summary
- add the `http-client` extension to the marketplace registry
- register the public `gozenc/zed-http-client` repository as a submodule
- publish version `0.1.0`

## Notes
- license file is present in the source repository
- extension is already tested locally in Zed via dev install