### PR TITLE
Add Ansible Lens extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,6 +142,10 @@
 	path = extensions/ansible
 	url = https://github.com/kartikvashistha/zed-ansible
 
+[submodule "extensions/ansible-lens"]
+	path = extensions/ansible-lens
+	url = https://github.com/jan-krueger/ansible-lens.git
+
 [submodule "extensions/anthracite-theme"]
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -146,6 +146,11 @@ version = "21.0.0"
 submodule = "extensions/ansible"
 version = "1.0.0"
 
+[ansible-lens]
+submodule = "extensions/ansible-lens"
+path = "editors/zed"
+version = "0.2.2"
+
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"


### PR DESCRIPTION
Ansible Lens is a language server that brings go-to-definition, find-references, hover, completion, and undefined-variable diagnostics to nested Ansible & Jinja2 variables - resolving them across group_vars, host_vars, role defaults/vars, and set_fact/register.