### PR TITLE
Add Moonfly theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5001,3 +5001,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/moonfly-theme"]
+	path = extensions/moonfly-theme
+	url = https://github.com/mirrrjr/zed-moonfly-theme


### PR DESCRIPTION
Adds the Moonfly theme to the Zed extensions registry.

The theme includes:

* Moonfly color palette
* Dark UI styling
* Syntax highlighting definitions
* Terminal ANSI color mappings

Tested locally in Zed.
