### PR TITLE
Update Zuraffa to v5.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2708,7 +2708,7 @@ version = "0.1.0"
 
 [mcp-server-zuraffa]
 submodule = "extensions/mcp-server-zuraffa"
-version = "4.1.2"
+version = "5.1.1"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
Updates `mcp-server-zuraffa` to v5.1.1.

Changes:
- Updated submodule to commit `fc33a05` (v5.1.1)
- Updated `version` in `extensions.toml` from `4.1.2` → `5.1.1` to match the submodule's `extension.toml`