### PR TITLE
Bump phpmd to v0.1.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3424,7 +3424,7 @@ version = "0.1.0"
 
 [phpmd]
 submodule = "extensions/phpmd"
-version = "0.1.2"
+version = "0.1.4"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
Bumps `phpmd` to v0.1.4.

Release notes: https://github.com/mike-bronner/zed-phpmd-lsp/releases/tag/0.1.4