### PR TITLE
Add heta extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1810,6 +1810,10 @@
 	path = extensions/herzha-theme
 	url = https://github.com/madhanmaaz/herzha-theme.git
 
+[submodule "extensions/heta"]
+	path = extensions/heta
+	url = https://github.com/hetalang/zed-heta.git
+
 [submodule "extensions/hex-light-theme"]
 	path = extensions/hex-light-theme
 	url = https://github.com/coghost/light-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1842,6 +1842,10 @@ submodule = "extensions/herzha-theme"
 version = "0.0.1"
 path = "packages/zed"
 
+[heta]
+submodule = "extensions/heta"
+version = "0.1.0"
+
 [hex-light-theme]
 submodule = "extensions/hex-light-theme"
 version = "0.0.4"


### PR DESCRIPTION
## Summary

Add the Heta language extension for Zed.

Repository: https://github.com/hetalang/zed-heta

## Testing

- Installed locally as a dev extension
- Verified syntax highlighting for `.heta` files