### PR TITLE
Add LEQL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2234,6 +2234,10 @@
 	path = extensions/leptos
 	url = https://github.com/zed-extensions/leptos.git
 
+[submodule "extensions/leql"]
+	path = extensions/leql
+	url = https://codeberg.org/vrsko/leql.git
+
 [submodule "extensions/less"]
 	path = extensions/less
 	url = https://github.com/jimliang/zed-less.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2274,6 +2274,10 @@ version = "0.2.0"
 submodule = "extensions/leptos"
 version = "0.1.1"
 
+[leql]
+submodule = "extensions/leql"
+version = "0.1.0"
+
 [less]
 submodule = "extensions/less"
 version = "0.1.0"


### PR DESCRIPTION
Adds syntax highlighting for LEQL (Log Entry Query Language).
Uses Tree-sitter grammar.
Extension repository:  https://codeberg.org/vrsko/leql