### PR TITLE
Add CfxLua extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -634,6 +634,10 @@
 	path = extensions/cfml
 	url = https://github.com/cfmleditor/zed-cfml.git
 
+[submodule "extensions/cfxlua"]
+	path = extensions/cfxlua
+	url = https://github.com/DemiAutomatic/zed-cfxlua.git
+
 [submodule "extensions/chai-theme"]
 	path = extensions/chai-theme
 	url = https://github.com/rushabhcodes/zed-chai-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -644,6 +644,10 @@ version = "1.0.5"
 submodule = "extensions/cfml"
 version = "0.2.23"
 
+[cfxlua]
+submodule = "extensions/cfxlua"
+version = "0.4.0"
+
 [chai-theme]
 submodule = "extensions/chai-theme"
 version = "0.0.2"


### PR DESCRIPTION
Adds **CfxLua**, a language for CitizenFX (Cfx) Lua, the dialect used by FiveM and RedM.

The stock Lua grammar renders cfx-specific syntax as plain text (compound assignment, `?.`/`?[` safe navigation, backtick hashes, `/* */` comments, set shorthand, `local a, b in t`, `defer ... end`). CfxLua ships a forked Tree-sitter grammar that parses it, bundles `lua-language-server`, and pulls in fivem-lls-addon on first run for cfx native types and diagnostics. It sits alongside the built-in Lua extension; users route `.lua` to it via `file_types`.

Repo: https://github.com/DemiAutomatic/zed-cfxlua
Grammar: https://github.com/DemiAutomatic/tree-sitter-cfxlua