### PR TITLE
Update polycarbonate-dark-theme to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3545,7 +3545,7 @@ version = "1.0.12"
 
 [polycarbonate-dark-theme]
 submodule = "extensions/polycarbonate-dark-theme"
-version = "0.0.1"
+version = "0.0.2"
 
 [pony]
 submodule = "extensions/pony"


### PR DESCRIPTION
This updates the polycarbonate-dark-theme extension entry to version 0.0.2.

Changes:
- Bump polycarbonate-dark-theme in extensions.toml from 0.0.1 to 0.0.2.
- Update the extensions/polycarbonate-dark-theme submodule pointer from 622a409 to 864f188.

The new theme release removes the 10 bpc theme variants and documents the current transparency/git gutter limitation.