### PR TITLE
Add island-dark-intellij-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4993,3 +4993,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/extensions/island-dark-intellij-theme"]
+	path = extensions/extensions/island-dark-intellij-theme
+	url = https://github.com/MSBruno0088/island-dark-intellij-theme-for-zed


### PR DESCRIPTION
This is a theme inspired by the Island Dark theme in JetBrains’ IntelliJ IDE,