### PR TITLE
Add gruvbox-material-icon-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1726,6 +1726,10 @@
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git
 
+[submodule "extensions/gruvbox-material-icon-theme"]
+	path = extensions/gruvbox-material-icon-theme
+	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git
+
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix
 	url = https://github.com/hyperdevstuff/zed-gruvbox-material.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1728,7 +1728,7 @@
 
 [submodule "extensions/gruvbox-material-icons"]
 	path = extensions/gruvbox-material-icons
-	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git
+	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons
 
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix

--- a/.gitmodules
+++ b/.gitmodules
@@ -1726,6 +1726,9 @@
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git
 
+[submodule "extensions/gruvbox-material-icons"]
+	path = extensions/gruvbox-material-icons
+	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git
 
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix
@@ -4990,6 +4993,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/gruvbox-material-icons"]
-	path = extensions/gruvbox-material-icons
-	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1726,9 +1726,6 @@
 	path = extensions/gruvbox-material
 	url = https://github.com/tokiory/zed-gruvbox-material.git
 
-[submodule "extensions/gruvbox-material-icon-theme"]
-	path = extensions/gruvbox-material-icon-theme
-	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git
 
 [submodule "extensions/gruvbox-material-mix"]
 	path = extensions/gruvbox-material-mix
@@ -4993,3 +4990,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/gruvbox-material-icons"]
+	path = extensions/gruvbox-material-icons
+	url = https://github.com/RiverMatsumoto/zed-gruvbox-material-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1757,6 +1757,10 @@ version = "0.0.1"
 submodule = "extensions/gruvbox-material"
 version = "1.1.0"
 
+[gruvbox-material-icons]
+submodule = "extensions/gruvbox-material-icon-theme"
+version = "0.1.0"
+
 [gruvbox-material-mix]
 submodule = "extensions/gruvbox-material-mix"
 version = "1.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1758,7 +1758,7 @@ submodule = "extensions/gruvbox-material"
 version = "1.1.0"
 
 [gruvbox-material-icons]
-submodule = "extensions/gruvbox-material-icon-theme"
+submodule = "extensions/gruvbox-material-icons"
 version = "0.1.0"
 
 [gruvbox-material-mix]


### PR DESCRIPTION
I ported over the Gruvbox Material Icons theme from one of the vscode extensions over to zed. The original that it is based off of is here: https://github.com/Jonathan-Harty/vscode-material-icon-theme