### PR TITLE
Update rlsp-yaml to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3770,7 +3770,7 @@ version = "0.0.1"
 [rlsp-yaml]
 submodule = "extensions/rlsp-yaml"
 path = "rlsp-yaml/integrations/zed"
-version = "0.1.1"
+version = "0.1.2"
 
 [robot-framework]
 submodule = "extensions/robot-framework"


### PR DESCRIPTION
Bumps rlsp-yaml Zed extension to v0.1.2

Upstream tag: https://github.com/chdalski/rlsp/releases/tag/zed-v0.1.2