### PR TITLE
Update maho-lsp to v0.10.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2452,7 +2452,7 @@ version = "0.1.0"
 
 [maho-lsp]
 submodule = "extensions/maho-lsp"
-version = "0.9.1"
+version = "0.10.0"
 
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"


### PR DESCRIPTION
Bumps `maho-lsp` to v0.10.0.

This release adds a Model Context Protocol (MCP) context server (`maho-intelligence-mcp`) for Zed's AI agent, exposing Maho's runtime configuration (class aliases, rewrites, merged config, modules, events, EAV attributes, DB schema, and more), alongside the existing LSP integration.

Release notes: https://github.com/MahoCommerce/zed/releases/tag/v0.10.0