### PR TITLE
Add sublime-original theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4997,3 +4997,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sublime-original"]
+	path = extensions/sublime-original
+	url = https://github.com/ultimatevegance/sublime-original-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4180,6 +4180,10 @@ version = "0.1.0"
 submodule = "extensions/sublime-mariana-theme"
 version = "1.1.4"
 
+[sublime-original]
+submodule = "extensions/sublime-original"
+version = "0.1.0"
+
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
 version = "0.1.15"


### PR DESCRIPTION
## Summary

A faithful port of Sublime Text's Monokai theme to Zed.

**Variants:**
- **Sublime Original** — pixel-perfect Monokai colors, fully opaque
- **Sublime Original Blur** — heavy blur variant with near-transparent backgrounds

**Extension repo:** https://github.com/ultimatevegance/sublime-original-zed

## Checklist

- [x] Extension id is unique and kebab-case
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `description`, `authors`, `repository`
- [x] Entry added alphabetically to `extensions.toml`
- [x] Submodule points to a public GitHub repository
- [x] Theme uses Zed theme schema `v0.1.0`