### PR TITLE
Add VapourSynth extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4574,6 +4574,10 @@
 	path = extensions/vapor-theme
 	url = https://github.com/felipetesc/vapor-theme.git
 
+[submodule "extensions/vapoursynth"]
+	path = extensions/vapoursynth
+	url = https://github.com/Cola-Ace/Zed-VapourSynth.git
+
 [submodule "extensions/vcard"]
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4645,6 +4645,10 @@ version = "1.0.2"
 submodule = "extensions/vapor-theme"
 version = "0.0.2"
 
+[vapoursynth]
+submodule = "extensions/vapoursynth"
+version = "0.0.2"
+
 [vcard]
 submodule = "extensions/vcard"
 version = "0.3.0"


### PR DESCRIPTION
Adds the VapourSynth extension to the registry. Checks: pnpm sort-extensions; pnpm test.