### PR TITLE
Add Bloblang extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5193,3 +5193,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/bloblang"]
+	path = extensions/bloblang
+	url = https://github.com/peczenyj/zed-bloblang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -478,6 +478,10 @@
 	path = extensions/blk-theme
 	url = https://github.com/leetdavid/blk-zed
 
+[submodule "extensions/bloblang"]
+	path = extensions/bloblang
+	url = https://github.com/peczenyj/zed-bloblang.git
+
 [submodule "extensions/bloc"]
 	path = extensions/bloc
 	url = https://github.com/felangel/bloc.git
@@ -5193,6 +5197,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/bloblang"]
-	path = extensions/bloblang
-	url = https://github.com/peczenyj/zed-bloblang.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -485,6 +485,10 @@ version = "0.1.0"
 submodule = "extensions/blk-theme"
 version = "0.1.0"
 
+[bloblang]
+submodule = "extensions/bloblang"
+version = "0.1.0"
+
 [bloc]
 submodule = "extensions/bloc"
 version = "0.1.0"


### PR DESCRIPTION
Adds a new extension: **Bloblang** — syntax highlighting for the [Bloblang](https://docs.redpanda.com/connect/guides/bloblang/about/) language, plus embedded Bloblang inside Benthos / [Redpanda Connect](https://docs.redpanda.com/connect/home/) YAML configs.

- Repository: https://github.com/peczenyj/zed-bloblang
- Submodule: `extensions/bloblang`, version `0.1.0`

- [x] Read the extension publishing prerequisites
- [x] Tested locally as a dev extension (both grammars build & link; `.blobl` highlighting and the `#!blobl` YAML injection verified)
- [x] Repository includes an accepted license (MIT)
- [x] Does not duplicate an existing published extension