### PR TITLE
Add Todo.txt Actions extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4338,6 +4338,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todo-txt-actions"]
+	path = extensions/todo-txt-actions
+	url = https://github.com/khotyn/zed-todotxt.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4407,6 +4407,10 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todo-txt-actions]
+submodule = "extensions/todo-txt-actions"
+version = "0.0.1"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"


### PR DESCRIPTION
Adds the Todo.txt Actions extension.

Extension repository: https://github.com/khotyn/zed-todotxt
Release: https://github.com/khotyn/zed-todotxt/releases/tag/v0.0.1
Grammar repository: https://github.com/khotyn/tree-sitter-todotxt

Local validation:
- cargo test in the extension repo: 3 passed
- node src/sort-extensions.js in the registry repo
- tsc -p . in the registry repo