### PR TITLE
Upgrade pnpm to v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          version: 11
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          version: 11
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1061.0",
     "@iarna/toml": "2.2.5",
-    "@types/semver": "^7.7.1",
     "git-submodule-js": "1.0.5",
-    "semver": "^7.7.4"
+    "semver": "7.7.4"
   },
   "devDependencies": {
     "@tsconfig/node24": "24.0.4",
     "@tsconfig/strictest": "2.0.8",
     "@types/node": "24.12.4",
+    "@types/semver": "7.7.1",
     "danger": "13.0.7",
     "danger-plugin-pr-hygiene": "0.7.1",
     "prettier": "3.8.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,12 @@ importers:
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
-      '@types/semver':
-        specifier: ^7.7.1
-        version: 7.7.1
       git-submodule-js:
         specifier: 1.0.5
         version: 1.0.5
       semver:
-        specifier: ^7.7.4
-        version: 7.8.4
+        specifier: 7.7.4
+        version: 7.7.4
     devDependencies:
       '@tsconfig/node24':
         specifier: 24.0.4
@@ -33,6 +30,9 @@ importers:
       '@types/node':
         specifier: 24.12.4
         version: 24.12.4
+      '@types/semver':
+        specifier: 7.7.1
+        version: 7.7.1
       danger:
         specifier: 13.0.7
         version: 13.0.7
@@ -998,13 +998,13 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  semver@7.8.3:
-    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+  semver@7.8.3:
+    resolution: {integrity: sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2194,9 +2194,9 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  semver@7.8.3: {}
+  semver@7.7.4: {}
 
-  semver@7.8.4: {}
+  semver@7.8.3: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  core-js: true
+  esbuild: true


### PR DESCRIPTION
This PR upgrades our pnpm version to v11.

We're also pinning `semver` and `@types/semver` to exact versions, as all of our dependencies should use exact versions.