### PR TITLE
Add PIO Assembly language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3386,6 +3386,10 @@
 	path = extensions/pinkzuna-theme
 	url = https://github.com/memiux/pinkzuna-zed.git
 
+[submodule "extensions/pioasm"]
+	path = extensions/pioasm
+	url = https://github.com/GGORG0/zed-pioasm-syntax.git
+
 [submodule "extensions/pkl"]
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3439,6 +3439,10 @@ version = "1.3.0"
 submodule = "extensions/pinkzuna-theme"
 version = "1.0.0"
 
+[pioasm]
+submodule = "extensions/pioasm"
+version = "0.0.1"
+
 [pkl]
 submodule = "extensions/pkl"
 version = "0.3.0"


### PR DESCRIPTION
Adds the [PIO Assembly](https://github.com/GGORG0/zed-pioasm-syntax.git) extension, which provides grammar for Raspberry Pi's PIO Assembly language.

Sample files: https://github.com/search?q=repo%3Araspberrypi%2Fpico-examples%20path%3A%2F%5C.pio%24%2F&type=code
Language documentation (section 3): https://pip-assets.raspberrypi.com/categories/609-microcontroller-boards/documents/RP-009085-KB-1-raspberry-pi-pico-c-sdk.pdf