### PR TITLE
Update vrl to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4816,7 +4816,7 @@ version = "0.0.1"
 
 [vrl]
 submodule = "extensions/vrl"
-version = "0.1.0"
+version = "0.1.1"
 
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"


### PR DESCRIPTION
Update highlight queries in `highlights.scm`.

Release notes:

https://github.com/belltoy/zed-vrl/releases/tag/v0.1.1