### PR TITLE
Add excalidraw-preview extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1326,6 +1326,10 @@
 	path = extensions/evolved-theme
 	url = https://github.com/evoL/evolved-theme.git
 
+[submodule "extensions/excalidraw-preview"]
+	path = extensions/excalidraw-preview
+	url = https://github.com/yankeeinlondon/excalidraw-zed-extension.git
+
 [submodule "extensions/exograph"]
 	path = extensions/exograph
 	url = https://github.com/exograph/zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1349,6 +1349,11 @@ submodule = "extensions/evolved-theme"
 path = "dist/zed"
 version = "0.3.0"
 
+[excalidraw-preview]
+submodule = "extensions/excalidraw-preview"
+path = "extension"
+version = "0.3.0"
+
 [exograph]
 submodule = "extensions/exograph"
 version = "0.0.2"


### PR DESCRIPTION
Adds **Excalidraw Preview** (`excalidraw-preview`): previews `.excalidraw`, `.excalidraw.svg`, and `.excalidraw.png` files in a native WebView window with live reload, native export save dialogs, and persistent shape library.

- Repo: https://github.com/yankeeinlondon/excalidraw-zed-extension
- The extension manifest is in the `extension/` subdirectory (hence `path = "extension"`).
- The companion native binary is downloaded at runtime from GitHub Releases (v0.3.0), not bundled.
- LICENSE present at repo root.