### PR TITLE
Add blueprint-dark-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -486,6 +486,10 @@
 	path = extensions/blueprint
 	url = https://github.com/tfuxu/zed-blueprint.git
 
+[submodule "extensions/blueprint-dark-theme"]
+	path = extensions/blueprint-dark-theme
+	url = https://github.com/SM2507/blueprint-dark-theme.git
+
 [submodule "extensions/bluespec-systemverilog"]
 	path = extensions/bluespec-systemverilog
 	url = https://github.com/sandytruant/zed-bsv

--- a/extensions.toml
+++ b/extensions.toml
@@ -494,6 +494,10 @@ version = "1.0.0"
 submodule = "extensions/blueprint"
 version = "0.4.1"
 
+[blueprint-dark-theme]
+submodule = "extensions/blueprint-dark-theme"
+version = "0.1.0"
+
 [bluespec-systemverilog]
 submodule = "extensions/bluespec-systemverilog"
 version = "0.1.0"


### PR DESCRIPTION
**Summary**
Adds Blueprint Dark Theme as a Zed theme extension.
The extension source is https://github.com/SM2507/blueprint-dark-theme and includes:

- extension.toml with extension ID blueprint-dark-theme
- themes/blueprint-dark-theme.json
- MIT license at the extension root

**Validation**

- Ran pnpm sort-extensions
- Installed and tested locally as a dev extension via zed: install dev extension