### PR TITLE
Add Dark 2026 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -966,6 +966,10 @@
 	path = extensions/darcula-forest-theme
 	url = https://github.com/oryanm/darcula-forest-zed
 
+[submodule "extensions/dark-2026-theme"]
+	path = extensions/dark-2026-theme
+	url = https://github.com/igor570/zed-dark-2026.git
+
 [submodule "extensions/dark-castle-theme"]
 	path = extensions/dark-castle-theme
 	url = https://github.com/malucard/dark-castle-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -982,6 +982,10 @@ version = "0.1.4"
 submodule = "extensions/darcula-forest-theme"
 version = "0.1.0"
 
+[dark-2026-theme]
+submodule = "extensions/dark-2026-theme"
+version = "0.1.0"
+
 [dark-castle-theme]
 submodule = "extensions/dark-castle-theme"
 version = "0.0.4"


### PR DESCRIPTION
Adds [Dark 2026](https://github.com/igor570/zed-dark-2026) — a port of VS Code's "2026 Dark" default theme (shipped in VS Code 1.113) to Zed.

- Colors resolved from VS Code's full theme inheritance chain (`2026-dark` → `dark_modern` → `dark_plus` → `dark_vs`) using TextMate scope-specificity rules, so inherited colors render as VS Code actually displays them
- MIT licensed, with attribution to microsoft/vscode theme-defaults (MIT)
- README documents optional semantic-token settings for the full VS Code look