### PR TITLE
Add template-string-converter extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4258,6 +4258,10 @@
 	path = extensions/templ
 	url = https://github.com/makifdb/zed-templ.git
 
+[submodule "extensions/template-string-converter"]
+	path = extensions/template-string-converter
+	url = https://github.com/ivan-szz/template-string-converter.git
+
 [submodule "extensions/templeos-theme"]
 	path = extensions/templeos-theme
 	url = https://github.com/b6k-dev/zed-templeos-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4327,6 +4327,10 @@ path = "zed"
 submodule = "extensions/templ"
 version = "0.0.11"
 
+[template-string-converter]
+submodule = "extensions/template-string-converter"
+version = "0.0.2"
+
 [templeos-theme]
 submodule = "extensions/templeos-theme"
 version = "1.0.0"


### PR DESCRIPTION
Auto-converts quotes to backticks when typing ${} inside JS/TS strings.