### PR TITLE
Add Hoverfly extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1886,6 +1886,10 @@
 	path = extensions/hot-dog-stand
 	url = https://github.com/CoasterFan5/hotdog-stand-zed.git
 
+[submodule "extensions/hoverfly"]
+	path = extensions/hoverfly
+	url = https://github.com/jterrazz/hoverfly-lsp.git
+
 [submodule "extensions/hp42s"]
 	path = extensions/hp42s
 	url = https://codeberg.org/brechanbech/tree-sitter-hp42s.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1919,6 +1919,11 @@ version = "1.0.0"
 submodule = "extensions/hot-dog-stand"
 version = "0.0.2"
 
+[hoverfly]
+submodule = "extensions/hoverfly"
+path = "editors/zed"
+version = "0.1.0"
+
 [hp42s]
 submodule = "extensions/hp42s"
 version = "0.3.0"


### PR DESCRIPTION
Adds the **Hoverfly** extension: language support for [Hoverfly](https://hoverfly.io) API simulation files (`*.hoverfly.json`, `*.hfy`, `hoverfly-simulation.json`): diagnostics, completion, hover, and semantic-token highlighting for the templating syntax.

- Source: https://github.com/jterrazz/hoverfly-lsp (extension in `editors/zed`, pinned to tag `v0.1.0`).
- The language server is published on npm as [`@jterrazz/hoverfly-lsp`](https://www.npmjs.com/package/@jterrazz/hoverfly-lsp) and auto-installed by the extension (it also prefers a project-local `node_modules/.bin/hoverfly-lsp` or one on `$PATH` if present).
- Built against `zed_extension_api` 0.7.0 (wasm32-wasip2); reuses the JSON grammar for base highlighting.

Tested locally as a dev extension.
