### PR TITLE
Add outrun-vscode theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3246,6 +3246,10 @@
 	path = extensions/outrun
 	url = https://github.com/Acepie/OutrunZedTheme.git
 
+[submodule "extensions/outrun-vscode"]
+	path = extensions/outrun-vscode
+	url = https://github.com/exkungen/outrun-vscode-zed.git
+
 [submodule "extensions/oxc"]
 	path = extensions/oxc
 	url = https://github.com/oxc-project/oxc-zed.git
@@ -5057,6 +5061,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/outrun-vscode"]
-	path = extensions/outrun-vscode
-	url = https://github.com/exkungen/outrun-vscode-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3246,8 +3246,8 @@
 	path = extensions/outrun
 	url = https://github.com/Acepie/OutrunZedTheme.git
 
-[submodule "extensions/outrun-vscode"]
-	path = extensions/outrun-vscode
+[submodule "extensions/outrun-vscode-theme"]
+	path = extensions/outrun-vscode-theme
 	url = https://github.com/exkungen/outrun-vscode-zed.git
 
 [submodule "extensions/oxc"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -5057,3 +5057,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/outrun-vscode"]
+	path = extensions/outrun-vscode
+	url = https://github.com/exkungen/outrun-vscode-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3296,8 +3296,8 @@ version = "0.2.0"
 submodule = "extensions/outrun"
 version = "0.0.3"
 
-[outrun-vscode]
-submodule = "extensions/outrun-vscode"
+[outrun-vscode-theme]
+submodule = "extensions/outrun-vscode-theme"
 version = "0.1.0"
 
 [oxc]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3296,6 +3296,10 @@ version = "0.2.0"
 submodule = "extensions/outrun"
 version = "0.0.3"
 
+[outrun-vscode]
+submodule = "extensions/outrun-vscode"
+version = "0.1.0"
+
 [oxc]
 submodule = "extensions/oxc"
 version = "0.4.7"


### PR DESCRIPTION
Adds **Outrun (VS Code Port)**, a port of the [Outrun VS Code theme](https://github.com/samrap/outrun-theme-vscode) by samrapdev. Synthwave inspired, includes the Night and Electric variants.

The existing `outrun` extension is a different take on the palette. This port keeps the original VS Code theme's colors (editor chrome, syntax, terminal ANSI palette, git and status colors), adapted to tree-sitter scopes where needed.

Extension repo: https://github.com/exkungen/outrun-vscode-zed