### PR TITLE
Update svelte-effect-runtime-language-server to v2.3.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4260,7 +4260,7 @@ version = "0.2.11"
 [svelte-effect-runtime-language-server]
 submodule = "extensions/svelte-effect-runtime-language-server"
 path = "modules/svelte-effect-runtime-zed"
-version = "2.3.0"
+version = "2.3.1"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"


### PR DESCRIPTION
## Summary
- Updates \\svelte-effect-runtime-language-server\\ from 2.3.0 to 2.3.1.
- Points the submodule at usebarekey/svelte-effect-runtime@8045e3a, which packages the Zed LSP from the v2.3.1 GitHub release asset instead of resolving the private language-server package from npm.
- Release: https://github.com/usebarekey/svelte-effect-runtime/releases/tag/v2.3.1

## Checks
- \\corepack pnpm sort-extensions\\`n- \\corepack pnpm build\\`n- \\corepack pnpm test\\ (111 tests)