### PR TITLE
Update mach to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2391,7 +2391,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.1.0"
+version = "0.2.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2440,7 +2440,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.2.1"
+version = "0.2.2"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
Updates the existing `mach` extension 0.2.1 → 0.2.2.

- Bumps `zed_extension_api` 0.6.0 → 0.7.0 to track the current extension API. No user-facing behavior change (the language-server discovery logic is unchanged; the API surface used is source-compatible).
- Submodule `extensions/mach` points at octalide/mach-zed@f476e39 (the v0.2.2 release commit on `main`); `extensions.toml` version matches `extension.toml` at that commit.
- Build-verified: clean `cargo build --release --target wasm32-wasip1`.
- License: MIT.

- [x] I have tested my changes against the latest version of Zed