### PR TITLE
Update Gem extension to 0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1558,7 +1558,7 @@ version = "0.0.2"
 [gem]
 submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
-version = "0.0.3"
+version = "0.0.5"
 
 [genexpr]
 submodule = "extensions/genexpr"


### PR DESCRIPTION
Updates the Gem Zed extension to 0.0.5.

- Updates `extensions.toml`
- Updates `extensions/gem` to `31b4b3716e55d02ae7d4dd89415e64b7e621d458`

Source commit: https://github.com/mantou132/gem/commit/31b4b3716e55d02ae7d4dd89415e64b7e621d458