### PR TITLE
Update design-tokens to v0.3.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1075,7 +1075,7 @@ version = "1.0.1"
 [design-tokens]
 submodule = "extensions/design-tokens"
 path = "extensions/zed"
-version = "0.3.1"
+version = "0.3.2"
 
 [desktop]
 submodule = "extensions/desktop"


### PR DESCRIPTION
Updates design-tokens extension to [version 0.3.2](https://github.com/bennypowers/asimonim/releases/tag/v0.3.2).