### PR TITLE
Add react-component-lens language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3610,8 +3610,8 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
-[submodule "extensions/react-component-lens"]
-	path = extensions/react-component-lens
+[submodule "extensions/react-component-lens-lsp"]
+	path = extensions/react-component-lens-lsp
 	url = https://github.com/dev-five-git/react-component-lens.git
 
 [submodule "extensions/react-snippets"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -3610,6 +3610,10 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
+[submodule "extensions/react-component-lens"]
+	path = extensions/react-component-lens
+	url = https://github.com/dev-five-git/react-component-lens.git
+
 [submodule "extensions/react-snippets"]
 	path = extensions/react-snippets
 	url = https://github.com/tamimhasandev/react-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -3669,8 +3669,8 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
-[react-component-lens]
-submodule = "extensions/react-component-lens"
+[react-component-lens-lsp]
+submodule = "extensions/react-component-lens-lsp"
 path = "packages/zed"
 version = "1.0.5"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -3669,6 +3669,11 @@ version = "1.0.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
+[react-component-lens]
+submodule = "extensions/react-component-lens"
+path = "packages/zed"
+version = "1.0.4"
+
 [react-snippets]
 submodule = "extensions/react-snippets"
 version = "1.0.6"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3672,7 +3672,7 @@ version = "0.12.0"
 [react-component-lens]
 submodule = "extensions/react-component-lens"
 path = "packages/zed"
-version = "1.0.4"
+version = "1.0.5"
 
 [react-snippets]
 submodule = "extensions/react-snippets"


### PR DESCRIPTION
Adds **React Component Lens**, an extension that colors JSX component tags in .tsx files based on the React Server Component / Client Component ("use client") boundary.

- **Repository:** https://github.com/dev-five-git/react-component-lens
- **License:** MIT (present at the extension path `packages/zed/LICENSE` and repo root)
- **Layout:** monorepo — the Zed extension lives in `packages/zed` (referenced via the `path` field)
- It ships the `rcl-lsp` language server (downloaded from the repo's GitHub Releases) which attaches to the built-in TSX language and adds `rscClientComponent` / `rscServerComponent` semantic tokens.

The submodule is pinned to a commit on `main` whose `extension.toml` version (1.0.4) matches the `extensions.toml` entry.