### PR TITLE
Add pink-spoon extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4989,3 +4989,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/pink-spoon"]
+	path = extensions/pink-spoon
+	url = https://github.com/janisharbs/zed-pink-spoon.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3426,6 +3426,10 @@ version = "0.2.0"
 submodule = "extensions/pink-cat-boo-theme"
 version = "1.3.0"
 
+[pink-spoon]
+submodule = "extensions/pink-spoon"
+version = "0.1.1"
+
 [pinkzuna-theme]
 submodule = "extensions/pinkzuna-theme"
 version = "1.0.0"


### PR DESCRIPTION
## Summary

**pink-spoon fills the gap between ruby-lsp and Sorbet RBI files.**

ruby-lsp gives you IDE features based on source code it can parse. It doesn't read Sorbet's generated `.rbi` files, so type signatures from gems, `T::Struct`, and other Sorbet-annotated code are invisible to it.

pink-spoon indexes everything under `sorbet/rbi/` and feeds that type information back into ruby-lsp:

- **Hover** shows the Sorbet `sig` for the method under the cursor, pulled from RBI, with doc comments from gem source
- **Go to definition** jumps to the `.rbi` entry (or straight to gem source when a `# source://` comment exists)
- **Completion** suggests typed methods from RBI when the receiver type is known (e.g. `SomeClass.`)
- **Code lens** adds Run / Run in watch mode buttons next to RSpec `describe`/`context`/`it` blocks

Bonus: it walks `extend`/`include`/superclass chains, so mixin methods resolve correctly rather than coming up empty.

## Done

- add the `pink-spoon` extension to the marketplace registry
- register the public `janisharbs/pink-spoon` repository as a submodule
- publish version `0.1.1`