### PR TITLE
Add Marko language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2466,6 +2466,10 @@
 	path = extensions/markdownlint
 	url = https://github.com/vitallium/zed-markdownlint.git
 
+[submodule "extensions/marko"]
+	path = extensions/marko
+	url = https://github.com/marko-js/zed.git
+
 [submodule "extensions/marksman"]
 	path = extensions/marksman
 	url = https://github.com/vitallium/zed-marksman.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2510,6 +2510,10 @@ version = "0.0.8"
 submodule = "extensions/markdownlint"
 version = "0.4.0"
 
+[marko]
+submodule = "extensions/marko"
+version = "0.1.0"
+
 [marksman]
 submodule = "extensions/marksman"
 version = "1.0.0"


### PR DESCRIPTION
Adds the **Marko** extension ([marko-js/zed](https://github.com/marko-js/zed) @ `v0.1.0`), language support for the [Marko](https://markojs.com/) templating language:

- Syntax highlighting, embedded-language injections (TypeScript/CSS/SCSS), bracket matching, and outline via the [tree-sitter-marko](https://github.com/marko-js/tree-sitter) grammar.
- The [Marko language server](https://github.com/marko-js/language-server) (`@marko/language-server`).
- Typed `.marko` imports inside `.ts`/`.tsx` files via `@marko/ts-plugin` (registered with vtsls / typescript-language-server).

License: MIT. Maintained by the Marko team (marko-js).