### PR TITLE
Add palenight-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3314,6 +3314,10 @@
 	path = extensions/palenight
 	url = https://github.com/alanmontgomery/palenight-zed.git
 
+[submodule "extensions/palenight-theme"]
+	path = extensions/palenight-theme
+	url = https://github.com/hypn4/zed-palenight-theme.git
+
 [submodule "extensions/panda-plus-theme"]
 	path = extensions/panda-plus-theme
 	url = https://github.com/lucianoratamero/panda-plus-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3364,6 +3364,10 @@ version = "0.0.3"
 submodule = "extensions/palenight"
 version = "0.0.1"
 
+[palenight-theme]
+submodule = "extensions/palenight-theme"
+version = "0.1.0"
+
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

Adds the **Palenight** theme for Zed, an elegant material-inspired theme ported from the [VSCode Palenight Theme](https://github.com/whizkydee/vscode-palenight-theme).

- **Extension id:** `palenight-theme`
- **Repository:** https://github.com/hypn4/zed-palenight-theme
- **Variants (4):**
  - Palenight
  - Palenight Italic
  - Palenight Operator
  - Palenight Mild Contrast

## Checklist

- [x] Extension has `extension.toml` with valid metadata
- [x] Theme JSON follows the Zed theme schema
- [x] MIT license included in the extension repository
- [x] Submodule added under `extensions/palenight-theme` and registered in `extensions.toml`
- [x] `extensions.toml` and `.gitmodules` sorted via `pnpm sort-extensions`
- [x] Tested locally as a dev extension

## Note

This resubmits a previous PR (#5412) that was closed only due to an unresolved CLA. The CLA has since been signed by @hypn4.
