### PR TITLE
Add Logos extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2318,6 +2318,10 @@
 	path = extensions/logcat
 	url = https://github.com/vinnom/logcat-highlighter.git
 
+[submodule "extensions/logos"]
+	path = extensions/logos
+	url = https://github.com/nobottomline/logos-zed.git
+
 [submodule "extensions/logstash"]
 	path = extensions/logstash
 	url = https://github.com/StrongTheDev/logstash-for-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2360,6 +2360,10 @@ version = "0.0.7"
 submodule = "extensions/logcat"
 version = "0.0.1"
 
+[logos]
+submodule = "extensions/logos"
+version = "0.1.0"
+
 [logstash]
 submodule = "extensions/logstash"
 version = "0.0.2"


### PR DESCRIPTION
Adds syntax highlighting for Theos Logos files.

- Supports `.x`, `.xm`, `.xi`, and `.xmi` files
- Extends Objective-C/C syntax with Logos directives
- Repository: https://github.com/nobottomline/logos-zed

Validation:
- Tested locally as a Zed dev extension
- Tree-sitter corpus: 6/6 passed
- Registry tests: 111/111 passed
- Registry TypeScript build passed