### PR TITLE
Add Flutter Tools extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1458,6 +1458,10 @@
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets
 
+[submodule "extensions/flutter-tools"]
+	path = extensions/flutter-tools
+	url = https://github.com/qingzhoufeihu/flutter-zed-plugin.git
+
 [submodule "extensions/focus-theme"]
 	path = extensions/focus-theme
 	url = https://github.com/jigyansunanda/focus.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1482,6 +1482,10 @@ version = "1.0.0"
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"
 
+[flutter-tools]
+submodule = "extensions/flutter-tools"
+version = "0.1.1"
+
 [focus-theme]
 submodule = "extensions/focus-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the Flutter Tools extension.
This extension contributes Flutter-focused run and build tasks for Dart/Flutter projects in Zed, including:
- Run on Android Emulator with automatic emulator launch
- Run on iOS Simulator, Chrome, and macOS
- Release build shortcuts for APK, split-per-ABI APKs, App Bundle, IPA, and Web

Validation run locally:
- pnpm sort-extensions
- pnpm build
- pnpm test