### PR TITLE
Add Patina theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3358,6 +3358,10 @@
 	path = extensions/pathy
 	url = https://github.com/gokulp01/pathy.git
 
+[submodule "extensions/patina-theme"]
+	path = extensions/patina-theme
+	url = https://github.com/lmarkmann/patina-theme.git
+
 [submodule "extensions/pbxproj"]
 	path = extensions/pbxproj
 	url = https://github.com/zwaldowski/zed-pbxproj.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3410,6 +3410,10 @@ version = "1.3.1"
 submodule = "extensions/pathy"
 version = "0.1.0"
 
+[patina-theme]
+submodule = "extensions/patina-theme"
+version = "1.3.0"
+
 [pbxproj]
 submodule = "extensions/pbxproj"
 version = "0.2.0"


### PR DESCRIPTION
Adds **Patina**, a warm, muted theme with earthy tones: teal oxidation against amber warmth. Six variants: Dark, Dark Soft, Moss, Light, Lichen, and Stellar.

Repository: https://github.com/lmarkmann/patina-theme

- Extension ID `patina-theme` (suffixed `-theme`), unique in `extensions.toml`.
- MIT `LICENSE` at the repository root.
- Submodule pinned to the `v1.3.0` commit on `main`.
- Also published on the VS Code Marketplace and Open VSX.

Ran `pnpm sort-extensions`, so `extensions.toml` and `.gitmodules` stay sorted.
