### PR TITLE
Update objectscript to v1.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3103,7 +3103,7 @@ version = "1.0.1"
 
 [objectscript]
 submodule = "extensions/objectscript"
-version = "1.3.0"
+version = "1.4.0"
 
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"


### PR DESCRIPTION
# Overview
Updated the ObjectScript Zed Extension to the latest [tree-sitter-objectscript](https://github.com/intersystems/tree-sitter-objectscript) commit.

Updated highlights.scm based on grammar changes.