### PR TITLE
Add Azure MCP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -342,6 +342,10 @@
 	path = extensions/azure-context-server
 	url = https://github.com/oWretch/zed-extension-azure-mcp
 
+[submodule "extensions/azure-mcp"]
+	path = extensions/azure-mcp
+	url = https://github.com/hodyhq/zed-azure-mcp.git
+
 [submodule "extensions/azutiku-theme"]
 	path = extensions/azutiku-theme
 	url = https://github.com/bwind/zed-azutiku-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -349,6 +349,10 @@ version = "1.0.0"
 submodule = "extensions/azure-context-server"
 version = "1.0.0"
 
+[azure-mcp]
+submodule = "extensions/azure-mcp"
+version = "0.1.1"
+
 [azutiku-theme]
 submodule = "extensions/azutiku-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds **Azure MCP** (`azure-mcp`) — wires Microsoft's official [`@azure/mcp`](https://www.npmjs.com/package/@azure/mcp) server into Zed's Agent Panel, giving the agent tools to manage and query Azure (resource groups, storage, Key Vault, Functions, AKS, Cosmos DB, Monitor, and more) via the user's ambient `az login` identity.

Repo: https://github.com/hodyhq/zed-azure-mcp (MIT)

### Why a second Azure extension?

An Azure extension already exists (`azure-context-server`), but it is currently broken and appears unmaintained:

- Crashes on Zed stable.285+ for every fresh install — settings are mandatory and fail to parse (oWretch/zed-extension-azure-mcp#26, open since May 2026)
- Downloads its server binary from GitHub releases of `Azure/azure-mcp`, a repo that has since migrated to `microsoft/mcp`
- Built against `zed_extension_api` 0.5.0; the 0.7.0 bump and ~10 other dependabot PRs have sat unmerged for up to a year

### What this one does differently

- `zed_extension_api` 0.7.0, edition 2024
- **Zero-config**: all settings optional with working defaults; unknown settings fields tolerated for forward compatibility
- Launches via Zed's managed Node runtime + the package's `index.js` (no npx, no user Node install; cross-platform incl. Windows)
- Settings: namespace filtering (`--namespace`), tool mode, `--read-only` safety switch, individual tool selection, sovereign clouds (`--cloud`), version pinning, debug logging
- Offline-resilient startup: falls back to the installed server version when the npm registry is unreachable
- Settings UI via `context_server_configuration` with installation instructions and a schemars-generated schema
- Unit-tested settings→args mapping (16 tests); CI with fmt/clippy/test/wasm build and a weekly canary that catches upstream `@azure/mcp` breakage