### PR TITLE
Update karma-theme to v3.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2168,7 +2168,7 @@ version = "1.0.5"
 [karma-theme]
 submodule = "extensions/karma-theme"
 path = "packages/zed"
-version = "1.0.0"
+version = "3.1.1"
 
 [kcl]
 submodule = "extensions/kcl"


### PR DESCRIPTION
Updates the published **Karma Theme** extension (`karma-theme`) from `1.0.0` to `3.1.1`.

This advances the `extensions/karma-theme` submodule to the latest Karma `main` commit and bumps the `version` field in `extensions.toml` to match `packages/zed/extension.toml` at that commit.

### Changes

- Advance `extensions/karma-theme` from `bfc00b5` to `858961c`.
- Bump `[karma-theme]` in `extensions.toml` from `1.0.0` to `3.1.1`.
- Keep the existing `path = "packages/zed"` registry entry.

The updated Zed package regenerates the Karma theme from shared theme tokens and includes the latest Zed theme refinements from the Karma repository.

### Checklist

- [x] Update to an existing extension; only `extensions.toml` and the submodule pointer change.
- [x] Extension repository is public and the submodule uses an HTTPS URL.
- [x] The submodule commit is reachable on the Karma repository's `main` branch.
- [x] `version` in `extensions.toml` (`3.1.1`) matches `version` in `packages/zed/extension.toml` at the pinned commit.
- [x] License is present in the extension path.
