### PR TITLE
Add Redmine MCP Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3734,6 +3734,10 @@
 	path = extensions/red
 	url = https://github.com/red/zed-red.git
 
+[submodule "extensions/redmine-mcp-server"]
+	path = extensions/redmine-mcp-server
+	url = https://github.com/weirdo-adam/zed-mcp-server-redmine.git
+
 [submodule "extensions/redscript"]
 	path = extensions/redscript
 	url = https://github.com/jac3km4/redscript-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3796,6 +3796,10 @@ version = "0.1.4"
 submodule = "extensions/red"
 version = "0.2.0"
 
+[redmine-mcp-server]
+submodule = "extensions/redmine-mcp-server"
+version = "0.1.0"
+
 [redscript]
 submodule = "extensions/redscript"
 version = "0.2.0"


### PR DESCRIPTION
Adds the Redmine MCP Server extension to the Zed extension registry.\n\nExtension repository: https://github.com/weirdo-adam/zed-mcp-server-redmine\nVersion: 0.1.0\n\nLocal checks run:\n- pnpm sort-extensions\n- pnpm build\n- pnpm test\n\nThe extension was also checked in its own repository before adding the registry entry.