### PR TITLE
Add cpp-toolkit extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -830,6 +830,10 @@
 	path = extensions/coverage-lsp
 	url = https://github.com/fargies/coverage-lsp.git
 
+[submodule "extensions/cpp-toolkit"]
+	path = extensions/cpp-toolkit
+	url = https://github.com/spartajet/zed-cpp-toolkit.git
+
 [submodule "extensions/cpp2"]
 	path = extensions/cpp2
 	url = https://github.com/tsoj/zed-cpp2.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -844,6 +844,10 @@ submodule = "extensions/coverage-lsp"
 version = "1.0.1"
 path = "zed-coverage-lsp"
 
+[cpp-toolkit]
+submodule = "extensions/cpp-toolkit"
+version = "1.0.0"
+
 [cpp2]
 submodule = "extensions/cpp2"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -846,7 +846,7 @@ path = "zed-coverage-lsp"
 
 [cpp-toolkit]
 submodule = "extensions/cpp-toolkit"
-version = "1.0.0"
+version = "1.0.1"
 
 [cpp2]
 submodule = "extensions/cpp2"


### PR DESCRIPTION
## Summary
- Add cpp-toolkit as a new extension submodule.
- Register cpp-toolkit version 1.0.1 in extensions.toml.

## Validation
- npm run sort-extensions
- npm run build
- npm test
- GitHub CI package: passed
- Verified submodule points to spartajet/zed-cpp-toolkit v1.0.1 (be38d16).