### PR TITLE
Add AutoHotkey 2.0 extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5117,3 +5117,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ahk2"]
+	path = extensions/ahk2
+	url = https://github.com/BlessEphraem/zed-ahk2

--- a/.gitmodules
+++ b/.gitmodules
@@ -78,6 +78,10 @@
 	path = extensions/agno-theme
 	url = https://github.com/devalexandre/agno-theme.git
 
+[submodule "extensions/ahk2"]
+	path = extensions/ahk2
+	url = https://github.com/BlessEphraem/zed-ahk2
+
 [submodule "extensions/aiken"]
 	path = extensions/aiken
 	url = https://github.com/aiken-lang/zed-aiken.git
@@ -5117,6 +5121,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ahk2"]
-	path = extensions/ahk2
-	url = https://github.com/BlessEphraem/zed-ahk2

--- a/extensions.toml
+++ b/extensions.toml
@@ -80,6 +80,10 @@ submodule = "extensions/agno-theme"
 path = "zed"
 version = "0.0.4"
 
+[ahk2]
+submodule = "extensions/ahk2"
+version = "0.0.1"
+
 [aiken]
 submodule = "extensions/aiken"
 version = "1.0.0"


### PR DESCRIPTION
## Summary

Adds syntax highlighting support for [AutoHotkey v2](https://www.autohotkey.com/) (AHK2).

**Extension repo:** https://github.com/BlessEphraem/zed-ahk2

## Why a separate extension from `autohotkey`?

The existing `autohotkey` extension targets AHK **v1**. AHK v2 is a breaking redesign — different syntax, different keywords, different string delimiters (v2 uses `"` only), different class system, etc. A shared grammar cannot correctly highlight both.

## Features

- Tree-sitter grammar written from scratch for AHK2
- Hotkeys and hotstrings, including non-ASCII / AZERTY keys (`#é::`, `#²::`, `!&::`, …)
- Classes, methods, properties, arrow functions
- Directives (`#Requires`, `#Include`, `#HotIf`, …)
- Built-in variables (`A_ThisHotkey`, `A_ScriptDir`, …)
- Case-insensitive keyword handling via GLR parsing
- File extensions: `.ah2`, `.ahk2` (avoids conflict with v1 extension on `.ahk`)
- `first_line_pattern` detects `#Requires AutoHotkey 2` for auto-identification

## Checklist

- [x] `extension.toml` present and valid
- [x] Grammar compiles (tree-sitter grammar + `src/parser.c` committed)
- [x] No `.ahk` suffix conflict with existing `autohotkey` extension
- [x] MIT license