### PR TITLE
Add CSS-in-JS extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -878,6 +878,10 @@
 	path = extensions/cspell
 	url = https://github.com/mantou132/zed-cspell
 
+[submodule "extensions/css-in-js"]
+	path = extensions/css-in-js
+	url = https://github.com/ivanwooc/zed-css-in-js.git
+
 [submodule "extensions/css-modules-kit"]
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -893,6 +893,10 @@ version = "1.2.4"
 submodule = "extensions/cspell"
 version = "0.0.7"
 
+[css-in-js]
+submodule = "extensions/css-in-js"
+version = "0.1.0"
+
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
 version = "0.1.1"


### PR DESCRIPTION
Adds the CSS-in-JS extension to the official Zed extension registry.

The extension provides CSS-in-JS IntelliSense for styled-components and Emotion tagged template literals, including completion, hover, diagnostics, and quick fixes via `@styled/typescript-styled-plugin`.

Validation performed:
- Tested locally in Zed as a dev extension by the extension author.
- `cargo check --target wasm32-wasip1` passed in the extension repository.
- `pnpm sort-extensions` passed in this repository.
- `pnpm build` passed in this repository.
- `pnpm test` passed in this repository.
