### PR TITLE
Update Pierre theme to v0.0.29

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3412,7 +3412,7 @@ version = "0.0.2"
 [pierre-theme]
 submodule = "extensions/pierre-theme"
 path = "zed"
-version = "0.0.23"
+version = "0.0.29"
 
 [pigs-in-space]
 submodule = "extensions/pigs-in-space"


### PR DESCRIPTION
Update the `pierre-theme` extension submodule to the latest commit on the remote, which introduces both Pierre Light Soft and Pierre Dark Soft variants, and bumps the version in `extensions.toml` from `0.0.23` to `0.0.29` to match `extension.toml` at that commit.