### PR TITLE
Update mach to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2391,7 +2391,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.1.0"
+version = "0.2.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2435,7 +2435,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.2.0"
+version = "0.2.1"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
Updates the Mach extension to v0.2.1.

Release notes: documentation corrections for the language server binary rename (`mach-lsp` → `mls`) — fixes the documented `lsp` settings key (`lsp.mach-lsp` → `lsp.mls`) and stale build paths in the extension README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)