### PR TITLE
Update effect-language-service-tsgo to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1212,7 +1212,7 @@ version = "0.1.0"
 
 [effect-language-service-tsgo]
 submodule = "extensions/effect-language-service-tsgo"
-version = "0.0.4"
+version = "0.0.5"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"


### PR DESCRIPTION
This is a patch as per [this comment](https://github.com/zed-industries/extensions/pull/5300#pullrequestreview-4405148789) for the `effect-language-service-tsgo` extension.

The following changes were made:
  - Read the server binary path from the strongly-typed `LspSettings.binary.path` field over digging through the untyped `lsp.<id>.settings.binary` JSON blob.
  - Changed the config key from `lsp.effect-tsgo.settings.binary.path` to `lsp.effect-tsgo.binary.path`.
  - Removed the now-redundant "Raw Binary Override" docs section, collapsing both paths into the single canonical key.
  - Added dev-extension setup notes to the README
  - Bumped extension version `0.0.4` -> `0.0.5`.