### PR TITLE
Fix `flexoki-themes` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1418,6 +1418,10 @@
 	path = extensions/fleury
 	url = https://github.com/1ay1/fleury-zed-theme.git
 
+[submodule "extensions/flexoki-themes"]
+	path = extensions/flexoki-themes
+	url = https://github.com/kepano/flexoki.git
+
 [submodule "extensions/flow"]
 	path = extensions/flow
 	url = https://github.com/jthomaschewski/zed-flow.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1418,10 +1418,6 @@
 	path = extensions/fleury
 	url = https://github.com/1ay1/fleury-zed-theme.git
 
-[submodule "extensions/flexoki-themes"]
-	path = extensions/flexoki-themes
-	url = https://github.com/kepano/flexoki.git
-
 [submodule "extensions/flow"]
 	path = extensions/flow
 	url = https://github.com/jthomaschewski/zed-flow.git


### PR DESCRIPTION
This PR fixes an issue with the `flexoki-themes` submodule.

When trying to initialize the submodule, we are seeing the following error:

```
λ just init-submodule extensions/flexoki-themes
git submodule update --init --recursive extensions/flexoki-themes
fatal: remote error: upload-pack: not our ref 8d723bac4a9ac46adfdf99d42155286977aac72a
fatal: Fetched in submodule path 'extensions/flexoki-themes', but it did not contain 8d723bac4a9ac46adfdf99d42155286977aac72a. Direct fetching of that commit failed.
error: Recipe `init-submodule` failed on line 11 with exit code 128
```

I think the issue stems from the switch from https://github.com/oddship/zed-flexoki-theme to https://github.com/kepano/flexoki at some point, but am having trouble tracking down exactly where things went awry.