### PR TITLE
Add Svelte Effect Runtime language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4162,8 +4162,8 @@
 	path = extensions/svelte
 	url = https://github.com/zed-extensions/svelte.git
 
-[submodule "extensions/svelte-effect-runtime"]
-	path = extensions/svelte-effect-runtime
+[submodule "extensions/svelte-effect-runtime-language-server"]
+	path = extensions/svelte-effect-runtime-language-server
 	url = https://github.com/usebarekey/svelte-effect-runtime.git
 
 [submodule "extensions/svelte-mcp"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4162,6 +4162,10 @@
 	path = extensions/svelte
 	url = https://github.com/zed-extensions/svelte.git
 
+[submodule "extensions/svelte-effect-runtime"]
+	path = extensions/svelte-effect-runtime
+	url = https://github.com/usebarekey/svelte-effect-runtime.git
+
 [submodule "extensions/svelte-mcp"]
 	path = extensions/svelte-mcp
 	url = https://github.com/ghostdevv/zed-svelte-mcp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4227,10 +4227,10 @@ version = "0.0.1"
 submodule = "extensions/svelte"
 version = "0.2.11"
 
-[svelte-effect-runtime]
-submodule = "extensions/svelte-effect-runtime"
+[svelte-effect-runtime-language-server]
+submodule = "extensions/svelte-effect-runtime-language-server"
 path = "modules/svelte-effect-runtime-zed"
-version = "2.0.1"
+version = "2.3.0"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4227,6 +4227,11 @@ version = "0.0.1"
 submodule = "extensions/svelte"
 version = "0.2.11"
 
+[svelte-effect-runtime]
+submodule = "extensions/svelte-effect-runtime"
+path = "modules/svelte-effect-runtime-zed"
+version = "2.0.1"
+
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"
 version = "0.1.1"


### PR DESCRIPTION
Adds the Svelte Effect Runtime language-server extension to the Zed registry.

The extension lives in a subdirectory of the source repo, so this registry entry uses the path field:

```toml
[svelte-effect-runtime]
submodule = "extensions/svelte-effect-runtime"
path = "modules/svelte-effect-runtime-zed"
version = "2.0.1"
```

Source extension commit: usebarekey/svelte-effect-runtime@44e110af6efb79d55374eefe36e2f48a87de577e

Validation run locally:
- `corepack pnpm sort-extensions`
- `corepack pnpm test`
- `corepack pnpm build`
