### PR TITLE
Add cursor-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -910,6 +910,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/cursor-theme"]
+	path = extensions/cursor-theme
+	url = https://github.com/Jenil-Desai/cursor-theme.git
+
 [submodule "extensions/cyan-light-theme"]
 	path = extensions/cyan-light-theme
 	url = https://github.com/biaqat/cyan-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -926,6 +926,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[cursor-theme]
+submodule = "extensions/cursor-theme"
+version = "0.0.1"
+
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"


### PR DESCRIPTION
Dark theme from cursor to zed

This pull request adds a new theme extension, `cursor-theme`, to the project. The necessary configuration and submodule references have been updated to include this new extension.

Theme extension addition:

* Added `cursor-theme` as a new submodule in `.gitmodules` and initialized it at commit `4dd6cac` in `extensions/cursor-theme`. [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R913-R916) [[2]](diffhunk://#diff-8a33b0f6f4a374c5c99730db8ed7298c2cf65886c7d689b45e064185471a765fR1)
* Registered `cursor-theme` in `extensions.toml` with version `0.0.1` and linked it to the new submodule.