### PR TITLE
Remove `sqruff` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4106,10 +4106,6 @@
 	path = extensions/sqlmesh
 	url = https://github.com/GitToby/zed-sqlmesh.git
 
-[submodule "extensions/sqruff"]
-	path = extensions/sqruff
-	url = https://github.com/gvozdvmozgu/sqruff-zed.git
-
 [submodule "extensions/squirrel"]
 	path = extensions/squirrel
 	url = https://github.com/mnshdw/squirrel-lsp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4172,10 +4172,6 @@ version = "0.2.0"
 submodule = "extensions/sqlmesh"
 version = "0.1.4"
 
-[sqruff]
-submodule = "extensions/sqruff"
-version = "0.1.0"
-
 [squirrel]
 submodule = "extensions/squirrel"
 version = "0.1.0"


### PR DESCRIPTION
This PR removes the `sqruff` extension, as the upstream repository is gone: https://github.com/gvozdvmozgu/sqruff-zed