### PR TITLE
Update phpcs to v0.4.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3471,7 +3471,7 @@ version = "0.1.0"
 
 [phpcs]
 submodule = "extensions/phpcs"
-version = "0.4.3"
+version = "0.4.4"
 
 [phpmago-lsp]
 submodule = "extensions/phpmago-lsp"


### PR DESCRIPTION
Bumps `phpcs` to v0.4.4.

Release notes: https://github.com/mike-bronner/zed-phpcs-lsp/releases/tag/0.4.4