### PR TITLE
Add Moonfly theme and remove old submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5001,3 +5001,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/moonfly-theme"]
+	path = extensions/moonfly-theme
+	url = https://github.com/mirrrjr/zed-moonfly-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -5001,3 +5001,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/moonfly-theme"]
+	path = extensions/moonfly-theme
+	url = https://github.com/mirrrjr/moonfly

--- a/.gitmodules
+++ b/.gitmodules
@@ -5001,6 +5001,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/moonfly-theme"]
-	path = extensions/moonfly-theme
-	url = https://github.com/mirrrjr/zed-moonfly-theme


### PR DESCRIPTION
## Summary

Adds Moonfly theme support for Zed.

This extension ports the Moonfly color scheme to Zed, providing a dark, high-contrast theme optimized for readability and long coding sessions.

## Features

* Dark color palette based on the original Moonfly theme
* Syntax highlighting adapted for Zed
* Consistent UI colors across panels, editor, terminal, and status elements
* Suitable for PHP, JavaScript, TypeScript, Rust, Go, and other supported languages

## Credits

This extension is an independent port of the Moonfly color scheme for Zed.

Repository: https://github.com/mirrrjr/moonfly

## Checklist

* [x] Unique extension ID
* [x] Includes only files required by the extension
* [x] Theme is published as a standalone extension
* [x] README included
* [x] Theme tested locally in Zed
