### PR TITLE
Add svelte-5-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4258,6 +4258,10 @@
 	path = extensions/svelte
 	url = https://github.com/zed-extensions/svelte.git
 
+[submodule "extensions/svelte-5-snippets"]
+	path = extensions/svelte-5-snippets
+	url = https://github.com/polvallverdu/svelte-5-snippets-zed.git
+
 [submodule "extensions/svelte-effect-runtime-language-server"]
 	path = extensions/svelte-effect-runtime-language-server
 	url = https://github.com/usebarekey/svelte-effect-runtime.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4325,6 +4325,10 @@ version = "0.0.1"
 submodule = "extensions/svelte"
 version = "0.2.11"
 
+[svelte-5-snippets]
+submodule = "extensions/svelte-5-snippets"
+version = "1.0.0"
+
 [svelte-effect-runtime-language-server]
 submodule = "extensions/svelte-effect-runtime-language-server"
 path = "modules/svelte-effect-runtime-zed"


### PR DESCRIPTION
Adds the `svelte-5-snippets` extension — a port of the [VS Code svelte-5-snippets extension](https://github.com/Chanzhaoyu/svelte-5-snippets) by Chanzhaoyu.

**68 snippets** across:
- Svelte 5 runes (`$state`, `$derived`, `$effect`, `$props`, `$host` — including all sub-APIs)
- Svelte template syntax (`{#if}`, `{#each}`, `{#await}`, `{@render}`, `{#snippet}`, transitions, etc.)
- Svelte structural elements (`<script>`, `<style>`, `<svelte:*>` tags)
- SvelteKit scaffolding (`load` functions, API routes, actions, hooks, env imports)
- CSS (`:global()`)

**Checklist:**
- [x] Extension ID does not contain "zed" or "extension"
- [x] Uses HTTPS submodule URL
- [x] Submodule commit is on a branch (not detached)
- [x] MIT license included
- [x] `pnpm sort-extensions` run
- [x] Tested locally via "Install Dev Extension" in Zed