### PR TITLE
Add JSON Tools extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2094,6 +2094,10 @@
 	path = extensions/json-tool-lsp
 	url = https://github.com/xgfone/zed-json-tool.git
 
+[submodule "extensions/json-tools"]
+	path = extensions/json-tools
+	url = https://github.com/pengpercy/zed-json.git
+
 [submodule "extensions/json5"]
 	path = extensions/json5
 	url = https://github.com/ChunzhengLab/json5-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2133,6 +2133,10 @@ version = "0.0.2"
 submodule = "extensions/json-tool-lsp"
 version = "0.0.3"
 
+[json-tools]
+submodule = "extensions/json-tools"
+version = "0.1.0"
+
 [json5]
 submodule = "extensions/json5"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the `json-tools` extension to the Zed extension registry.

The extension provides Zed Assistant slash commands for validating, beautifying, uglifying, escaping, and unescaping JSON text, plus JSON snippets.

Extension repository: https://github.com/pengpercy/zed-json

## Verification

- `cargo test` in `pengpercy/zed-json`
- `cargo build --target wasm32-wasip1` in `pengpercy/zed-json`
- Installed successfully as a Zed dev extension after launching Zed with the rustup toolchain available
- `pnpm sort-extensions`
- `pnpm test`
- `pnpm build`