### PR TITLE
Update Perl to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3363,7 +3363,7 @@ version = "1.0.1"
 
 [perl]
 submodule = "extensions/perl"
-version = "0.2.0"
+version = "0.3.0"
 
 [perm]
 submodule = "extensions/perm"


### PR DESCRIPTION
Bumps the Perl extension to `0.3.0`.

This release pulls in everything merged since the currently published `0.2.0`:

- **POD language support** — adds the POD grammar plus highlights, injections, and outline queries.
- **Grammar updates** — `tree-sitter-perl` and `tree-sitter-pod` updated to their latest release revisions.
- **POD query updates** — `E<…>` is now matched as the dedicated `escape_sequence` node, and `=begin`/`=end`/`=for` paragraphs are highlighted.

Submodule `extensions/perl` updated `552ed02` → `0187d62` (https://github.com/tree-sitter-perl/zed-perl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)