### PR TITLE
Add zenscript-toolkit extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4950,6 +4950,10 @@
 	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git
 
+[submodule "extensions/zenscript-toolkit"]
+	path = extensions/zenscript-toolkit
+	url = https://github.com/Copernicium282/zenscript-toolkit.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5021,6 +5021,10 @@ version = "1.4.3"
 submodule = "extensions/zenburn-transparent-theme"
 version = "1.0.0"
 
+[zenscript-toolkit]
+submodule = "extensions/zenscript-toolkit"
+version = "0.1.0"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: set this to true or false
+  esbuild: set this to true or false


### PR DESCRIPTION
Adds **`zenscript-toolkit`**: ZenScript + Minecraft `.lang` language support, plus the `zsbc` LSP for `<item:…>`-style bracket completions from `crafttweaker.log`.

Follows the [Extension Publishing Prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites): id `zenscript-toolkit` (no `zed`/`Zed`/`extension`), MIT, [public repo](https://github.com/Copernicium282/zenscript-toolkit), HTTPS submodule on `main`, `[zenscript-toolkit]` added to `extensions.toml` (sorted, alphabetical slot, `pnpm sort-extensions` clean).

Per the no-ship rule, `zsbc-lsp` is downloaded from the extension repo's [releases](https://github.com/Copernicium282/zenscript-toolkit/releases) on first activation; the `v0.1.0` release ships binaries for all 6 targets.

The vendored tree-sitter grammar completes the upstream stubs (`class_declaration: choice('todo1')`, `_expression: choice('todo4')`); validated against 32 real-world scripts + 4 fixtures with 0 ERROR nodes.