### PR TITLE
Update geode-theme to v2.0.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1574,7 +1574,7 @@ version = "1.2.2"
 
 [geode-theme]
 submodule = "extensions/geode-theme"
-version = "0.1.0"
+version = "1.1.1"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1574,7 +1574,7 @@ version = "1.2.2"
 
 [geode-theme]
 submodule = "extensions/geode-theme"
-version = "1.1.1"
+version = "1.1.3"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1574,7 +1574,7 @@ version = "1.2.2"
 
 [geode-theme]
 submodule = "extensions/geode-theme"
-version = "2.0.0"
+version = "2.0.1"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1574,7 +1574,7 @@ version = "1.2.2"
 
 [geode-theme]
 submodule = "extensions/geode-theme"
-version = "1.1.3"
+version = "1.1.4"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1574,7 +1574,7 @@ version = "1.2.2"
 
 [geode-theme]
 submodule = "extensions/geode-theme"
-version = "1.1.4"
+version = "2.0.0"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"


### PR DESCRIPTION
Bumps the published **Geode** theme (`geode-theme`) from `0.1.0` to the current **v2.0.1**.

This updates an existing extension (originally added in #6317): it only advances the `extensions/geode-theme` submodule and the `version` field in `extensions.toml` — no new entries, and `.gitmodules` is unchanged.

### Changes

- Advance the `extensions/geode-theme` submodule to the `2.0.1` release commit (`04bfb10`), the tip of `main`.
- Bump `version` for `[geode-theme]` in `extensions.toml` to `2.0.1`, matching `extension.toml` at that commit.

The headline change in this bump is the **v2.0.0** rename: the dark variant is renamed `Geode` → `Geode Dark`, so both cuts read as an explicit pair in the theme picker. No colors changed; `Geode Light` is unchanged. **v2.0.1** on top is documentation and tooling only (the README previews are now generated from the theme) — nothing that ships to Zed changes beyond the version string.

Full notes: [CHANGELOG](https://github.com/almeladev/geode-zed/blob/main/CHANGELOG.md) · [v2.0.1 release](https://github.com/almeladev/geode-zed/releases/tag/2.0.1).

Supersedes #6324.

### Checklist

- [x] Update to an existing extension; only `extensions.toml` and the submodule pointer change.
- [x] Extension repository is public and the submodule uses an **HTTPS** URL.
- [x] The submodule commit is reachable on `main` (not detached/dangling).
- [x] `version` in `extensions.toml` (`2.0.1`) matches `version` in `extension.toml` at the pinned commit.
- [x] An accepted license (**MIT**) is present at the repository root.
