### PR TITLE
Remove `mcp-server-byterover` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2522,10 +2522,6 @@
 	path = extensions/mcp-server-buildkite
 	url = https://github.com/mcncl/zed-mcp-server-buildkite
 
-[submodule "extensions/mcp-server-byterover"]
-	path = extensions/mcp-server-byterover
-	url = https://github.com/campfirein/byterover-zed-extension.git
-
 [submodule "extensions/mcp-server-code-runner"]
 	path = extensions/mcp-server-code-runner
 	url = https://github.com/formulahendry/zed-code-runner-mcp-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2566,10 +2566,6 @@ version = "0.2.0"
 submodule = "extensions/mcp-server-buildkite"
 version = "0.0.4"
 
-[mcp-server-byterover]
-submodule = "extensions/mcp-server-byterover"
-version = "0.0.3"
-
 [mcp-server-code-runner]
 submodule = "extensions/mcp-server-code-runner"
 version = "0.1.0"


### PR DESCRIPTION
This PR removes the `mcp-server-byterover` extension, as the upstream GitHub repository is gone: https://github.com/campfirein/byterover-zed-extension