### PR TITLE
Update Gem to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1558,7 +1558,7 @@ version = "0.0.2"
 [gem]
 submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
-version = "0.0.3"
+version = "0.0.5"
 
 [genexpr]
 submodule = "extensions/genexpr"


### PR DESCRIPTION
Updates the Gem Zed extension to 0.0.5.

- Updates `extensions.toml`
- Updates `extensions/gem` to `ecd1ac476b7ed81da40de5ff60ee4a9d18c42007`

Source commit: https://github.com/mantou132/gem/commit/ecd1ac476b7ed81da40de5ff60ee4a9d18c42007