### PR TITLE
Add Simple Light theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3898,6 +3898,10 @@
 	path = extensions/simple-darker
 	url = https://github.com/DP19/zed-theme-simple-darker.git
 
+[submodule "extensions/simple-light-theme"]
+	path = extensions/simple-light-theme
+	url = https://github.com/xseman/simple-light.git
+
 [submodule "extensions/simula"]
 	path = extensions/simula
 	url = https://github.com/eirslett/simula-zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -3960,6 +3960,10 @@ version = "0.1.0"
 submodule = "extensions/simple-darker"
 version = "0.0.1"
 
+[simple-light-theme]
+submodule = "extensions/simple-light-theme"
+version = "0.4.0"
+
 [simula]
 submodule = "extensions/simula"
 version = "0.0.1"


### PR DESCRIPTION
Adds the **Simple Light** theme — a minimal light theme with the fewest meaningful colors to reduce visual distraction.

- Repository: https://github.com/xseman/simple-light
- License: Apache-2.0
- ID: `simple-light-theme`, version `0.4.0`

I have tested the extension locally as a dev extension.