### PR TITLE
Add Legendary Dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2274,6 +2274,10 @@
 	path = extensions/ledger
 	url = https://github.com/mrkstwrt/zed-ledger.git
 
+[submodule "extensions/legendary-dark"]
+	path = extensions/legendary-dark
+	url = https://github.com/Llewellyn500/Legendary-Dark.git
+
 [submodule "extensions/leptos"]
 	path = extensions/leptos
 	url = https://github.com/zed-extensions/leptos.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2274,8 +2274,8 @@
 	path = extensions/ledger
 	url = https://github.com/mrkstwrt/zed-ledger.git
 
-[submodule "extensions/legendary-dark"]
-	path = extensions/legendary-dark
+[submodule "extensions/legendary-dark-theme"]
+	path = extensions/legendary-dark-theme
 	url = https://github.com/Llewellyn500/Legendary-Dark.git
 
 [submodule "extensions/leptos"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2315,8 +2315,9 @@ version = "1.0.1"
 submodule = "extensions/ledger"
 version = "0.2.0"
 
-[legendary-dark]
-submodule = "extensions/legendary-dark"
+[legendary-dark-theme]
+submodule = "extensions/legendary-dark-theme"
+path = "zed"
 version = "5.0.1"
 
 [leptos]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2315,6 +2315,10 @@ version = "1.0.1"
 submodule = "extensions/ledger"
 version = "0.2.0"
 
+[legendary-dark]
+submodule = "extensions/legendary-dark"
+version = "5.0.1"
+
 [leptos]
 submodule = "extensions/leptos"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2317,7 +2317,6 @@ version = "0.2.0"
 
 [legendary-dark]
 submodule = "extensions/legendary-dark"
-path = "zed"
 version = "5.0.1"
 
 [leptos]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2317,6 +2317,7 @@ version = "0.2.0"
 
 [legendary-dark]
 submodule = "extensions/legendary-dark"
+path = "zed"
 version = "5.0.1"
 
 [leptos]


### PR DESCRIPTION
﻿## Summary

Adds Legendary Dark as a Zed theme extension.

The extension source is https://github.com/Llewellyn500/Legendary-Dark and includes:

- `extension.toml` with extension ID `legendary-dark`
- `themes/legendary-dark.json`
- MIT license at the extension root

## Validation

- Installed the registry dependencies with `pnpm sort-extensions`
- Ran `pnpm sort-extensions`
- Ran `pnpm build`
- Ran `pnpm test`
- Validated `themes/legendary-dark.json` against `https://zed.dev/schema/themes/v0.2.0.json` using `ajv-cli`
