### PR TITLE
Bump laravel to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2239,7 +2239,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.2.2"
+version = "0.3.0"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.3.0.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.3.0