### PR TITLE
Add sublime-monokai theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4166,6 +4166,10 @@
 	path = extensions/sublime-mariana-theme
 	url = https://github.com/hnatiukr/zed-mariana-theme.git
 
+[submodule "extensions/sublime-monokai"]
+	path = extensions/sublime-monokai
+	url = https://github.com/shkarlsson/zed-sublime-monokai.git
+
 [submodule "extensions/subliminal-nightfall"]
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall

--- a/extensions.toml
+++ b/extensions.toml
@@ -4233,6 +4233,10 @@ version = "0.1.0"
 submodule = "extensions/sublime-mariana-theme"
 version = "1.1.4"
 
+[sublime-monokai]
+submodule = "extensions/sublime-monokai"
+version = "0.0.1"
+
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
 version = "0.1.15"


### PR DESCRIPTION
This PR adds the Sublime Monokai theme to the Zed extensions registry.

- **Repository**: https://github.com/shkarlsson/zed-sublime-monokai
- **Description**: A faithful port of the classic Sublime Monokai theme for the Zed editor.
- **Licensing Note**: This is a port of the classic Monokai theme. The MIT license and this PR apply strictly to the adaptation/conversion code for Zed. The original Monokai design is credited to Wimer Hazenberg.