### PR TITLE
Remove `wren-lsp` extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4878,10 +4878,6 @@
 	path = extensions/wren
 	url = https://github.com/hgmich/zed-wren.git
 
-[submodule "extensions/wren-lsp"]
-	path = extensions/wren-lsp
-	url = https://github.com/jossephus/wren-lsp
-
 [submodule "extensions/wxml"]
 	path = extensions/wxml
 	url = https://github.com/BlockLune/zed-wxml.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4956,11 +4956,6 @@ version = "0.0.1"
 submodule = "extensions/wren"
 version = "0.0.1"
 
-[wren-lsp]
-submodule = "extensions/wren-lsp"
-path = "editors/zed"
-version = "0.0.1"
-
 [wxml]
 submodule = "extensions/wxml"
 version = "0.1.0"


### PR DESCRIPTION
This PR removes the `wren-lsp` extension, as the submodule is currently broken due to https://github.com/jossephus/wren-lsp/issues/11.

@jossephus We can re-add the extension once that issue has been addressed.