### PR TITLE
feat: add Batch/CMD language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -366,6 +366,10 @@
 	path = extensions/basher
 	url = https://github.com/zed-extensions/bash.git
 
+[submodule "extensions/batch"]
+	path = extensions/batch
+	url = https://github.com/helldio/zed-batch.git
+
 [submodule "extensions/batman"]
 	path = extensions/batman
 	url = https://github.com/devzaidi/batman-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -373,6 +373,10 @@ version = "0.1.2"
 submodule = "extensions/basher"
 version = "0.0.5"
 
+[batch]
+submodule = "extensions/batch"
+version = "0.11.1"
+
 [batman]
 submodule = "extensions/batman"
 version = "0.0.3"


### PR DESCRIPTION
## Summary

Adds syntax highlighting support for Windows Batch/CMD files (.bat, .cmd) to Zed via the [helldio/zed-batch](https://github.com/helldio/zed-batch) extension.

### Extension details
- **Grammar**: [wharflab/tree-sitter-batch](https://github.com/wharflab/tree-sitter-batch) — a dedicated tree-sitter grammar for Windows Batch/CMD
- **File types**: .bat, .cmd
- **Features**: syntax highlighting for keywords, variables, labels, commands, strings, numbers, operators, comments, and redirects
- **No language server** — grammar-only extension
- **License**: MIT

### Testing
Tested locally via \zed: install dev extension\ with Batch scripts.