### PR TITLE
Add edusites-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1190,6 +1190,10 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/edusites-theme"]
+	path = extensions/edusites-theme
+	url = https://github.com/eduardolecdt/edusites-theme-zed.git
+
 [submodule "extensions/effect-language-service-tsgo"]
 	path = extensions/effect-language-service-tsgo
 	url = https://github.com/RATIU5/zed-effect-tsgo.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1210,6 +1210,10 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
+[edusites-theme]
+submodule = "extensions/edusites-theme"
+version = "1.0.0"
+
 [effect-language-service-tsgo]
 submodule = "extensions/effect-language-service-tsgo"
 version = "0.0.5"


### PR DESCRIPTION
Adds the **EduSites** theme extension.

- Repository: https://github.com/eduardolecdt/edusites-theme-zed
- Two variants: **EduSites Dark** and **EduSites Light**
- Brand palette built around purple `#6217EC`
- License: MIT (present at the repository root)

### Checklist
- [x] Extension ID suffixed with `-theme` (`edusites-theme`), no "zed"/"extension" in the name
- [x] `extension.toml` includes id, name, version, schema_version, authors, description, repository
- [x] Description is in English
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml` in alphabetical order (`pnpm sort-extensions` produces no changes)
- [x] Repository is public with a tagged release (`v1.0.0`)
- [x] License file present at repository root

This replaces #6278 — that PR was left in a stale `changes requested` state after all requested updates (extension ID + English description) were already applied. Opening fresh for a clean review. Thanks!