### PR TITLE
Add Darcula theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -954,6 +954,10 @@
 	path = extensions/dang
 	url = https://codeberg.org/vito/zed-dang.git
 
+[submodule "extensions/darcula"]
+	path = extensions/darcula
+	url = https://github.com/ysalitrynskyi/zed-theme-darcula.git
+
 [submodule "extensions/darcula-dark"]
 	path = extensions/darcula-dark
 	url = https://github.com/not-a-cowfr/Darcula-Dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -970,6 +970,10 @@ version = "0.0.1"
 submodule = "extensions/dang"
 version = "0.1.1"
 
+[darcula]
+submodule = "extensions/darcula"
+version = "1.0.0"
+
 [darcula-dark]
 submodule = "extensions/darcula-dark"
 version = "0.1.1"


### PR DESCRIPTION
This PR adds **Darcula**, a port of the classic JetBrains Darcula color scheme to Zed.

Repository: https://github.com/ysalitrynskyi/zed-theme-darcula

It ships **9 dark variants** built from the same canonical Darcula palette:
Lighter, Darcula, Dim, Darker, Pitch Black, High Contrast, Vivid, Vivid Darker, and Vivid Black.

- [x] I have tested my theme locally (installed as a dev extension).
- [x] Added the extension as a git submodule under `extensions/darcula`.
- [x] Added a `[darcula]` entry to `extensions.toml` in alphabetical order.

The theme is licensed under Apache 2.0 and includes a `NOTICE.txt` clarifying it is an
independent, unofficial port and is not affiliated with JetBrains.