### PR TITLE
Add i18n-lens language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1890,6 +1890,10 @@
 	path = extensions/hyprlang
 	url = https://github.com/WhySoBad/zed-hyprlang-extension.git
 
+[submodule "extensions/i18n-lens"]
+	path = extensions/i18n-lens
+	url = https://github.com/yizixu/zed-i18n-lens.git
+
 [submodule "extensions/ibm-5151"]
 	path = extensions/ibm-5151
 	url = https://github.com/Takk8IS/ibm-5151-theme-for-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -2030,10 +2030,6 @@
 	path = extensions/hyprlang
 	url = https://github.com/WhySoBad/zed-hyprlang-extension.git
 
-[submodule "extensions/i18n-lens"]
-	path = extensions/i18n-lens
-	url = https://github.com/yizixu/zed-i18n-lens.git
-
 [submodule "extensions/ibm-5151"]
 	path = extensions/ibm-5151
 	url = https://github.com/Takk8IS/ibm-5151-theme-for-zed
@@ -5349,3 +5345,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/i18n-lens-language-server"]
+	path = extensions/i18n-lens-language-server
+	url = https://github.com/yizixu/zed-i18n-lens.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2030,6 +2030,10 @@
 	path = extensions/hyprlang
 	url = https://github.com/WhySoBad/zed-hyprlang-extension.git
 
+[submodule "extensions/i18n-lens-language-server"]
+	path = extensions/i18n-lens-language-server
+	url = https://github.com/yizixu/zed-i18n-lens.git
+
 [submodule "extensions/ibm-5151"]
 	path = extensions/ibm-5151
 	url = https://github.com/Takk8IS/ibm-5151-theme-for-zed
@@ -5345,6 +5349,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/i18n-lens-language-server"]
-	path = extensions/i18n-lens-language-server
-	url = https://github.com/yizixu/zed-i18n-lens.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2001,7 +2001,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.8.2"
+version = "0.9.0"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,7 +1929,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.8.1"
+version = "0.8.2"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,7 +1929,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.5.0"
+version = "0.6.0"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,7 +1929,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.4.0"
+version = "0.5.0"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,7 +1929,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.7.0"
+version = "0.8.1"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1927,6 +1927,10 @@ version = "0.1.0"
 submodule = "extensions/hyprlang"
 version = "0.0.5"
 
+[i18n-lens]
+submodule = "extensions/i18n-lens"
+version = "0.4.0"
+
 [ibm-5151]
 submodule = "extensions/ibm-5151"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2072,9 +2072,9 @@ version = "0.1.0"
 submodule = "extensions/hyprlang"
 version = "0.0.5"
 
-[i18n-lens]
-submodule = "extensions/i18n-lens"
-version = "0.11.0"
+[i18n-lens-language-server]
+submodule = "extensions/i18n-lens-language-server"
+version = "0.11.1"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2001,7 +2001,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.9.0"
+version = "0.11.0"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1929,7 +1929,7 @@ version = "0.0.5"
 
 [i18n-lens]
 submodule = "extensions/i18n-lens"
-version = "0.6.0"
+version = "0.7.0"
 
 [ibm-5151]
 submodule = "extensions/ibm-5151"


### PR DESCRIPTION
Adds **i18n-lens**, a language-server-backed extension that shows inline i18n translations for Vue/TypeScript/TSX/JavaScript.

- Repository: https://github.com/yizixu/zed-i18n-lens
- Version: 0.8.1 (submodule pinned, MIT licensed)
- npm package: https://www.npmjs.com/package/i18n-lens-language-server/v/0.8.1

Features: inlay-hint inline translations, hover (all locales), completion, diagnostics for missing keys, go-to-definition into locale files, multi-locale definition choices, monorepo package contexts, TypeScript locale modules, and additional i18n call-site detection for Vue I18n, react-i18next, and react-intl.

The JavaScript language server is published to npm as i18n-lens-language-server and installed into the extension work directory at runtime through the Zed Rust Extension API npm helpers. No language-server binary is committed to the extension repository.
