### PR TITLE
Add Karma theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2126,6 +2126,10 @@
 	path = extensions/kanso
 	url = https://github.com/webhooked/kanso-zed.git
 
+[submodule "extensions/karma-theme"]
+	path = extensions/karma-theme
+	url = https://github.com/sreetamdas/karma.git
+
 [submodule "extensions/kcl"]
 	path = extensions/kcl
 	url = https://github.com/pisarenko91/kcl-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2168,7 +2168,7 @@ version = "1.0.5"
 [karma-theme]
 submodule = "extensions/karma-theme"
 path = "packages/zed"
-version = "0.0.1"
+version = "1.0.0"
 
 [kcl]
 submodule = "extensions/kcl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2165,6 +2165,11 @@ version = "0.1.2"
 submodule = "extensions/kanso"
 version = "1.0.5"
 
+[karma-theme]
+submodule = "extensions/karma-theme"
+path = "packages/zed"
+version = "0.0.1"
+
 [kcl]
 submodule = "extensions/kcl"
 version = "0.0.2"


### PR DESCRIPTION
Adds Karma, a colorful dark theme, to the Zed extension registry.

The extension lives in `packages/zed` in the Karma repo, so this uses the registry `path` field.

- Extension ID: `karma-theme`
- Version: `1.0.0`
- License: MIT
