### PR TITLE
Add SchemaLock language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3894,6 +3894,10 @@
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git
 
+[submodule "extensions/schemalock"]
+	path = extensions/schemalock
+	url = https://github.com/schemalock/zed.git
+
 [submodule "extensions/scheme"]
 	path = extensions/scheme
 	url = https://github.com/zed-extensions/scheme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3946,8 +3946,8 @@
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git
 
-[submodule "extensions/schemalock"]
-	path = extensions/schemalock
+[submodule "extensions/schemalock-lsp"]
+	path = extensions/schemalock-lsp
 	url = https://github.com/schemalock/zed.git
 
 [submodule "extensions/scheme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3958,6 +3958,10 @@ version = "0.0.4"
 submodule = "extensions/scala"
 version = "0.2.2"
 
+[schemalock]
+submodule = "extensions/schemalock"
+version = "0.1.0"
+
 [scheme]
 submodule = "extensions/scheme"
 version = "0.0.6"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4013,8 +4013,8 @@ version = "0.0.4"
 submodule = "extensions/scala"
 version = "0.2.2"
 
-[schemalock]
-submodule = "extensions/schemalock"
+[schemalock-lsp]
+submodule = "extensions/schemalock-lsp"
 version = "0.1.0"
 
 [scheme]


### PR DESCRIPTION
Adds the **SchemaLock** extension (id `schemalock-lsp`): schema-pinned validation, completion, and hover for Kubernetes-style YAML, backed by a language server.

- **Repo:** https://github.com/schemalock/zed
- **ID:** `schemalock-lsp`
- **Version:** `0.1.0`
- **License:** Apache-2.0

The extension does **not** bundle a binary — it downloads the pinned per-platform language server from the public [`schemalock/schemalock` GitHub releases](https://github.com/schemalock/schemalock/releases) on first use (via the release API) and caches it. Registers the `schemalock` language server for YAML; unowned YAML is transparently proxied to `yaml-language-server`.