### PR TITLE
Add Halloween Night theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1758,6 +1758,10 @@
 	path = extensions/halcyon
 	url = https://github.com/hichemfantar/halcyon-zed.git
 
+[submodule "extensions/halloween-night-theme"]
+	path = extensions/halloween-night-theme
+	url = https://github.com/BlueRexPY/HalloweenNightZed.git
+
 [submodule "extensions/hami-melon-theme"]
 	path = extensions/hami-melon-theme
 	url = https://github.com/isunjn/hami-melon-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1789,6 +1789,10 @@ version = "0.0.1"
 submodule = "extensions/halcyon"
 version = "0.2.3"
 
+[halloween-night-theme]
+submodule = "extensions/halloween-night-theme"
+version = "0.0.1"
+
 [hami-melon-theme]
 submodule = "extensions/hami-melon-theme"
 version = "0.5.0"


### PR DESCRIPTION
## Description
Ported Halloween Night theme from VS Code to Zed.

## Checklist
- [x] Tested locally as a dev extension
- [x] License is MIT (accepted)
- [x] Extension ID is unique: `halloween-night-theme`
- [x] Extension ID is suffixed with `-theme`
- [x] Only includes theme-related resources
- [x] No custom Rust/WASM code (theme-only extension)

## Links
- [Source repository](https://github.com/BlueRexPY/HalloweenNightZed)
- [Original VS Code theme](https://github.com/BlueRexPY/HalloweenNight)

<img width="1818" height="1041" alt="Screenshot from 2026-06-05 01-06-13" src="https://github.com/user-attachments/assets/7cb09256-e4ef-4f3c-a6d7-88534d2006cc" />
