### PR TITLE
Fix `flexoki-themes` submodule (again)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1418,6 +1418,10 @@
 	path = extensions/fleury
 	url = https://github.com/1ay1/fleury-zed-theme.git
 
+[submodule "extensions/flexoki-themes"]
+	path = extensions/flexoki-themes
+	url = https://github.com/kepano/flexoki.git
+
 [submodule "extensions/flow"]
 	path = extensions/flow
 	url = https://github.com/jthomaschewski/zed-flow.git
@@ -5045,6 +5049,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/flexoki-themes"]
-	path = extensions/flexoki-themes
-	url = https://github.com/kepano/flexoki.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1418,10 +1418,6 @@
 	path = extensions/fleury
 	url = https://github.com/1ay1/fleury-zed-theme.git
 
-[submodule "extensions/flexoki-themes"]
-	path = extensions/flexoki-themes
-	url = https://github.com/kepano/flexoki.git
-
 [submodule "extensions/flow"]
 	path = extensions/flow
 	url = https://github.com/jthomaschewski/zed-flow.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5045,3 +5045,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/flexoki-themes"]
+	path = extensions/flexoki-themes
+	url = https://github.com/kepano/flexoki.git


### PR DESCRIPTION
This PR is a follow-up to #6436, as I hadn't fixed the problem the first time around.

I needed to nuke the cached submodule using:

```
rm -rf .git/modules/extensions/flexoki-themes
```

Before re-adding it.