### PR TITLE
Add Ember.js language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1246,6 +1246,10 @@
 	path = extensions/ember
 	url = https://github.com/jylamont/zed-ember.git
 
+[submodule "extensions/ember-lsp"]
+	path = extensions/ember-lsp
+	url = https://github.com/sathish-pv/zed-ember-lsp.git
+
 [submodule "extensions/ember-theme"]
 	path = extensions/ember-theme
 	url = https://github.com/biaqat/ember-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1267,6 +1267,10 @@ version = "0.2.2"
 submodule = "extensions/ember"
 version = "0.1.0"
 
+[ember-lsp]
+submodule = "extensions/ember-lsp"
+version = "0.1.0"
+
 [ember-theme]
 submodule = "extensions/ember-theme"
 version = "0.9.1"


### PR DESCRIPTION
Adds language server for [Ember.js](https://emberjs.com/) using [Glint](https://typed-ember.gitbook.io/glint).
Also add Syntax highlighting.

Extension Repository: https://github.com/sathish-pv/zed-ember-lsp
