### PR TITLE
Add imzed extension (IBM mainframe languages: JCL, COBOL, REXX, HLASM)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,10 @@
 	path = extensions/1984-theme
 	url = https://github.com/chenmijiang/zed-1984.git
 
+[submodule "extensions/a-distant-hope-theme"]
+	path = extensions/a-distant-hope-theme
+	url = https://github.com/chrislockard/a-distant-hope-theme.git
+
 [submodule "extensions/a-touch-of-lilac-theme"]
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme
@@ -46,6 +50,10 @@
 	path = extensions/adech
 	url = https://github.com/adechlien/adech-theme-zed.git
 
+[submodule "extensions/adventurex-theme"]
+	path = extensions/adventurex-theme
+	url = https://github.com/AdventureX-RGE/zed-adventurex-theme.git
+
 [submodule "extensions/adwaita"]
 	path = extensions/adwaita
 	url = https://github.com/somepaulo/adwaita-zed-theme.git
@@ -66,6 +74,10 @@
 	path = extensions/agnix
 	url = https://github.com/avifenesh/agnix.git
 
+[submodule "extensions/agno-theme"]
+	path = extensions/agno-theme
+	url = https://github.com/devalexandre/agno-theme.git
+
 [submodule "extensions/aiken"]
 	path = extensions/aiken
 	url = https://github.com/aiken-lang/zed-aiken.git
@@ -81,6 +93,14 @@
 [submodule "extensions/aizen-theme"]
 	path = extensions/aizen-theme
 	url = https://github.com/vivy-company/zed-aizen-theme.git
+
+[submodule "extensions/akhdar-by-aramb-dev-theme"]
+	path = extensions/akhdar-by-aramb-dev-theme
+	url = https://github.com/aramb-dev/akhdar-by-aramb-dev-theme.git
+
+[submodule "extensions/al-business-central"]
+	path = extensions/al-business-central
+	url = https://github.com/mhensberg2003/ALzed.git
 
 [submodule "extensions/alabaster"]
 	path = extensions/alabaster
@@ -170,6 +190,10 @@
 	path = extensions/arctic-depth
 	url = https://github.com/MarvellinusVincent/Arctic-Depth-Zed.git
 
+[submodule "extensions/arctikai-theme"]
+	path = extensions/arctikai-theme
+	url = https://github.com/hexqnt/arctikai-zed.git
+
 [submodule "extensions/arduino"]
 	path = extensions/arduino
 	url = https://github.com/mambucodev/zed-arduino.git
@@ -182,9 +206,13 @@
 	path = extensions/arkts
 	url = https://github.com/liuyanghejerry/zed-arkts.git
 
+[submodule "extensions/ars-goetia-theme"]
+	path = extensions/ars-goetia-theme
+	url = https://github.com/rvdeguzman/ars-goetia-zed.git
+
 [submodule "extensions/arturo"]
 	path = extensions/arturo
-	url = https://github.com/DaZhi-the-Revelator/zed-arturo.git
+	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo.git
 
 [submodule "extensions/asciidoc"]
 	path = extensions/asciidoc
@@ -218,9 +246,17 @@
 	path = extensions/asteroid
 	url = https://github.com/webhooked/asteroid-zed
 
+[submodule "extensions/astral-theme"]
+	path = extensions/astral-theme
+	url = https://github.com/leofernandesbh/astral-zed-theme.git
+
 [submodule "extensions/astro"]
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
+
+[submodule "extensions/atlas-ragnarok-theme"]
+	path = extensions/atlas-ragnarok-theme
+	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git
 
 [submodule "extensions/atom-one-theme"]
 	path = extensions/atom-one-theme
@@ -274,9 +310,17 @@
 	path = extensions/awk
 	url = https://github.com/dangh/zed-awk.git
 
+[submodule "extensions/awsum"]
+	path = extensions/awsum
+	url = https://github.com/awsum-lang/awsum-zed.git
+
 [submodule "extensions/axolosin"]
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git
+
+[submodule "extensions/ayla"]
+	path = extensions/ayla
+	url = https://github.com/z-sk1/zed-ayla
 
 [submodule "extensions/aylin-theme"]
 	path = extensions/aylin-theme
@@ -326,6 +370,10 @@
 	path = extensions/batman
 	url = https://github.com/devzaidi/batman-theme-zed
 
+[submodule "extensions/batsignal-theme"]
+	path = extensions/batsignal-theme
+	url = https://github.com/kijv/batsignal-zed.git
+
 [submodule "extensions/beancount"]
 	path = extensions/beancount
 	url = https://github.com/zed-extensions/beancount.git
@@ -366,6 +414,10 @@
 	path = extensions/biome
 	url = https://github.com/biomejs/biome-zed.git
 
+[submodule "extensions/birds-of-paradise-theme"]
+	path = extensions/birds-of-paradise-theme
+	url = https://github.com/LoganBresnahan/birds-of-paradise-zed.git
+
 [submodule "extensions/bison"]
 	path = extensions/bison
 	url = https://github.com/fanwenlin/bison-zed
@@ -377,6 +429,10 @@
 [submodule "extensions/blackfox"]
 	path = extensions/blackfox
 	url = https://github.com/matejcerny/BlackFoxZed.git
+
+[submodule "extensions/blacknpink-theme"]
+	path = extensions/blacknpink-theme
+	url = https://github.com/blacknpink/zed.git
 
 [submodule "extensions/blackrain-theme"]
 	path = extensions/blackrain-theme
@@ -418,6 +474,10 @@
 	path = extensions/bloc
 	url = https://github.com/felangel/bloc.git
 
+[submodule "extensions/blueberry-banana-theme"]
+	path = extensions/blueberry-banana-theme
+	url = https://github.com/srijonp4/blueberry-banana-zed.git
+
 [submodule "extensions/blueforest-theme"]
 	path = extensions/blueforest-theme
 	url = https://github.com/alonsodomin/zed-blueforest-theme.git
@@ -442,6 +502,10 @@
 	path = extensions/borderless-minimal-theme
 	url = https://github.com/hatemecha/borderless-minimal-zed.git
 
+[submodule "extensions/borealis-theme"]
+	path = extensions/borealis-theme
+	url = https://github.com/VimCommando/zed-theme-borealis.git
+
 [submodule "extensions/bqn"]
 	path = extensions/bqn
 	url = https://github.com/DavidZwitser/zed-bqn.git
@@ -449,6 +513,10 @@
 [submodule "extensions/brainfuck"]
 	path = extensions/brainfuck
 	url = https://github.com/JosephTLyons/zed-brainfuck.git
+
+[submodule "extensions/brogrammer-theme"]
+	path = extensions/brogrammer-theme
+	url = https://github.com/gebeto/brogrammer-theme.git
 
 [submodule "extensions/browser-tools-context-server"]
 	path = extensions/browser-tools-context-server
@@ -465,6 +533,10 @@
 [submodule "extensions/bubblegum"]
 	path = extensions/bubblegum
 	url = https://github.com/koalefant/zed-bubblegum
+
+[submodule "extensions/bugstalker-dap"]
+	path = extensions/bugstalker-dap
+	url = https://github.com/godzie44/BugStalker.git
 
 [submodule "extensions/bun-docs-mcp"]
 	path = extensions/bun-docs-mcp
@@ -490,6 +562,10 @@
 	path = extensions/call-trans-opt-received
 	url = https://github.com/takk8is/call-trans-opt-received-2-19-98-13-24-18-rec-log-theme-for-zed.git
 
+[submodule "extensions/canipls-lint"]
+	path = extensions/canipls-lint
+	url = https://github.com/taylorplewe/canipls-zed.git
+
 [submodule "extensions/capnp"]
 	path = extensions/capnp
 	url = https://github.com/cmackenzie1/zed-capnp.git
@@ -502,6 +578,10 @@
 	path = extensions/carbonfox
 	url = https://github.com/harrisonablack/carbonfox-zed.git
 
+[submodule "extensions/carbonmeda-theme"]
+	path = extensions/carbonmeda-theme
+	url = https://github.com/Fyelne/carbonfox-andromeda.git
+
 [submodule "extensions/cargo-appraiser"]
 	path = extensions/cargo-appraiser
 	url = https://github.com/washanhanzi/zed-cargo-appraiser
@@ -509,6 +589,10 @@
 [submodule "extensions/cargo-tom"]
 	path = extensions/cargo-tom
 	url = https://github.com/frederik-uni/zed-cargotom.git
+
+[submodule "extensions/cassette-futurism-theme"]
+	path = extensions/cassette-futurism-theme
+	url = https://github.com/taotao7/cassette-futurism-theme
 
 [submodule "extensions/catbox"]
 	path = extensions/catbox
@@ -554,6 +638,10 @@
 	path = extensions/chai-theme
 	url = https://github.com/rushabhcodes/zed-chai-theme
 
+[submodule "extensions/chalice-theme"]
+	path = extensions/chalice-theme
+	url = https://github.com/huangkairan/chalice-theme-zed.git
+
 [submodule "extensions/chanterelle"]
 	path = extensions/chanterelle
 	url = https://github.com/steffenhaug/chanterelle-zed.git
@@ -561,6 +649,10 @@
 [submodule "extensions/chaos-theory-theme"]
 	path = extensions/chaos-theory-theme
 	url = https://github.com/FeurJak/Chaos-Theory-Zed.git
+
+[submodule "extensions/charbox-theme"]
+	path = extensions/charbox-theme
+	url = https://github.com/monarcode/charbox-zed
 
 [submodule "extensions/charcoal-theme"]
 	path = extensions/charcoal-theme
@@ -606,6 +698,10 @@
 	path = extensions/city-lights
 	url = https://github.com/DP19/zed-theme-city-lights.git
 
+[submodule "extensions/civet"]
+	path = extensions/civet
+	url = https://github.com/DanielXMoore/Civet.git
+
 [submodule "extensions/clarity"]
 	path = extensions/clarity
 	url = https://github.com/stx-labs/clarity-zed.git
@@ -613,6 +709,10 @@
 [submodule "extensions/claude-code-inspired-dark"]
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git
+
+[submodule "extensions/claude-warm-theme"]
+	path = extensions/claude-warm-theme
+	url = https://github.com/intherejeet/claude-warm-theme.git
 
 [submodule "extensions/clean-vscode-icons"]
 	path = extensions/clean-vscode-icons
@@ -633,6 +733,10 @@
 [submodule "extensions/cobalt2"]
 	path = extensions/cobalt2
 	url = https://github.com/wesbos/cobalt2-zed.git
+
+[submodule "extensions/cobalt2x2-theme"]
+	path = extensions/cobalt2x2-theme
+	url = https://github.com/kbilkis/cobalt2x2.git
 
 [submodule "extensions/cobol"]
 	path = extensions/cobol
@@ -698,6 +802,10 @@
 	path = extensions/comment
 	url = https://github.com/thedadams/zed-comment.git
 
+[submodule "extensions/comment-block-snippets"]
+	path = extensions/comment-block-snippets
+	url = https://github.com/rami-shalhoub/comment-blocks-zed.git
+
 [submodule "extensions/comphy-crisp-themes"]
 	path = extensions/comphy-crisp-themes
 	url = https://github.com/VatsalSy/comphy-zed-themes.git
@@ -725,6 +833,10 @@
 [submodule "extensions/cosmos"]
 	path = extensions/cosmos
 	url = https://github.com/nauvalazhar/cosmos.git
+
+[submodule "extensions/coverage-lsp"]
+	path = extensions/coverage-lsp
+	url = https://github.com/fargies/coverage-lsp.git
 
 [submodule "extensions/cpp2"]
 	path = extensions/cpp2
@@ -774,6 +886,10 @@
 	path = extensions/css-variables
 	url = https://github.com/lmn451/css-variables-zed.git
 
+[submodule "extensions/csskit-lsp"]
+	path = extensions/csskit-lsp
+	url = https://github.com/csskit/csskit
+
 [submodule "extensions/csv"]
 	path = extensions/csv
 	url = https://github.com/huacnlee/zed-csv.git
@@ -809,6 +925,10 @@
 [submodule "extensions/cyberpunk-2077"]
 	path = extensions/cyberpunk-2077
 	url = https://github.com/takk8is/cyberpunk-2077-theme-for-zed.git
+
+[submodule "extensions/cyberpunk-2077-theme"]
+	path = extensions/cyberpunk-2077-theme
+	url = https://github.com/thomassimmer/cyberpunk-2077-zed-extension.git
 
 [submodule "extensions/cyberpunk-scarlet"]
 	path = extensions/cyberpunk-scarlet
@@ -850,6 +970,10 @@
 	path = extensions/darcula-dark-okkano
 	url = https://github.com/okkan/zed-darcula-dark-okkano.git
 
+[submodule "extensions/darcula-forest-theme"]
+	path = extensions/darcula-forest-theme
+	url = https://github.com/oryanm/darcula-forest-zed
+
 [submodule "extensions/dark-castle-theme"]
 	path = extensions/dark-castle-theme
 	url = https://github.com/malucard/dark-castle-theme-zed
@@ -874,6 +998,10 @@
 	path = extensions/dark-pop-ui
 	url = https://github.com/kunal-arora/zed-theme-dark-pop-ui.git
 
+[submodule "extensions/dark-purple-theme"]
+	path = extensions/dark-purple-theme
+	url = https://github.com/brgr/dark-purple-theme-for-zed.git
+
 [submodule "extensions/darker-horizon"]
 	path = extensions/darker-horizon
 	url = https://github.com/ewwwdp/dark-horizon-zed.git
@@ -897,6 +1025,10 @@
 [submodule "extensions/dbml"]
 	path = extensions/dbml
 	url = https://github.com/shuklaayush/zed-dbml.git
+
+[submodule "extensions/dbt"]
+	path = extensions/dbt
+	url = https://github.com/kylejbrk/zed-dbt.git
 
 [submodule "extensions/decorative-stitch"]
 	path = extensions/decorative-stitch
@@ -932,7 +1064,7 @@
 
 [submodule "extensions/design-tokens"]
 	path = extensions/design-tokens
-	url = https://github.com/bennypowers/design-tokens-language-server
+	url = https://github.com/bennypowers/asimonim.git
 
 [submodule "extensions/desktop"]
 	path = extensions/desktop
@@ -942,9 +1074,17 @@
 	path = extensions/dev-magic
 	url = https://github.com/susanta96/dev-magic.git
 
+[submodule "extensions/devglobe-activity-ls"]
+	path = extensions/devglobe-activity-ls
+	url = https://github.com/devglobe-xyz/zed-devglobe.git
+
 [submodule "extensions/devicetree"]
 	path = extensions/devicetree
 	url = https://github.com/anikinmd/zed_devicetree
+
+[submodule "extensions/dhall"]
+	path = extensions/dhall
+	url = https://github.com/SrGaabriel/zed-dhall
 
 [submodule "extensions/discord-presence"]
 	path = extensions/discord-presence
@@ -957,6 +1097,10 @@
 [submodule "extensions/django-snippets"]
 	path = extensions/django-snippets
 	url = https://github.com/bencres/zed-django-snippets.git
+
+[submodule "extensions/djot"]
+	path = extensions/djot
+	url = https://github.com/nzoschke/zed-djot.git
 
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose
@@ -973,6 +1117,10 @@
 [submodule "extensions/dogxi-theme"]
 	path = extensions/dogxi-theme
 	url = https://github.com/dogxii/dogxi-theme-zed.git
+
+[submodule "extensions/doom-one-theme"]
+	path = extensions/doom-one-theme
+	url = https://github.com/bashln/zed-doom.git
 
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
@@ -1018,6 +1166,10 @@
 	path = extensions/dwp
 	url = https://github.com/shenlong21/zed-dwp-theme.git
 
+[submodule "extensions/earo-theme"]
+	path = extensions/earo-theme
+	url = https://github.com/earomc/earo-theme-zed.git
+
 [submodule "extensions/earthfile"]
 	path = extensions/earthfile
 	url = https://github.com/glehmann/earthfile.zed.git
@@ -1025,6 +1177,14 @@
 [submodule "extensions/earthsong-theme"]
 	path = extensions/earthsong-theme
 	url = https://github.com/hsjoberg/zedsong.git
+
+[submodule "extensions/easy-opaque-theme"]
+	path = extensions/easy-opaque-theme
+	url = https://github.com/KarmanyaIyer/zed-easy-opaque-theme.git
+
+[submodule "extensions/ebnf"]
+	path = extensions/ebnf
+	url = https://github.com/louiss0/zed-ebnf.git
 
 [submodule "extensions/eclat"]
 	path = extensions/eclat
@@ -1042,6 +1202,14 @@
 	path = extensions/editorconfig
 	url = https://github.com/notpeter/editorconfig-zed.git
 
+[submodule "extensions/edusites-theme"]
+	path = extensions/edusites-theme
+	url = https://github.com/eduardolecdt/edusites-theme-zed.git
+
+[submodule "extensions/effect-language-service-tsgo"]
+	path = extensions/effect-language-service-tsgo
+	url = https://github.com/RATIU5/zed-effect-tsgo.git
+
 [submodule "extensions/eiffel-theme"]
 	path = extensions/eiffel-theme
 	url = https://github.com/demiurg/zed-theme-eiffel.git
@@ -1058,6 +1226,10 @@
 	path = extensions/eldritch-theme
 	url = https://github.com/edheltzel/eldritch-zed.git
 
+[submodule "extensions/electron-highlighter-theme"]
+	path = extensions/electron-highlighter-theme
+	url = https://github.com/electron-highlighter/zed.git
+
 [submodule "extensions/electron-vue-theme"]
 	path = extensions/electron-vue-theme
 	url = https://github.com/Drew-Chase/electron-vue-themes.git
@@ -1069,6 +1241,10 @@
 [submodule "extensions/elixir"]
 	path = extensions/elixir
 	url = https://github.com/zed-extensions/elixir.git
+
+[submodule "extensions/elixir-hex-lens"]
+	path = extensions/elixir-hex-lens
+	url = https://github.com/jotaviobiondo/elixir-hex-lens-zed.git
 
 [submodule "extensions/elixir-snippets"]
 	path = extensions/elixir-snippets
@@ -1126,6 +1302,10 @@
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed
 
+[submodule "extensions/eva-theme"]
+	path = extensions/eva-theme
+	url = https://github.com/Oneptica/Zed-Theme-Evangelion.git
+
 [submodule "extensions/everforest"]
 	path = extensions/everforest
 	url = https://github.com/albertsko/zed-everforest.git
@@ -1166,6 +1346,10 @@
 	path = extensions/factory-droid
 	url = https://github.com/Factory-AI/factory-zed-extension.git
 
+[submodule "extensions/falcon-theme"]
+	path = extensions/falcon-theme
+	url = https://github.com/panxiaoan/falcon-zed-themes.git
+
 [submodule "extensions/fantasticons-icons-theme"]
 	path = extensions/fantasticons-icons-theme
 	url = https://github.com/caiolandgraf/fantasticons-zed.git
@@ -1182,6 +1366,10 @@
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git
 
+[submodule "extensions/fff-mcp"]
+	path = extensions/fff-mcp
+	url = https://github.com/dl-alexandre/zed-fff.git
+
 [submodule "extensions/fiber-snippets"]
 	path = extensions/fiber-snippets
 	url = https://github.com/ayberkgezer/fiber-zed-snippets
@@ -1190,9 +1378,21 @@
 	path = extensions/fiberplane-studio
 	url = https://github.com/keturiosakys/zed-fp-studio.git
 
+[submodule "extensions/field-lights-theme"]
+	path = extensions/field-lights-theme
+	url = https://github.com/adamsharifc/zed-field-lights
+
+[submodule "extensions/file-icons"]
+	path = extensions/file-icons
+	url = https://github.com/toxblh/zed-file-icons.git
+
 [submodule "extensions/findrakecil-alabaster"]
 	path = extensions/findrakecil-alabaster
 	url = https://github.com/findrakecil/alabaster-zed-theme.git
+
+[submodule "extensions/fineorite-theme"]
+	path = extensions/fineorite-theme
+	url = https://github.com/Finorion/zed-fineorite.git
 
 [submodule "extensions/firebase-security-rules"]
 	path = extensions/firebase-security-rules
@@ -1205,6 +1405,10 @@
 [submodule "extensions/fish"]
 	path = extensions/fish
 	url = https://github.com/hasit/zed-fish.git
+
+[submodule "extensions/fjord-theme"]
+	path = extensions/fjord-theme
+	url = https://github.com/fjord-themes/fjord-zed.git
 
 [submodule "extensions/flask-snippets"]
 	path = extensions/flask-snippets
@@ -1246,6 +1450,10 @@
 	path = extensions/flow-theme
 	url = https://github.com/Rics-Dev/zed-flow-theme.git
 
+[submodule "extensions/fluent-oled-theme"]
+	path = extensions/fluent-oled-theme
+	url = https://github.com/fermeridamagni/fluent-oled-for-zed.git
+
 [submodule "extensions/flutter-snippets"]
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets
@@ -1282,6 +1490,10 @@
 	path = extensions/fozzy
 	url = https://github.com/juxta-tad/fozzy-zed.git
 
+[submodule "extensions/framer-dark-theme"]
+	path = extensions/framer-dark-theme
+	url = https://github.com/gxanshu/zed-framer-dark.git
+
 [submodule "extensions/freemarker"]
 	path = extensions/freemarker
 	url = https://github.com/debba/zed-freemarker.git
@@ -1289,6 +1501,10 @@
 [submodule "extensions/freezed-dart-flutter-snippets"]
 	path = extensions/freezed-dart-flutter-snippets
 	url = https://github.com/OppositeDragon/freezed-snippets.git
+
+[submodule "extensions/frieren-theme"]
+	path = extensions/frieren-theme
+	url = https://github.com/PR454D/frieren-theme.git
 
 [submodule "extensions/frosted-theme"]
 	path = extensions/frosted-theme
@@ -1302,6 +1518,10 @@
 	path = extensions/fsm
 	url = https://codeberg.org/reesericci/zed-extension-fsm.git
 
+[submodule "extensions/fujihaze-theme"]
+	path = extensions/fujihaze-theme
+	url = https://github.com/BinaryMoura/FujiHaze-Theme.git
+
 [submodule "extensions/furina-vibe-theme"]
 	path = extensions/furina-vibe-theme
 	url = https://github.com/Hilrein/zed-Furina-vibe-theme.git
@@ -1309,6 +1529,14 @@
 [submodule "extensions/gafelson"]
 	path = extensions/gafelson
 	url = https://github.com/GafelSon/zed-theme.git
+
+[submodule "extensions/gas-plasma-icons"]
+	path = extensions/gas-plasma-icons
+	url = https://github.com/JohnThre/GasPlasma-theme.git
+
+[submodule "extensions/gas-plasma-theme"]
+	path = extensions/gas-plasma-theme
+	url = https://github.com/JohnThre/GasPlasma-theme.git
 
 [submodule "extensions/gatito-theme"]
 	path = extensions/gatito-theme
@@ -1334,17 +1562,21 @@
 	path = extensions/gem
 	url = https://github.com/mantou132/gem
 
-[submodule "extensions/gemini"]
-	path = extensions/gemini
-	url = https://github.com/clseibold/gemini-zed.git
-
 [submodule "extensions/genexpr"]
 	path = extensions/genexpr
 	url = https://github.com/isabelgk/genexpr-zed.git
 
+[submodule "extensions/geno"]
+	path = extensions/geno
+	url = https://github.com/jlyonsmith/zed-geno.git
+
 [submodule "extensions/gentle-dark"]
 	path = extensions/gentle-dark
 	url = https://github.com/gentlelionstudios/gentle-dark-zed.git
+
+[submodule "extensions/geode-theme"]
+	path = extensions/geode-theme
+	url = https://github.com/almeladev/geode-zed.git
 
 [submodule "extensions/ghost-in-the-shell-theme"]
 	path = extensions/ghost-in-the-shell-theme
@@ -1353,6 +1585,10 @@
 [submodule "extensions/ghostty"]
 	path = extensions/ghostty
 	url = https://github.com/Else00/ghostty-zed-extension.git
+
+[submodule "extensions/ghostty-dark-theme"]
+	path = extensions/ghostty-dark-theme
+	url = https://github.com/davideluzi/ghostty-dark-theme.git
 
 [submodule "extensions/git-firefly"]
 	path = extensions/git-firefly
@@ -1414,6 +1650,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/gn"]
+	path = extensions/gn
+	url = https://github.com/dsa28s/zed-gn-language.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets
@@ -1434,6 +1674,10 @@
 	path = extensions/gotmpl
 	url = https://github.com/hjr265/zed-gotmpl.git
 
+[submodule "extensions/grafana-alloy"]
+	path = extensions/grafana-alloy
+	url = https://github.com/lenstr/zed-grafana-alloy.git
+
 [submodule "extensions/graphene"]
 	path = extensions/graphene
 	url = https://github.com/adinack/graphene.git
@@ -1449,6 +1693,10 @@
 [submodule "extensions/green-monochrome-monitor-crt-phosphor"]
 	path = extensions/green-monochrome-monitor-crt-phosphor
 	url = https://github.com/Takk8IS/green-monochrome-monitor-crt-phosphor-theme-for-zed.git
+
+[submodule "extensions/green-theme"]
+	path = extensions/green-theme
+	url = https://github.com/ningfangbin/zed_code_green.git
 
 [submodule "extensions/gren"]
 	path = extensions/gren
@@ -1477,6 +1725,10 @@
 [submodule "extensions/groq"]
 	path = extensions/groq
 	url = https://github.com/juice49/zed-groq
+
+[submodule "extensions/grove-theme"]
+	path = extensions/grove-theme
+	url = https://github.com/HimaAramona/grove-theme.git
 
 [submodule "extensions/gruber-darker"]
 	path = extensions/gruber-darker
@@ -1522,9 +1774,9 @@
 	path = extensions/hacker-night-vision
 	url = https://github.com/Takk8IS/hacker-night-vision-theme-for-zed.git
 
-[submodule "extensions/hacker-theme"]
-	path = extensions/hacker-theme
-	url = https://github.com/0xSandiem/zedhacker.git
+[submodule "extensions/hackthebox-theme"]
+	path = extensions/hackthebox-theme
+	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
 [submodule "extensions/haku-dark-theme"]
 	path = extensions/haku-dark-theme
@@ -1533,6 +1785,10 @@
 [submodule "extensions/halcyon"]
 	path = extensions/halcyon
 	url = https://github.com/hichemfantar/halcyon-zed.git
+
+[submodule "extensions/halloween-night-theme"]
+	path = extensions/halloween-night-theme
+	url = https://github.com/BlueRexPY/HalloweenNightZed.git
 
 [submodule "extensions/hami-melon-theme"]
 	path = extensions/hami-melon-theme
@@ -1562,6 +1818,10 @@
 	path = extensions/hbuilderx-push-light
 	url = https://github.com/yuanzhhh/hbuilderx-theme-zed.git
 
+[submodule "extensions/helios-theme"]
+	path = extensions/helios-theme
+	url = https://github.com/heliosgraphics/helios-theme.git
+
 [submodule "extensions/helm"]
 	path = extensions/helm
 	url = https://github.com/cabrinha/helm.zed.git
@@ -1577,6 +1837,10 @@
 [submodule "extensions/hexpeek"]
 	path = extensions/hexpeek
 	url = https://github.com/A-23187/zed-hexpeek.git
+
+[submodule "extensions/high-contrast-themes"]
+	path = extensions/high-contrast-themes
+	url = https://github.com/rakshit087/high-contrast-zed.git
 
 [submodule "extensions/hilleer-v-theme"]
 	path = extensions/hilleer-v-theme
@@ -1602,6 +1866,10 @@
 	path = extensions/hocon
 	url = https://github.com/tomatitito/hocon-zed-extension.git
 
+[submodule "extensions/hoon"]
+	path = extensions/hoon
+	url = https://github.com/TisaneFruitRouge/hoon-zed.git
+
 [submodule "extensions/horizon"]
 	path = extensions/horizon
 	url = https://github.com/ayn2op/zed-horizon.git
@@ -1609,6 +1877,10 @@
 [submodule "extensions/horizon-extended"]
 	path = extensions/horizon-extended
 	url = https://github.com/lancewilhelm/horizon-extended.zed.git
+
+[submodule "extensions/horizon-theme"]
+	path = extensions/horizon-theme
+	url = https://codeberg.org/ava/horizon-zed.git
 
 [submodule "extensions/hot-dog-stand"]
 	path = extensions/hot-dog-stand
@@ -1629,10 +1901,6 @@
 [submodule "extensions/html-snippets"]
 	path = extensions/html-snippets
 	url = https://github.com/seekode/zed-html-snippets.git
-
-[submodule "extensions/htmx-lsp"]
-	path = extensions/htmx-lsp
-	url = https://github.com/prophittcorey/zed-htmx-lsp.git
 
 [submodule "extensions/http"]
 	path = extensions/http
@@ -1682,6 +1950,18 @@
 	path = extensions/immigrant
 	url = https://github.com/deltarocks/zed-immigrant.git
 
+[submodule "extensions/import-cost-lsp"]
+	path = extensions/import-cost-lsp
+	url = https://github.com/gcampes/zed-import-cost.git
+
+[submodule "extensions/imzed"]
+	path = extensions/imzed
+	url = https://github.com/Infomanta/imzed.git
+
+[submodule "extensions/inbedby7pm-theme"]
+	path = extensions/inbedby7pm-theme
+	url = https://github.com/ChocolateNao/inbedby7pm-zed.git
+
 [submodule "extensions/indigo"]
 	path = extensions/indigo
 	url = https://github.com/p3rception/Indigo-zed.git
@@ -1690,6 +1970,10 @@
 	path = extensions/inform6
 	url = https://github.com/Or4c/zed-inform6.git
 
+[submodule "extensions/infracost-ls"]
+	path = extensions/infracost-ls
+	url = https://github.com/infracost/zed-infracost.git
+
 [submodule "extensions/ini"]
 	path = extensions/ini
 	url = https://github.com/bajrangCoder/zed-ini.git
@@ -1697,6 +1981,10 @@
 [submodule "extensions/ink"]
 	path = extensions/ink
 	url = https://github.com/yuna0x0/zed-ink.git
+
+[submodule "extensions/inko"]
+	path = extensions/inko
+	url = https://github.com/inko-lang/zed.git
 
 [submodule "extensions/intellij-light-theme"]
 	path = extensions/intellij-light-theme
@@ -1710,6 +1998,10 @@
 	path = extensions/intl-lens
 	url = https://github.com/nguyenphutrong/intl-lens.git
 
+[submodule "extensions/inuzdev-coffee-theme"]
+	path = extensions/inuzdev-coffee-theme
+	url = https://github.com/InuzDev/inuzdev-coffee-theme
+
 [submodule "extensions/ion"]
 	path = extensions/ion
 	url = https://github.com/tartarughina/zed-amazon-ion.git
@@ -1717,6 +2009,10 @@
 [submodule "extensions/ir-black"]
 	path = extensions/ir-black
 	url = https://github.com/sametaylak/ir-black-zed-theme
+
+[submodule "extensions/irix-terminal-theme"]
+	path = extensions/irix-terminal-theme
+	url = https://codeberg.org/nwgh/zed-irix-terminal-theme
 
 [submodule "extensions/irodori-theme"]
 	path = extensions/irodori-theme
@@ -1774,6 +2070,14 @@
 	path = extensions/jellybeans-vim
 	url = https://github.com/rajerthat1/jellybeans.zed.git
 
+[submodule "extensions/jemini-theme"]
+	path = extensions/jemini-theme
+	url = https://github.com/iamguba/zed-jemini-theme
+
+[submodule "extensions/jerry"]
+	path = extensions/jerry
+	url = https://github.com/jeffscottbrown/jerry-zed.git
+
 [submodule "extensions/jetbrains-darcula-theme-by-bronya0"]
 	path = extensions/jetbrains-darcula-theme-by-bronya0
 	url = https://github.com/Bronya0/Jetbrains-Darcula-Zed-Theme.git
@@ -1810,6 +2114,10 @@
 	path = extensions/jq
 	url = https://github.com/dangh/zed-jq.git
 
+[submodule "extensions/json-tool-lsp"]
+	path = extensions/json-tool-lsp
+	url = https://github.com/xgfone/zed-json-tool.git
+
 [submodule "extensions/json5"]
 	path = extensions/json5
 	url = https://github.com/ChunzhengLab/json5-zed-extension.git
@@ -1825,6 +2133,10 @@
 [submodule "extensions/jsp"]
 	path = extensions/jsp
 	url = https://github.com/tartarughina/zed-jsp.git
+
+[submodule "extensions/jubby-theme"]
+	path = extensions/jubby-theme
+	url = https://github.com/zeke-john/jubby-theme.git
 
 [submodule "extensions/julia"]
 	path = extensions/julia
@@ -1850,9 +2162,17 @@
 	path = extensions/kanagawa-themes
 	url = https://github.com/ethangilmore/zed-kanagawa.git
 
+[submodule "extensions/kanagawa-wave-blur-theme"]
+	path = extensions/kanagawa-wave-blur-theme
+	url = https://github.com/funsaized/kanagawa-zed-theme.git
+
 [submodule "extensions/kanso"]
 	path = extensions/kanso
 	url = https://github.com/webhooked/kanso-zed.git
+
+[submodule "extensions/karma-theme"]
+	path = extensions/karma-theme
+	url = https://github.com/sreetamdas/karma.git
 
 [submodule "extensions/kcl"]
 	path = extensions/kcl
@@ -1870,9 +2190,17 @@
 	path = extensions/kdl
 	url = https://github.com/elkowar/zed-kdl.git
 
+[submodule "extensions/keep-a-changelog-snippets"]
+	path = extensions/keep-a-changelog-snippets
+	url = https://github.com/ssh-den/zed-keep-a-changelog-snippets.git
+
 [submodule "extensions/keepcalm"]
 	path = extensions/keepcalm
 	url = https://github.com/sgmonda/keepcalm-zed.git
+
+[submodule "extensions/keo-theme"]
+	path = extensions/keo-theme
+	url = https://github.com/keoneSomers/Keo-theme.git
 
 [submodule "extensions/kiro"]
 	path = extensions/kiro
@@ -1881,6 +2209,10 @@
 [submodule "extensions/kiselevka"]
 	path = extensions/kiselevka
 	url = https://github.com/kdubrovsky/kiselevka.git
+
+[submodule "extensions/koda-theme"]
+	path = extensions/koda-theme
+	url = https://github.com/markosnarinian/koda-zed.git
 
 [submodule "extensions/kokedera-icons"]
 	path = extensions/kokedera-icons
@@ -1902,6 +2234,10 @@
 	path = extensions/ktrz-monokai
 	url = https://github.com/pcminh0505/ktrz-monokai-zed-theme.git
 
+[submodule "extensions/kubernetes-snippets"]
+	path = extensions/kubernetes-snippets
+	url = https://github.com/zed-kubernetes/kubernetes-snippets
+
 [submodule "extensions/kubesong"]
 	path = extensions/kubesong
 	url = https://github.com/helgelol/kubesong-zed-theme.git
@@ -1914,6 +2250,10 @@
 	path = extensions/kvs-cyberpunk-2077
 	url = https://github.com/notKvS/2077-zed.git
 
+[submodule "extensions/laravel"]
+	path = extensions/laravel
+	url = https://github.com/mike-bronner/zed-laravel.git
+
 [submodule "extensions/latex"]
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git
@@ -1921,6 +2261,10 @@
 [submodule "extensions/latte"]
 	path = extensions/latte
 	url = https://github.com/josbeir/zed-latte.git
+
+[submodule "extensions/lazyvim-theme"]
+	path = extensions/lazyvim-theme
+	url = https://github.com/BadRat-in/zed-lazyvim-theme.git
 
 [submodule "extensions/lean4"]
 	path = extensions/lean4
@@ -1950,6 +2294,10 @@
 	path = extensions/lights-out
 	url = https://github.com/Ajiva-D/lights-out-theme-zed.git
 
+[submodule "extensions/likec4"]
+	path = extensions/likec4
+	url = https://github.com/Lenivvenil/zed-likec4.git
+
 [submodule "extensions/lilypond"]
 	path = extensions/lilypond
 	url = https://github.com/nwhetsell/lilypond-zed-extension
@@ -1969,6 +2317,14 @@
 [submodule "extensions/liquidsoap"]
 	path = extensions/liquidsoap
 	url = https://github.com/LooFifteen/liquidsoap-zed.git
+
+[submodule "extensions/lisette"]
+	path = extensions/lisette
+	url = https://github.com/ivov/lisette.git
+
+[submodule "extensions/little-league-theme"]
+	path = extensions/little-league-theme
+	url = https://github.com/ilikescience/little-league.git
 
 [submodule "extensions/live-server"]
 	path = extensions/live-server
@@ -1993,6 +2349,10 @@
 [submodule "extensions/logstash"]
 	path = extensions/logstash
 	url = https://github.com/StrongTheDev/logstash-for-zed
+
+[submodule "extensions/loi-paper-theme"]
+	path = extensions/loi-paper-theme
+	url = https://github.com/aliaksei-loi/zed-loi-paper-theme.git
 
 [submodule "extensions/lonely-planet"]
 	path = extensions/lonely-planet
@@ -2022,6 +2382,10 @@
 	path = extensions/luau
 	url = https://github.com/4teapo/zed-luau
 
+[submodule "extensions/lume-theme"]
+	path = extensions/lume-theme
+	url = https://github.com/danfry1/lume-zed-theme.git
+
 [submodule "extensions/lumina-theme"]
 	path = extensions/lumina-theme
 	url = https://github.com/alexjthomson/lumina-theme-zed
@@ -2042,9 +2406,25 @@
 	path = extensions/macos-classic
 	url = https://github.com/huacnlee/zed-theme-macos-classic.git
 
+[submodule "extensions/magento2-snippets"]
+	path = extensions/magento2-snippets
+	url = https://github.com/mage-os-lab/zed-magento2-snippets
+
+[submodule "extensions/maho-lsp"]
+	path = extensions/maho-lsp
+	url = https://github.com/MahoCommerce/zed.git
+
+[submodule "extensions/mainframe-theme"]
+	path = extensions/mainframe-theme
+	url = https://github.com/jmg-duarte/mainframe-zed.git
+
 [submodule "extensions/make"]
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
+
+[submodule "extensions/mako"]
+	path = extensions/mako
+	url = https://github.com/ron0studios/mako-zed.git
 
 [submodule "extensions/malibu"]
 	path = extensions/malibu
@@ -2142,6 +2522,10 @@
 	path = extensions/maybe-material
 	url = https://github.com/iamawatermelo/maybe-material
 
+[submodule "extensions/mc-dp-icons-theme"]
+	path = extensions/mc-dp-icons-theme
+	url = https://github.com/funcfusion/mc-dp-icons-zed.git
+
 [submodule "extensions/mcfunction"]
 	path = extensions/mcfunction
 	url = https://github.com/bcheidemann/zed-mcfunction.git
@@ -2173,10 +2557,6 @@
 [submodule "extensions/mcp-server-buildkite"]
 	path = extensions/mcp-server-buildkite
 	url = https://github.com/mcncl/zed-mcp-server-buildkite
-
-[submodule "extensions/mcp-server-byterover"]
-	path = extensions/mcp-server-byterover
-	url = https://github.com/campfirein/byterover-zed-extension.git
 
 [submodule "extensions/mcp-server-code-runner"]
 	path = extensions/mcp-server-code-runner
@@ -2214,6 +2594,10 @@
 	path = extensions/mcp-server-gitlab
 	url = https://github.com/akbxr/gitlab-mcp-zed
 
+[submodule "extensions/mcp-server-godot"]
+	path = extensions/mcp-server-godot
+	url = https://github.com/maccesch/zed-extension-mcp-server-godot.git
+
 [submodule "extensions/mcp-server-grafana"]
 	path = extensions/mcp-server-grafana
 	url = https://github.com/sd2k/zed-mcp-grafana.git
@@ -2225,6 +2609,10 @@
 [submodule "extensions/mcp-server-master-go"]
 	path = extensions/mcp-server-master-go
 	url = https://github.com/aizigao/zed-mcp-server-master-go.git
+
+[submodule "extensions/mcp-server-memory"]
+	path = extensions/mcp-server-memory
+	url = https://github.com/robin-afro/zed-mcp-memory
 
 [submodule "extensions/mcp-server-miaoduo"]
 	path = extensions/mcp-server-miaoduo
@@ -2306,13 +2694,17 @@
 	path = extensions/mcp-server-threadbridge
 	url = https://github.com/dereklei12/zed-mcp-server-threadbridge.git
 
-[submodule "extensions/mcp-server-weave"]
-	path = extensions/mcp-server-weave
-	url = https://github.com/Ataraxy-Labs/weave-zed.git
-
 [submodule "extensions/mcp-server-webflow"]
 	path = extensions/mcp-server-webflow
 	url = https://github.com/LoamStudios/zed-mcp-server-webflow.git
+
+[submodule "extensions/mcp-server-zuraffa"]
+	path = extensions/mcp-server-zuraffa
+	url = https://github.com/arrrrny/zuraffa-zed.git
+
+[submodule "extensions/mdias-oled-theme"]
+	path = extensions/mdias-oled-theme
+	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git
 
 [submodule "extensions/mdx"]
 	path = extensions/mdx
@@ -2362,6 +2754,14 @@
 	path = extensions/mint-theme
 	url = https://github.com/Ivanopulo124/zed-theme-mint.git
 
+[submodule "extensions/miramare-theme"]
+	path = extensions/miramare-theme
+	url = https://github.com/franbach/miramare-zed.git
+
+[submodule "extensions/mire-theme"]
+	path = extensions/mire-theme
+	url = https://github.com/monarcode/mire-theme-zed
+
 [submodule "extensions/missing-theme"]
 	path = extensions/missing-theme
 	url = https://codeberg.org/dz4k/zed-missing.git
@@ -2369,6 +2769,14 @@
 [submodule "extensions/mistral-vibe"]
 	path = extensions/mistral-vibe
 	url = https://github.com/mistralai/mistral-vibe.git
+
+[submodule "extensions/mjml"]
+	path = extensions/mjml
+	url = https://github.com/pataruco/zed-mjml.git
+
+[submodule "extensions/mlir-tablegen"]
+	path = extensions/mlir-tablegen
+	url = https://github.com/feichai0017/mlir-zed.git
 
 [submodule "extensions/mnemonic"]
 	path = extensions/mnemonic
@@ -2394,13 +2802,13 @@
 	path = extensions/molten-theme
 	url = https://github.com/vaqxai/zed-molten-theme.git
 
+[submodule "extensions/monochromator-theme"]
+	path = extensions/monochromator-theme
+	url = https://codeberg.org/beem/monochromator.git
+
 [submodule "extensions/monokai-nebula"]
 	path = extensions/monokai-nebula
 	url = https://github.com/JacobCallahan/monokai-nebula-zed.git
-
-[submodule "extensions/monokai-night"]
-	path = extensions/monokai-night
-	url = https://github.com/farbodvand/zed-monokai-night.git
 
 [submodule "extensions/monokai-og"]
 	path = extensions/monokai-og
@@ -2421,6 +2829,10 @@
 [submodule "extensions/monokai-vibrant-amped"]
 	path = extensions/monokai-vibrant-amped
 	url = https://github.com/Ceebox/zed-monokai-vibrant-amped.git
+
+[submodule "extensions/monokuro-theme"]
+	path = extensions/monokuro-theme
+	url = https://github.com/KawaneNamito/zed-monokuro-theme.git
 
 [submodule "extensions/monolith"]
 	path = extensions/monolith
@@ -2566,6 +2978,10 @@
 	path = extensions/night-shift
 	url = https://github.com/Jean-Tinland/zed-theme-night-shift.git
 
+[submodule "extensions/nightfall-theme"]
+	path = extensions/nightfall-theme
+	url = https://github.com/andrewzhuk/nightfall-theme.git
+
 [submodule "extensions/nightfox"]
 	path = extensions/nightfox
 	url = https://github.com/ssaunderss/zed-nightfox.git
@@ -2584,7 +3000,7 @@
 
 [submodule "extensions/ninja"]
 	path = extensions/ninja
-	url = https://github.com/c0mpiler/ninja.theme.git
+	url = https://github.com/c0mpiler/theme.ninja.git
 
 [submodule "extensions/niva"]
 	path = extensions/niva
@@ -2650,6 +3066,10 @@
 	path = extensions/not-too-shabby
 	url = https://github.com/staleo/zed-nottooshabby-theme.git
 
+[submodule "extensions/noted-theme"]
+	path = extensions/noted-theme
+	url = https://github.com/sergeevalera/noted-theme.git
+
 [submodule "extensions/nova-theme"]
 	path = extensions/nova-theme
 	url = https://github.com/overstarry/zed-nova.git
@@ -2657,6 +3077,10 @@
 [submodule "extensions/npm-package-json-checker"]
 	path = extensions/npm-package-json-checker
 	url = https://github.com/e-simpson/zed-npm-update-checker.git
+
+[submodule "extensions/nsis"]
+	path = extensions/nsis
+	url = https://github.com/idleberg/zed-nsis-extension.git
 
 [submodule "extensions/nstlgy-dark"]
 	path = extensions/nstlgy-dark
@@ -2698,6 +3122,10 @@
 	path = extensions/oat
 	url = https://github.com/WhySoBad/zed-oat-extension.git
 
+[submodule "extensions/oberon"]
+	path = extensions/oberon
+	url = https://github.com/KnyazLV/zed-oberon.git
+
 [submodule "extensions/objective-c"]
 	path = extensions/objective-c
 	url = https://github.com/Akzestia/objcpp.git
@@ -2709,6 +3137,10 @@
 [submodule "extensions/obsidian-sunset"]
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git
+
+[submodule "extensions/oc-2-theme"]
+	path = extensions/oc-2-theme
+	url = https://github.com/nstlgy/oc-2-theme
 
 [submodule "extensions/ocaml"]
 	path = extensions/ocaml
@@ -2725,6 +3157,10 @@
 [submodule "extensions/oceanic-next"]
 	path = extensions/oceanic-next
 	url = https://github.com/rkunev/oceanic-next.git
+
+[submodule "extensions/oceans-of-andromeda-theme"]
+	path = extensions/oceans-of-andromeda-theme
+	url = https://github.com/jdonlucas/zed-oceans-of-andromeda
 
 [submodule "extensions/odin"]
 	path = extensions/odin
@@ -2814,17 +3250,17 @@
 	path = extensions/openfga
 	url = https://github.com/rosnovsky/zed-extension-fga.git
 
-[submodule "extensions/openmoji-icons"]
-	path = extensions/openmoji-icons
-	url = https://github.com/cotyhamilton/zed-emoji-icon-theme.git
-
 [submodule "extensions/openscad"]
 	path = extensions/openscad
 	url = https://github.com/dotcypress/zed-openscad.git
 
 [submodule "extensions/opentofu"]
 	path = extensions/opentofu
-	url = https://github.com/ashpool37/zed-extension-opentofu
+	url = https://github.com/tzabbi/zed-opentofu.git
+
+[submodule "extensions/opentype-feature"]
+	path = extensions/opentype-feature
+	url = https://github.com/mishamyrt/zed-opentype-feature
 
 [submodule "extensions/optima-theme"]
 	path = extensions/optima-theme
@@ -2838,6 +3274,10 @@
 	path = extensions/orng
 	url = https://github.com/elithrar/orng-zed.git
 
+[submodule "extensions/osaka-jade-theme"]
+	path = extensions/osaka-jade-theme
+	url = https://github.com/ruslan-kurchenko/osaka-jade-zed-theme.git
+
 [submodule "extensions/oscura"]
 	path = extensions/oscura
 	url = https://github.com/webhooked/oscura-zed.git
@@ -2849,6 +3289,10 @@
 [submodule "extensions/outrun"]
 	path = extensions/outrun
 	url = https://github.com/Acepie/OutrunZedTheme.git
+
+[submodule "extensions/outrun-vscode-theme"]
+	path = extensions/outrun-vscode-theme
+	url = https://github.com/exkungen/outrun-vscode-zed.git
 
 [submodule "extensions/oxc"]
 	path = extensions/oxc
@@ -2865,6 +3309,10 @@
 [submodule "extensions/pace-pro-theme"]
 	path = extensions/pace-pro-theme
 	url = https://github.com/VMachihin/pace-theme-pro.git
+
+[submodule "extensions/package-json-upgrade-lsp"]
+	path = extensions/package-json-upgrade-lsp
+	url = https://github.com/Arthurmtro/zed-package-json-upgrade.git
 
 [submodule "extensions/package-swift-lsp"]
 	path = extensions/package-swift-lsp
@@ -2906,6 +3354,10 @@
 	path = extensions/path-of-exile
 	url = https://github.com/egibs/poe.zed.git
 
+[submodule "extensions/path-server-lsp"]
+	path = extensions/path-server-lsp
+	url = https://github.com/kunlinglio/path-server.git
+
 [submodule "extensions/pathy"]
 	path = extensions/pathy
 	url = https://github.com/gokulp01/pathy.git
@@ -2918,6 +3370,10 @@
 	path = extensions/pearish-theme
 	url = https://github.com/dvhthomas/pearish-theme.git
 
+[submodule "extensions/pelpsi-night-theme"]
+	path = extensions/pelpsi-night-theme
+	url = https://github.com/simonepelosi/pelpsi-night.git
+
 [submodule "extensions/penumbra"]
 	path = extensions/penumbra
 	url = https://github.com/jbisits/penumbra-zed.git
@@ -2925,6 +3381,10 @@
 [submodule "extensions/penumbra-plus"]
 	path = extensions/penumbra-plus
 	url = https://github.com/everdrone/zed-penumbra-plus.git
+
+[submodule "extensions/peppermint-theme"]
+	path = extensions/peppermint-theme
+	url = https://github.com/sttefaano/peppermint-zed.git
 
 [submodule "extensions/perfect-dusk"]
 	path = extensions/perfect-dusk
@@ -2958,6 +3418,10 @@
 	path = extensions/phosphor-icons-theme
 	url = https://github.com/theoluciano/phosphor-icons-theme.git
 
+[submodule "extensions/phosphor-theme"]
+	path = extensions/phosphor-theme
+	url = https://github.com/Codenii/phosphor-zed
+
 [submodule "extensions/php"]
 	path = extensions/php
 	url = https://github.com/zed-extensions/php.git
@@ -2968,11 +3432,15 @@
 
 [submodule "extensions/phpcs"]
 	path = extensions/phpcs
-	url = https://github.com/GeneaLabs/zed-phpcs-lsp.git
+	url = https://github.com/mike-bronner/zed-phpcs-lsp.git
+
+[submodule "extensions/phpmago-lsp"]
+	path = extensions/phpmago-lsp
+	url = https://github.com/LirimSakura/zed-php-mago.git
 
 [submodule "extensions/phpmd"]
 	path = extensions/phpmd
-	url = https://github.com/GeneaLabs/zed-phpmd-lsp.git
+	url = https://github.com/mike-bronner/zed-phpmd-lsp.git
 
 [submodule "extensions/pica200"]
 	path = extensions/pica200
@@ -2990,9 +3458,21 @@
 	path = extensions/pinata-theme
 	url = https://github.com/stevedylandev/pinata-theme-zed
 
+[submodule "extensions/pink-candy-theme"]
+	path = extensions/pink-candy-theme
+	url = https://github.com/paulovictor237/pink-candy-theme.git
+
 [submodule "extensions/pink-cat-boo-theme"]
 	path = extensions/pink-cat-boo-theme
 	url = https://github.com/jjsalinas/PinkCatBooZed.git
+
+[submodule "extensions/pinkzuna-theme"]
+	path = extensions/pinkzuna-theme
+	url = https://github.com/memiux/pinkzuna-zed.git
+
+[submodule "extensions/pioasm"]
+	path = extensions/pioasm
+	url = https://github.com/GGORG0/zed-pioasm-syntax.git
 
 [submodule "extensions/pkl"]
 	path = extensions/pkl
@@ -3030,6 +3510,10 @@
 	path = extensions/poimandres
 	url = https://github.com/mshaugh/poimandres.zed.git
 
+[submodule "extensions/pointer-theme"]
+	path = extensions/pointer-theme
+	url = https://github.com/nezdemkovski/pointer-theme-for-zed.git
+
 [submodule "extensions/polar-context-server"]
 	path = extensions/polar-context-server
 	url = https://github.com/polarsource/zed-polar-context-server.git
@@ -3041,6 +3525,10 @@
 [submodule "extensions/pollinations-mcp"]
 	path = extensions/pollinations-mcp
 	url = https://github.com/FrancoStino/pollinations-mcp.git
+
+[submodule "extensions/polycarbonate-dark-theme"]
+	path = extensions/polycarbonate-dark-theme
+	url = https://github.com/Sha1rholder/polycarbonate-dark-theme.git
 
 [submodule "extensions/pony"]
 	path = extensions/pony
@@ -3057,6 +3545,10 @@
 [submodule "extensions/postgres-language-server"]
 	path = extensions/postgres-language-server
 	url = https://github.com/LoamStudios/zed-postgres-language-server.git
+
+[submodule "extensions/postman-context-server"]
+	path = extensions/postman-context-server
+	url = https://github.com/postmanlabs/postman-mcp-zed-extension
 
 [submodule "extensions/powershell"]
 	path = extensions/powershell
@@ -3106,13 +3598,13 @@
 	path = extensions/purescript
 	url = https://github.com/zed-extensions/purescript.git
 
-[submodule "extensions/purr"]
-	path = extensions/purr
-	url = https://github.com/nemanjastanic/zed-purr.git
-
 [submodule "extensions/px-to-rem"]
 	path = extensions/px-to-rem
 	url = https://github.com/ugi-dev/px-to-rem
+
+[submodule "extensions/pyatlas-lsp"]
+	path = extensions/pyatlas-lsp
+	url = https://github.com/Akamine2001/zed-pyatlas.git
 
 [submodule "extensions/pycharm-modern-themes"]
 	path = extensions/pycharm-modern-themes
@@ -3129,6 +3621,10 @@
 [submodule "extensions/pytest-language-server"]
 	path = extensions/pytest-language-server
 	url = https://github.com/bellini666/pytest-language-server.git
+
+[submodule "extensions/python-autodoc-lsp"]
+	path = extensions/python-autodoc-lsp
+	url = https://github.com/eallender/zed-python-autodoc.git
 
 [submodule "extensions/python-refactoring"]
 	path = extensions/python-refactoring
@@ -3210,9 +3706,17 @@
 	path = extensions/rapture-theme
 	url = https://github.com/gabors0/rapture-zed.git
 
+[submodule "extensions/rasi"]
+	path = extensions/rasi
+	url = https://github.com/mikaeladev/zed-rasi.git
+
 [submodule "extensions/rcl"]
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
+
+[submodule "extensions/react-component-lens-lsp"]
+	path = extensions/react-component-lens-lsp
+	url = https://github.com/dev-five-git/react-component-lens.git
 
 [submodule "extensions/react-snippets"]
 	path = extensions/react-snippets
@@ -3250,9 +3754,21 @@
 	path = extensions/rego
 	url = https://github.com/StyraInc/zed-rego.git
 
+[submodule "extensions/relaxed-theme"]
+	path = extensions/relaxed-theme
+	url = https://github.com/stefanbc/relaxed-zed-theme
+
 [submodule "extensions/relay"]
 	path = extensions/relay
 	url = https://github.com/XiNiHa/relay-zed
+
+[submodule "extensions/remedy-theme"]
+	path = extensions/remedy-theme
+	url = https://github.com/andrewRCr/zed-remedy-theme.git
+
+[submodule "extensions/remix-min-darker-theme"]
+	path = extensions/remix-min-darker-theme
+	url = https://github.com/FernaandoJr/remix-min-darker-zed.git
 
 [submodule "extensions/replicant"]
 	path = extensions/replicant
@@ -3262,9 +3778,17 @@
 	path = extensions/rescript
 	url = https://github.com/rescript-lang/rescript-zed.git
 
+[submodule "extensions/resonance-with-hatsune-miku-theme"]
+	path = extensions/resonance-with-hatsune-miku-theme
+	url = https://github.com/yuzukq/zed-theme-Resonance-with-HatsuneMiku.git
+
 [submodule "extensions/retrofit-theme"]
 	path = extensions/retrofit-theme
 	url = https://github.com/snapsnapturtle/retrofit-zed.git
+
+[submodule "extensions/retropc-theme"]
+	path = extensions/retropc-theme
+	url = https://github.com/abhishek-bhatkar/retroPC-zed-theme.git
 
 [submodule "extensions/rewrite-theme"]
 	path = extensions/rewrite-theme
@@ -3286,6 +3810,10 @@
 	path = extensions/riverpod-dart-flutter-snippets
 	url = https://github.com/OppositeDragon/riverpod-snippets
 
+[submodule "extensions/rlsp-yaml"]
+	path = extensions/rlsp-yaml
+	url = https://github.com/chdalski/rlsp
+
 [submodule "extensions/robot-framework"]
 	path = extensions/robot-framework
 	url = https://github.com/mendes-jose/zed-robot.git
@@ -3294,9 +3822,17 @@
 	path = extensions/roc
 	url = https://github.com/h2000/zed-roc.git
 
+[submodule "extensions/rockide-language-server"]
+	path = extensions/rockide-language-server
+	url = https://github.com/rockide/rockide-zed.git
+
 [submodule "extensions/ron"]
 	path = extensions/ron
 	url = https://github.com/onbjerg/zed-ron.git
+
+[submodule "extensions/rose-pine-recast-theme"]
+	path = extensions/rose-pine-recast-theme
+	url = https://github.com/ng-hai/zed-rose-pine-recast.git
 
 [submodule "extensions/rose-pine-theme"]
 	path = extensions/rose-pine-theme
@@ -3306,6 +3842,10 @@
 	path = extensions/rosevin
 	url = https://github.com/anson-ryea/rosevin-zed.git
 
+[submodule "extensions/rosewood-theme"]
+	path = extensions/rosewood-theme
+	url = https://github.com/ayush-porwal/zed-rosewood-theme.git
+
 [submodule "extensions/roto"]
 	path = extensions/roto
 	url = https://github.com/tertsdiepraam/zed-extension-roto.git
@@ -3313,6 +3853,10 @@
 [submodule "extensions/rover"]
 	path = extensions/rover
 	url = https://github.com/rover-app/zed-extension.git
+
+[submodule "extensions/rovo-lsp"]
+	path = extensions/rovo-lsp
+	url = https://github.com/Arthurdw/rovo.git
 
 [submodule "extensions/rpmspec"]
 	path = extensions/rpmspec
@@ -3354,6 +3898,10 @@
 	path = extensions/sagemath
 	url = https://github.com/rot256/zed-sagemath
 
+[submodule "extensions/salesforce"]
+	path = extensions/salesforce
+	url = https://github.com/Damecek/zed-salesforce-extension.git
+
 [submodule "extensions/scala"]
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git
@@ -3370,9 +3918,17 @@
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git
 
+[submodule "extensions/selene-abyss-theme"]
+	path = extensions/selene-abyss-theme
+	url = https://github.com/envoidia/zed-selene-abyss.git
+
 [submodule "extensions/semgrep"]
 	path = extensions/semgrep
 	url = https://github.com/zeelsheladiya/zed-semgrep.git
+
+[submodule "extensions/senkai-theme"]
+	path = extensions/senkai-theme
+	url = https://github.com/platformer/zed-senkai.git
 
 [submodule "extensions/sentry-mcp"]
 	path = extensions/sentry-mcp
@@ -3402,6 +3958,10 @@
 	path = extensions/serendipity-icons
 	url = https://github.com/meocoder31099/Serendipity-Icon-Theme-Zed.git
 
+[submodule "extensions/sergio-tech-code-black-theme"]
+	path = extensions/sergio-tech-code-black-theme
+	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git
+
 [submodule "extensions/seti-icons"]
 	path = extensions/seti-icons
 	url = https://github.com/d1y/zed-seti-icons.git
@@ -3422,6 +3982,10 @@
 	path = extensions/shades-of-purple-theme
 	url = https://github.com/irmhonde/shades-of-purple-theme.git
 
+[submodule "extensions/shale-theme"]
+	path = extensions/shale-theme
+	url = https://github.com/smit4k/zed-shale.git
+
 [submodule "extensions/shapels"]
 	path = extensions/shapels
 	url = https://github.com/carrascomj/shapels-zed.git
@@ -3440,11 +4004,15 @@
 
 [submodule "extensions/short-giraffe-theme"]
 	path = extensions/short-giraffe-theme
-	url = https://github.com/Mehdi-Hp/Short-Giraffe.git
+	url = https://github.com/kumamaki/Short-Giraffe.git
 
 [submodule "extensions/sieve"]
 	path = extensions/sieve
 	url = https://github.com/aRustyDev/zed-sieve.git
+
+[submodule "extensions/silverstripe"]
+	path = extensions/silverstripe
+	url = https://github.com/nicolas-cusan/zed-silverstripe.git
 
 [submodule "extensions/simple-darker"]
 	path = extensions/simple-darker
@@ -3481,6 +4049,10 @@
 [submodule "extensions/slint"]
 	path = extensions/slint
 	url = https://github.com/slint-ui/slint.git
+
+[submodule "extensions/slipstream-theme"]
+	path = extensions/slipstream-theme
+	url = https://github.com/kylemcd/zed-slipstream.git
 
 [submodule "extensions/smalisp"]
 	path = extensions/smalisp
@@ -3534,6 +4106,10 @@
 	path = extensions/solarized-fp
 	url = https://github.com/lohazo/zed-solarized-fp.git
 
+[submodule "extensions/solarized-osaka-theme"]
+	path = extensions/solarized-osaka-theme
+	url = https://github.com/clouby/solarized-osaka-zed.git
+
 [submodule "extensions/solid-typescript-snippets"]
 	path = extensions/solid-typescript-snippets
 	url = https://github.com/HarryYu02/zed-solid-ts-snippets.git
@@ -3553,6 +4129,10 @@
 [submodule "extensions/sonokai"]
 	path = extensions/sonokai
 	url = https://github.com/ciathefed/zed-sonokai.git
+
+[submodule "extensions/sora-theme"]
+	path = extensions/sora-theme
+	url = https://github.com/Aejkatappaja/sora-theme
 
 [submodule "extensions/sorbet"]
 	path = extensions/sorbet
@@ -3589,10 +4169,6 @@
 [submodule "extensions/sqlmesh"]
 	path = extensions/sqlmesh
 	url = https://github.com/GitToby/zed-sqlmesh.git
-
-[submodule "extensions/sqruff"]
-	path = extensions/sqruff
-	url = https://github.com/gvozdvmozgu/sqruff-zed.git
 
 [submodule "extensions/squirrel"]
 	path = extensions/squirrel
@@ -3658,6 +4234,10 @@
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
 
+[submodule "extensions/sunrise-bloom-theme"]
+	path = extensions/sunrise-bloom-theme
+	url = https://github.com/tejasashinde/sunrise-bloom-theme.git
+
 [submodule "extensions/sunset-drive"]
 	path = extensions/sunset-drive
 	url = https://github.com/tahayvr/sunset-drive-zed
@@ -3682,6 +4262,10 @@
 	path = extensions/supertheme4
 	url = https://github.com/superkacper4/supertheme4
 
+[submodule "extensions/surpassone-theme"]
+	path = extensions/surpassone-theme
+	url = https://github.com/aitit-inc/zed-surpassone-theme.git
+
 [submodule "extensions/surrealql"]
 	path = extensions/surrealql
 	url = https://github.com/siteforge-io/surql-zed
@@ -3693,6 +4277,10 @@
 [submodule "extensions/svelte"]
 	path = extensions/svelte
 	url = https://github.com/zed-extensions/svelte.git
+
+[submodule "extensions/svelte-effect-runtime-language-server"]
+	path = extensions/svelte-effect-runtime-language-server
+	url = https://github.com/usebarekey/svelte-effect-runtime.git
 
 [submodule "extensions/svelte-mcp"]
 	path = extensions/svelte-mcp
@@ -3721,6 +4309,10 @@
 [submodule "extensions/symposium"]
 	path = extensions/symposium
 	url = https://github.com/symposium-dev/symposium.git
+
+[submodule "extensions/syntaqlite-lsp"]
+	path = extensions/syntaqlite-lsp
+	url = https://github.com/LalitMaganti/syntaqlite.git
 
 [submodule "extensions/syntax"]
 	path = extensions/syntax
@@ -3769,6 +4361,10 @@
 [submodule "extensions/taskfile"]
 	path = extensions/taskfile
 	url = https://github.com/nickalie/zed-taskfile.git
+
+[submodule "extensions/tbilisi-night"]
+	path = extensions/tbilisi-night
+	url = https://github.com/IosebKoplatadze/tbilisi-night-zed.git
 
 [submodule "extensions/tcl"]
 	path = extensions/tcl
@@ -3862,6 +4458,10 @@
 	path = extensions/tmux
 	url = https://github.com/dangh/zed-tmux.git
 
+[submodule "extensions/todo-highlight-language-server"]
+	path = extensions/todo-highlight-language-server
+	url = https://github.com/shionit/zed-todo-highlight.git
+
 [submodule "extensions/todotxt"]
 	path = extensions/todotxt
 	url = https://github.com/pursvir/zed-todotxt.git
@@ -3877,6 +4477,10 @@
 [submodule "extensions/tokyo-night-dark"]
 	path = extensions/tokyo-night-dark
 	url = https://github.com/pyncz/zed-tokyo-night-dark-theme.git
+
+[submodule "extensions/tokyoppuccin-theme"]
+	path = extensions/tokyoppuccin-theme
+	url = https://github.com/EmmanuelVernet/zed-tokyoppuccin.git
 
 [submodule "extensions/tombi"]
 	path = extensions/tombi
@@ -3902,6 +4506,10 @@
 	path = extensions/ton
 	url = https://github.com/Bionic2113/ton-zed.git
 
+[submodule "extensions/tonel-smalltalk"]
+	path = extensions/tonel-smalltalk
+	url = https://github.com/mumez/zed-extension-tonel-smalltalk.git
+
 [submodule "extensions/toon"]
 	path = extensions/toon
 	url = https://github.com/3swordman/zed-toon.git
@@ -3913,6 +4521,10 @@
 [submodule "extensions/tree-sitter-query"]
 	path = extensions/tree-sitter-query
 	url = https://github.com/vitallium/zed-tree-sitter-query.git
+
+[submodule "extensions/triumph-theme"]
+	path = extensions/triumph-theme
+	url = https://github.com/Bushenzie/triumph.git
 
 [submodule "extensions/tron-legacy"]
 	path = extensions/tron-legacy
@@ -3990,6 +4602,14 @@
 	path = extensions/ultralytics-snippets
 	url = https://github.com/ayberkgezer/ultralytics-zed-snippets
 
+[submodule "extensions/ultraviolet-theme"]
+	path = extensions/ultraviolet-theme
+	url = https://github.com/Gurvirr/zed-ultraViolet.git
+
+[submodule "extensions/umbra-theme"]
+	path = extensions/umbra-theme
+	url = https://github.com/zaitsev-av/umbra
+
 [submodule "extensions/umbralkai"]
 	path = extensions/umbralkai
 	url = https://github.com/platformer/zed-umbralkai
@@ -3997,6 +4617,10 @@
 [submodule "extensions/umka"]
 	path = extensions/umka
 	url = https://github.com/michabay05/zed-umka.git
+
+[submodule "extensions/umple"]
+	path = extensions/umple
+	url = https://github.com/umple/umple.zed.git
 
 [submodule "extensions/underground-theme"]
 	path = extensions/underground-theme
@@ -4029,6 +4653,10 @@
 [submodule "extensions/unoflat"]
 	path = extensions/unoflat
 	url = https://github.com/bryanbuchanan/unoflat
+
+[submodule "extensions/urdf"]
+	path = extensions/urdf
+	url = https://github.com/MorningFrog/zed-urdf.git
 
 [submodule "extensions/usd"]
 	path = extensions/usd
@@ -4070,6 +4698,10 @@
 	path = extensions/valt
 	url = https://github.com/valtism/valt.git
 
+[submodule "extensions/vanta-theme"]
+	path = extensions/vanta-theme
+	url = https://codeberg.org/bogusz/vanta.git
+
 [submodule "extensions/vapor-theme"]
 	path = extensions/vapor-theme
 	url = https://github.com/felipetesc/vapor-theme.git
@@ -4077,6 +4709,10 @@
 [submodule "extensions/vcard"]
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git
+
+[submodule "extensions/veda-pro-theme"]
+	path = extensions/veda-pro-theme
+	url = https://github.com/xqsit94/veda-pro-zed.git
 
 [submodule "extensions/vento"]
 	path = extensions/vento
@@ -4094,6 +4730,10 @@
 	path = extensions/verilog
 	url = https://github.com/someone13574/zed-verilog-extension.git
 
+[submodule "extensions/version14-theme"]
+	path = extensions/version14-theme
+	url = https://github.com/version14/zed-theme.git
+
 [submodule "extensions/veryl"]
 	path = extensions/veryl
 	url = https://github.com/veryl-lang/veryl.git
@@ -4105,6 +4745,10 @@
 [submodule "extensions/vesper-blur"]
 	path = extensions/vesper-blur
 	url = https://github.com/taras-tereschenko/vesper-blur.git
+
+[submodule "extensions/vespertine-theme"]
+	path = extensions/vespertine-theme
+	url = https://github.com/filipeveronezi/vespertine.git
 
 [submodule "extensions/vhdl"]
 	path = extensions/vhdl
@@ -4154,6 +4798,10 @@
 	path = extensions/vitest-snippets
 	url = https://github.com/jwerre/vitest-snippets
 
+[submodule "extensions/vivid-void-theme"]
+	path = extensions/vivid-void-theme
+	url = https://github.com/fn-jakubkarp/zed-vivid-void-theme.git
+
 [submodule "extensions/vrl"]
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
@@ -4177,6 +4825,10 @@
 [submodule "extensions/vscode-dark-polished"]
 	path = extensions/vscode-dark-polished
 	url = https://github.com/yayashn/vscode-dark-polished.git
+
+[submodule "extensions/vscode-dark-siri-custom"]
+	path = extensions/vscode-dark-siri-custom
+	url = https://github.com/rschili/zed-theme-vscode-dark-siri-custom.git
 
 [submodule "extensions/vscode-great-icons"]
 	path = extensions/vscode-great-icons
@@ -4258,6 +4910,10 @@
 	path = extensions/webidl
 	url = https://github.com/padenot/zed-webidl.git
 
+[submodule "extensions/webstorm-darker-theme"]
+	path = extensions/webstorm-darker-theme
+	url = https://github.com/jxshwa/webstorm-darker-theme.git
+
 [submodule "extensions/wgsl"]
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl.git
@@ -4282,6 +4938,10 @@
 	path = extensions/witchesbrew-theme
 	url = https://github.com/shoenot/witchesbrew.zed
 
+[submodule "extensions/woocommerce-snippets"]
+	path = extensions/woocommerce-snippets
+	url = https://github.com/renzojohnson/woocommerce-snippets.git
+
 [submodule "extensions/wow-toc"]
 	path = extensions/wow-toc
 	url = https://github.com/Alexayy/zed-wow-toc.git
@@ -4289,10 +4949,6 @@
 [submodule "extensions/wren"]
 	path = extensions/wren
 	url = https://github.com/hgmich/zed-wren.git
-
-[submodule "extensions/wren-lsp"]
-	path = extensions/wren-lsp
-	url = https://github.com/jossephus/wren-lsp
 
 [submodule "extensions/wxml"]
 	path = extensions/wxml
@@ -4313,10 +4969,6 @@
 [submodule "extensions/xml"]
 	path = extensions/xml
 	url = https://github.com/sweetppro/zed-xml.git
-
-[submodule "extensions/xonsh"]
-	path = extensions/xonsh
-	url = https://github.com/oscarvarto/zed-xonsh.git
 
 [submodule "extensions/xy-zed"]
 	path = extensions/xy-zed
@@ -4361,6 +5013,10 @@
 [submodule "extensions/yugen"]
 	path = extensions/yugen
 	url = https://github.com/frank-vdm/yugen
+
+[submodule "extensions/yulang"]
+	path = extensions/yulang
+	url = https://github.com/momota1029/yulang-zed.git
 
 [submodule "extensions/zabby"]
 	path = extensions/zabby
@@ -4418,6 +5074,10 @@
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
 
+[submodule "extensions/zenburn-transparent-theme"]
+	path = extensions/zenburn-transparent-theme
+	url = https://github.com/rockas-d/zenburn-transparent.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git
@@ -4429,6 +5089,14 @@
 [submodule "extensions/ziggy"]
 	path = extensions/ziggy
 	url = https://github.com/lvignoli/zed-ziggy
+
+[submodule "extensions/zizmor"]
+	path = extensions/zizmor
+	url = https://github.com/zizmorcore/zizmor-zed.git
+
+[submodule "extensions/zk"]
+	path = extensions/zk
+	url = https://github.com/srivtx/zk-zed.git
 
 [submodule "extensions/zoegi-theme"]
 	path = extensions/zoegi-theme

--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SRC="/home/carmi/w/dev/extensions/"
+DEST="/mnt/h/carmi/Infomanta/work/backup/extensions/"
+ARCHIVE_DIR="${DEST}backups-archive"
+ZIP_FILE="${ARCHIVE_DIR}/project-backup.zip"
+LOG="$(dirname "$0")/backup.log"
+
+mkdir -p "$DEST" "$ARCHIVE_DIR"
+
+# 1. Detect changed files via rsync dry-run
+RSYNC_ITEMIZED=$(rsync -a --dry-run --itemize-changes "$SRC" "$DEST" 2>&1)
+CHANGED=$(echo "$RSYNC_ITEMIZED" | grep '^>f' | awk '{print $2}' | grep -v '^\.git/' || true)
+
+if [ -z "$CHANGED" ]; then
+  echo "[$(date +"%Y-%m-%d %H:%M:%S")] No changes detected" >> "$LOG"
+  echo "No changes to back up."
+  exit 0
+fi
+
+FILE_COUNT=$(echo "$CHANGED" | wc -l)
+
+# 2. Update the project zip — -FS syncs the zip with the filesystem:
+#    adds new files, updates changed files, removes deleted entries
+(cd "$SRC" && zip -FS -r "$ZIP_FILE" .)
+
+# 3. Rsync mirror (actual)
+rsync -a --info=progress2 "$SRC" "$DEST"
+
+# 4. Log entry
+{
+  echo "[$(date +"%Y-%m-%d %H:%M:%S")] Backup completed - ${FILE_COUNT} files changed"
+  echo "$CHANGED" | sed 's/^/  /'
+  echo ""
+} >> "$LOG"
+
+echo "Done. ${FILE_COUNT} files backed up and archived."

--- a/extensions.toml
+++ b/extensions.toml
@@ -10,6 +10,10 @@ version = "0.0.1"
 submodule = "extensions/1984-theme"
 version = "0.1.3"
 
+[a-distant-hope-theme]
+submodule = "extensions/a-distant-hope-theme"
+version = "0.1.0"
+
 [a-touch-of-lilac-theme]
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"
@@ -46,6 +50,10 @@ version = "0.2.3"
 submodule = "extensions/adech"
 version = "2.0.1"
 
+[adventurex-theme]
+submodule = "extensions/adventurex-theme"
+version = "0.1.0"
+
 [adwaita]
 submodule = "extensions/adwaita"
 version = "1.1.1"
@@ -67,6 +75,11 @@ submodule = "extensions/agnix"
 path = "editors/zed"
 version = "0.17.0"
 
+[agno-theme]
+submodule = "extensions/agno-theme"
+path = "zed"
+version = "0.0.4"
+
 [aiken]
 submodule = "extensions/aiken"
 version = "1.0.0"
@@ -84,9 +97,18 @@ version = "1.0.0"
 submodule = "extensions/aizen-theme"
 version = "0.1.0"
 
+[akhdar-by-aramb-dev-theme]
+submodule = "extensions/akhdar-by-aramb-dev-theme"
+version = "0.0.1"
+
+[al-business-central]
+submodule = "extensions/al-business-central"
+path = "crates/extension"
+version = "0.1.0"
+
 [alabaster]
 submodule = "extensions/alabaster"
-version = "0.0.3"
+version = "0.0.5"
 
 [alabaster-dark]
 submodule = "extensions/alabaster-dark"
@@ -94,7 +116,7 @@ version = "2.0.2"
 
 [alpental-theme]
 submodule = "extensions/alpental-theme"
-version = "0.0.8"
+version = "0.0.9"
 
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"
@@ -110,7 +132,7 @@ version = "0.1.3"
 
 [andromeda]
 submodule = "extensions/andromeda"
-version = "0.1.1"
+version = "0.1.2"
 
 [angular]
 submodule = "extensions/angular"
@@ -122,7 +144,7 @@ version = "21.0.0"
 
 [ansible]
 submodule = "extensions/ansible"
-version = "0.2.0"
+version = "1.0.0"
 
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
@@ -142,7 +164,7 @@ version = "0.1.0"
 
 [apathy-theme]
 submodule = "extensions/apathy-theme"
-version = "3.5.0"
+version = "3.8.0"
 path = "packages/zed"
 
 [apisartisan]
@@ -151,7 +173,7 @@ version = "0.0.1"
 
 [aptos-move]
 submodule = "extensions/aptos-move"
-version = "0.0.1"
+version = "0.0.2"
 
 [aquaflow-theme]
 submodule = "extensions/aquaflow-theme"
@@ -173,6 +195,10 @@ version = "1.0.0"
 submodule = "extensions/arctic-depth"
 version = "1.0.0"
 
+[arctikai-theme]
+submodule = "extensions/arctikai-theme"
+version = "0.1.0"
+
 [arduino]
 submodule = "extensions/arduino"
 version = "0.1.0"
@@ -185,13 +211,17 @@ version = "0.0.1"
 submodule = "extensions/arkts"
 version = "0.2.0"
 
+[ars-goetia-theme]
+submodule = "extensions/ars-goetia-theme"
+version = "0.0.1"
+
 [arturo]
 submodule = "extensions/arturo"
-version = "1.0.1"
+version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
-version = "0.5.1"
+version = "0.5.2"
 
 [ashen]
 submodule = "extensions/ashen"
@@ -221,9 +251,18 @@ version = "0.1.0"
 submodule = "extensions/asteroid"
 version = "0.0.1"
 
+[astral-theme]
+submodule = "extensions/astral-theme"
+version = "0.1.0"
+
 [astro]
 submodule = "extensions/astro"
-version = "0.1.9"
+version = "0.1.11"
+
+[atlas-ragnarok-theme]
+submodule = "extensions/atlas-ragnarok-theme"
+path = "editors/zed"
+version = "1.0.0"
 
 [atom-one-theme]
 submodule = "extensions/atom-one-theme"
@@ -256,7 +295,7 @@ version = "0.0.2"
 
 [auto-file-header]
 submodule = "extensions/auto-file-header"
-version = "0.2.7"
+version = "0.3.0"
 
 [autocorrect]
 submodule = "extensions/autocorrect"
@@ -278,9 +317,17 @@ version = "0.0.1"
 submodule = "extensions/awk"
 version = "0.0.1"
 
+[awsum]
+submodule = "extensions/awsum"
+version = "0.0.6"
+
 [axolosin]
 submodule = "extensions/axolosin"
 version = "1.1.1"
+
+[ayla]
+submodule = "extensions/ayla"
+version = "0.0.1"
 
 [aylin-theme]
 submodule = "extensions/aylin-theme"
@@ -292,7 +339,7 @@ version = "0.0.3"
 
 [ayu-darker]
 submodule = "extensions/ayu-darker"
-version = "1.1.1"
+version = "1.1.2"
 
 [ayu-themes-glass]
 submodule = "extensions/ayu-themes-glass"
@@ -312,7 +359,7 @@ version = "0.1.0"
 
 [baml]
 submodule = "extensions/baml"
-version = "0.220.0"
+version = "0.222.0"
 
 [barbenheimer]
 submodule = "extensions/barbenheimer"
@@ -329,6 +376,10 @@ version = "0.0.5"
 [batman]
 submodule = "extensions/batman"
 version = "0.0.3"
+
+[batsignal-theme]
+submodule = "extensions/batsignal-theme"
+version = "0.0.1"
 
 [beancount]
 submodule = "extensions/beancount"
@@ -368,7 +419,11 @@ version = "1.2.2"
 
 [biome]
 submodule = "extensions/biome"
-version = "0.2.2"
+version = "0.3.0"
+
+[birds-of-paradise-theme]
+submodule = "extensions/birds-of-paradise-theme"
+version = "0.1.0"
 
 [bison]
 submodule = "extensions/bison"
@@ -382,6 +437,10 @@ version = "0.0.4"
 submodule = "extensions/blackfox"
 version = "0.4.0"
 
+[blacknpink-theme]
+submodule = "extensions/blacknpink-theme"
+version = "0.1.0"
+
 [blackrain-theme]
 submodule = "extensions/blackrain-theme"
 version = "0.1.3"
@@ -392,7 +451,7 @@ version = "0.1.1"
 
 [blade]
 submodule = "extensions/blade"
-version = "0.2.5"
+version = "0.2.6"
 
 [blade-runner-2049]
 submodule = "extensions/blade-runner-2049"
@@ -423,6 +482,10 @@ submodule = "extensions/bloc"
 version = "0.1.0"
 path = "extensions/zed"
 
+[blueberry-banana-theme]
+submodule = "extensions/blueberry-banana-theme"
+version = "0.1.0"
+
 [blueforest-theme]
 submodule = "extensions/blueforest-theme"
 version = "1.0.0"
@@ -447,6 +510,10 @@ version = "0.1.0"
 submodule = "extensions/borderless-minimal-theme"
 version = "0.1.0"
 
+[borealis-theme]
+submodule = "extensions/borealis-theme"
+version = "0.0.1"
+
 [bqn]
 submodule = "extensions/bqn"
 version = "0.0.1"
@@ -455,13 +522,17 @@ version = "0.0.1"
 submodule = "extensions/brainfuck"
 version = "0.0.4"
 
+[brogrammer-theme]
+submodule = "extensions/brogrammer-theme"
+version = "0.0.1"
+
 [browser-tools-context-server]
 submodule = "extensions/browser-tools-context-server"
-version = "0.0.2"
+version = "0.1.0"
 
 [bsl]
 submodule = "extensions/bsl"
-version = "0.0.1"
+version = "0.0.2"
 
 [bubble-lsp]
 submodule = "extensions/bubble-lsp"
@@ -470,6 +541,11 @@ version = "0.0.1"
 [bubblegum]
 submodule = "extensions/bubblegum"
 version = "0.1.0"
+
+[bugstalker-dap]
+submodule = "extensions/bugstalker-dap"
+version = "0.1.0"
+path = "extension/zed"
 
 [bun-docs-mcp]
 submodule = "extensions/bun-docs-mcp"
@@ -495,16 +571,24 @@ version = "0.1.1"
 submodule = "extensions/call-trans-opt-received"
 version = "0.1.1"
 
+[canipls-lint]
+submodule = "extensions/canipls-lint"
+version = "0.0.1"
+
 [capnp]
 submodule = "extensions/capnp"
 version = "0.0.1"
 
 [carbonember]
 submodule = "extensions/carbonember"
-version = "1.0.1"
+version = "1.1.1"
 
 [carbonfox]
 submodule = "extensions/carbonfox"
+version = "1.0.0"
+
+[carbonmeda-theme]
+submodule = "extensions/carbonmeda-theme"
 version = "1.0.0"
 
 [cargo-appraiser]
@@ -514,6 +598,10 @@ version = "0.2.0"
 [cargo-tom]
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
+
+[cassette-futurism-theme]
+submodule = "extensions/cassette-futurism-theme"
+version = "0.0.1"
 
 [catbox]
 submodule = "extensions/catbox"
@@ -546,7 +634,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.9.17"
+version = "0.10.5"
 
 [cfengine]
 submodule = "extensions/cfengine"
@@ -554,11 +642,15 @@ version = "1.0.5"
 
 [cfml]
 submodule = "extensions/cfml"
-version = "0.1.9"
+version = "0.2.23"
 
 [chai-theme]
 submodule = "extensions/chai-theme"
 version = "0.0.2"
+
+[chalice-theme]
+submodule = "extensions/chalice-theme"
+version = "0.1.1"
 
 [chanterelle]
 submodule = "extensions/chanterelle"
@@ -567,6 +659,10 @@ version = "0.0.1"
 [chaos-theory-theme]
 submodule = "extensions/chaos-theory-theme"
 version = "0.0.2"
+
+[charbox-theme]
+submodule = "extensions/charbox-theme"
+version = "0.1.1"
 
 [charcoal-theme]
 submodule = "extensions/charcoal-theme"
@@ -612,6 +708,11 @@ version = "1.0.0"
 submodule = "extensions/city-lights"
 version = "0.0.2"
 
+[civet]
+submodule = "extensions/civet"
+path = "lsp/zed"
+version = "0.0.1"
+
 [clarity]
 submodule = "extensions/clarity"
 version = "0.1.0"
@@ -619,6 +720,10 @@ version = "0.1.0"
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"
+
+[claude-warm-theme]
+submodule = "extensions/claude-warm-theme"
+version = "0.0.1"
 
 [clean-vscode-icons]
 submodule = "extensions/clean-vscode-icons"
@@ -641,6 +746,10 @@ version = "0.1.0"
 submodule = "extensions/cobalt2"
 version = "0.1.0"
 
+[cobalt2x2-theme]
+submodule = "extensions/cobalt2x2-theme"
+version = "0.0.1"
+
 [cobol]
 submodule = "extensions/cobol"
 version = "0.0.5"
@@ -655,7 +764,7 @@ version = "0.0.5"
 
 [codebook]
 submodule = "extensions/codebook"
-version = "0.2.9"
+version = "0.2.12"
 
 [codebuddy]
 submodule = "extensions/codebuddy"
@@ -704,7 +813,11 @@ version = "0.0.1"
 
 [comment]
 submodule = "extensions/comment"
-version = "0.6.4"
+version = "0.6.6"
+
+[comment-block-snippets]
+submodule = "extensions/comment-block-snippets"
+version = "1.0.2"
 
 [comphy-crisp-themes]
 submodule = "extensions/comphy-crisp-themes"
@@ -729,11 +842,16 @@ version = "1.3.3"
 
 [corust-agent]
 submodule = "extensions/corust-agent"
-version = "0.4.1"
+version = "0.4.2"
 
 [cosmos]
 submodule = "extensions/cosmos"
 version = "0.0.1"
+
+[coverage-lsp]
+submodule = "extensions/coverage-lsp"
+version = "1.0.1"
+path = "zed-coverage-lsp"
 
 [cpp2]
 submodule = "extensions/cpp2"
@@ -761,7 +879,7 @@ version = "0.0.1"
 
 [csharp]
 submodule = "extensions/csharp"
-version = "1.0.4"
+version = "1.2.0"
 
 [csharp-snippets]
 submodule = "extensions/csharp-snippets"
@@ -783,6 +901,11 @@ path = "crates/zed"
 [css-variables]
 submodule = "extensions/css-variables"
 version = "0.1.0"
+
+[csskit-lsp]
+submodule = "extensions/csskit-lsp"
+version = "0.0.1"
+path = "packages/csskit_zed"
 
 [csv]
 submodule = "extensions/csv"
@@ -819,6 +942,10 @@ version = "0.7.1"
 [cyberpunk-2077]
 submodule = "extensions/cyberpunk-2077"
 version = "2.0.0"
+
+[cyberpunk-2077-theme]
+submodule = "extensions/cyberpunk-2077-theme"
+version = "0.0.3"
 
 [cyberpunk-scarlet]
 submodule = "extensions/cyberpunk-scarlet"
@@ -860,6 +987,10 @@ version = "0.1.1"
 submodule = "extensions/darcula-dark-okkano"
 version = "0.1.4"
 
+[darcula-forest-theme]
+submodule = "extensions/darcula-forest-theme"
+version = "0.1.0"
+
 [dark-castle-theme]
 submodule = "extensions/dark-castle-theme"
 version = "0.0.4"
@@ -884,6 +1015,10 @@ version = "0.1.0"
 submodule = "extensions/dark-pop-ui"
 version = "0.0.2"
 
+[dark-purple-theme]
+submodule = "extensions/dark-purple-theme"
+version = "0.1.0"
+
 [darker-horizon]
 submodule = "extensions/darker-horizon"
 version = "0.0.3"
@@ -894,11 +1029,11 @@ version = "0.0.2"
 
 [dart]
 submodule = "extensions/dart"
-version = "0.3.5"
+version = "0.3.8"
 
 [datadog-mcp]
 submodule = "extensions/datadog-mcp"
-version = "0.2.1"
+version = "0.3.0"
 
 [day-shift]
 submodule = "extensions/day-shift"
@@ -907,6 +1042,10 @@ version = "1.0.3"
 [dbml]
 submodule = "extensions/dbml"
 version = "0.0.1"
+
+[dbt]
+submodule = "extensions/dbt"
+version = "0.1.1"
 
 [decorative-stitch]
 submodule = "extensions/decorative-stitch"
@@ -931,7 +1070,7 @@ version = "0.1.1"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.7.0"
+version = "1.9.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"
@@ -945,7 +1084,7 @@ version = "1.0.1"
 [design-tokens]
 submodule = "extensions/design-tokens"
 path = "extensions/zed"
-version = "0.1.24"
+version = "0.3.2"
 
 [desktop]
 submodule = "extensions/desktop"
@@ -955,9 +1094,17 @@ version = "0.1.0"
 submodule = "extensions/dev-magic"
 version = "0.0.1"
 
+[devglobe-activity-ls]
+submodule = "extensions/devglobe-activity-ls"
+version = "2.0.1"
+
 [devicetree]
 submodule = "extensions/devicetree"
 version = "0.0.1"
+
+[dhall]
+submodule = "extensions/dhall"
+version = "0.1.0"
 
 [discord-presence]
 submodule = "extensions/discord-presence"
@@ -971,13 +1118,17 @@ version = "0.2.2"
 submodule = "extensions/django-snippets"
 version = "0.0.1"
 
+[djot]
+submodule = "extensions/djot"
+version = "0.1.0"
+
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"
 
 [dockerfile]
 submodule = "extensions/dockerfile"
-version = "0.2.0"
+version = "0.2.1"
 
 [dogi]
 submodule = "extensions/dogi"
@@ -986,6 +1137,10 @@ version = "1.0.4"
 [dogxi-theme]
 submodule = "extensions/dogxi-theme"
 version = "0.0.2"
+
+[doom-one-theme]
+submodule = "extensions/doom-one-theme"
+version = "1.0.0"
 
 [doxygen]
 submodule = "extensions/doxygen"
@@ -1032,12 +1187,24 @@ version = "0.1.0"
 submodule = "extensions/dwp"
 version = "0.0.4"
 
+[earo-theme]
+submodule = "extensions/earo-theme"
+version = "0.2.0"
+
 [earthfile]
 submodule = "extensions/earthfile"
 version = "0.1.0"
 
 [earthsong-theme]
 submodule = "extensions/earthsong-theme"
+version = "1.0.0"
+
+[easy-opaque-theme]
+submodule = "extensions/easy-opaque-theme"
+version = "0.0.1"
+
+[ebnf]
+submodule = "extensions/ebnf"
 version = "1.0.0"
 
 [eclat]
@@ -1056,6 +1223,14 @@ version = "0.0.2"
 submodule = "extensions/editorconfig"
 version = "0.1.0"
 
+[edusites-theme]
+submodule = "extensions/edusites-theme"
+version = "1.0.0"
+
+[effect-language-service-tsgo]
+submodule = "extensions/effect-language-service-tsgo"
+version = "0.0.5"
+
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
 version = "0.1.1"
@@ -1072,6 +1247,10 @@ version = "0.1.0"
 submodule = "extensions/eldritch-theme"
 version = "0.1.0"
 
+[electron-highlighter-theme]
+submodule = "extensions/electron-highlighter-theme"
+version = "0.0.1"
+
 [electron-vue-theme]
 submodule = "extensions/electron-vue-theme"
 version = "0.0.1"
@@ -1082,7 +1261,11 @@ version = "0.0.5"
 
 [elixir]
 submodule = "extensions/elixir"
-version = "0.4.3"
+version = "0.6.2"
+
+[elixir-hex-lens]
+submodule = "extensions/elixir-hex-lens"
+version = "0.1.0"
 
 [elixir-snippets]
 submodule = "extensions/elixir-snippets"
@@ -1115,7 +1298,7 @@ version = "0.0.2"
 
 [emmet]
 submodule = "extensions/emmet"
-version = "0.0.11"
+version = "0.0.13"
 
 [emmylua]
 submodule = "extensions/emmylua"
@@ -1139,11 +1322,15 @@ version = "0.2.1"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
-version = "0.1.0"
+version = "0.1.2"
+
+[eva-theme]
+submodule = "extensions/eva-theme"
+version = "0.0.1"
 
 [everforest]
 submodule = "extensions/everforest"
-version = "0.1.2"
+version = "0.1.4"
 
 [everforest-blurred]
 submodule = "extensions/everforest-blurred"
@@ -1182,6 +1369,10 @@ version = "0.0.8"
 submodule = "extensions/factory-droid"
 version = "0.68.1"
 
+[falcon-theme]
+submodule = "extensions/falcon-theme"
+version = "1.0.10"
+
 [fantasticons-icons-theme]
 submodule = "extensions/fantasticons-icons-theme"
 version = "1.0.0"
@@ -1198,6 +1389,10 @@ version = "1.0.0"
 submodule = "extensions/ferret"
 version = "0.0.11"
 
+[fff-mcp]
+submodule = "extensions/fff-mcp"
+version = "0.0.1"
+
 [fiber-snippets]
 submodule = "extensions/fiber-snippets"
 version = "0.1.0"
@@ -1206,9 +1401,21 @@ version = "0.1.0"
 submodule = "extensions/fiberplane-studio"
 version = "0.1.1"
 
+[field-lights-theme]
+submodule = "extensions/field-lights-theme"
+version = "1.0.0"
+
+[file-icons]
+submodule = "extensions/file-icons"
+version = "1.0.0"
+
 [findrakecil-alabaster]
 submodule = "extensions/findrakecil-alabaster"
-version = "1.0.2"
+version = "1.0.3"
+
+[fineorite-theme]
+submodule = "extensions/fineorite-theme"
+version = "0.1.1"
 
 [firebase-security-rules]
 submodule = "extensions/firebase-security-rules"
@@ -1220,7 +1427,11 @@ version = "0.1.0"
 
 [fish]
 submodule = "extensions/fish"
-version = "0.0.8"
+version = "0.1.0"
+
+[fjord-theme]
+submodule = "extensions/fjord-theme"
+version = "0.1.5"
 
 [flask-snippets]
 submodule = "extensions/flask-snippets"
@@ -1263,6 +1474,10 @@ version = "0.0.1"
 submodule = "extensions/flow-theme"
 version = "1.1.0"
 
+[fluent-oled-theme]
+submodule = "extensions/fluent-oled-theme"
+version = "1.0.0"
+
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"
@@ -1299,6 +1514,10 @@ version = "0.2.0"
 submodule = "extensions/fozzy"
 version = "0.0.1"
 
+[framer-dark-theme]
+submodule = "extensions/framer-dark-theme"
+version = "1.0.0"
+
 [freemarker]
 submodule = "extensions/freemarker"
 version = "0.1.0"
@@ -1306,6 +1525,10 @@ version = "0.1.0"
 [freezed-dart-flutter-snippets]
 submodule = "extensions/freezed-dart-flutter-snippets"
 version = "0.0.1"
+
+[frieren-theme]
+submodule = "extensions/frieren-theme"
+version = "0.1.0"
 
 [frosted-theme]
 submodule = "extensions/frosted-theme"
@@ -1319,6 +1542,10 @@ version = "0.0.9"
 submodule = "extensions/fsm"
 version = "0.3.0"
 
+[fujihaze-theme]
+submodule = "extensions/fujihaze-theme"
+version = "1.0.0"
+
 [furina-vibe-theme]
 submodule = "extensions/furina-vibe-theme"
 version = "0.1.2"
@@ -1327,9 +1554,19 @@ version = "0.1.2"
 submodule = "extensions/gafelson"
 version = "1.0.1"
 
+[gas-plasma-icons]
+submodule = "extensions/gas-plasma-icons"
+path = "zed/gas-plasma-icons"
+version = "0.1.1"
+
+[gas-plasma-theme]
+submodule = "extensions/gas-plasma-theme"
+path = "zed/gas-plasma-theme"
+version = "0.1.1"
+
 [gatito-theme]
 submodule = "extensions/gatito-theme"
-version = "0.0.1"
+version = "0.2.0"
 
 [gato-theme]
 submodule = "extensions/gato-theme"
@@ -1341,7 +1578,7 @@ version = "0.0.1"
 
 [gdscript]
 submodule = "extensions/gdscript"
-version = "0.7.0"
+version = "0.9.0"
 
 [gdscript-snippets]
 submodule = "extensions/gdscript-snippets"
@@ -1350,19 +1587,23 @@ version = "0.0.2"
 [gem]
 submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
-version = "0.0.3"
-
-[gemini]
-submodule = "extensions/gemini"
-version = "0.0.1"
+version = "0.0.5"
 
 [genexpr]
 submodule = "extensions/genexpr"
 version = "0.1.0"
 
+[geno]
+submodule = "extensions/geno"
+version = "0.2.0"
+
 [gentle-dark]
 submodule = "extensions/gentle-dark"
 version = "1.2.2"
+
+[geode-theme]
+submodule = "extensions/geode-theme"
+version = "2.0.1"
 
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"
@@ -1372,9 +1613,13 @@ version = "0.1.0"
 submodule = "extensions/ghostty"
 version = "0.3.2"
 
+[ghostty-dark-theme]
+submodule = "extensions/ghostty-dark-theme"
+version = "0.1.0"
+
 [git-firefly]
 submodule = "extensions/git-firefly"
-version = "0.1.4"
+version = "0.1.7"
 
 [github-actions]
 submodule = "extensions/github-actions"
@@ -1435,7 +1680,11 @@ version = "0.2.1"
 [glsl]
 submodule = "extensions/zed"
 path = "extensions/glsl"
-version = "0.2.3"
+version = "0.2.4"
+
+[gn]
+submodule = "extensions/gn"
+version = "1.4.0"
 
 [go-snippets]
 submodule = "extensions/go-snippets"
@@ -1443,7 +1692,7 @@ version = "0.1.5"
 
 [godot-theme]
 submodule = "extensions/godot-theme"
-version = "1.2.0"
+version = "1.3.0"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
@@ -1457,13 +1706,17 @@ version = "0.0.2"
 submodule = "extensions/gotmpl"
 version = "0.0.1"
 
+[grafana-alloy]
+submodule = "extensions/grafana-alloy"
+version = "0.0.1"
+
 [graphene]
 submodule = "extensions/graphene"
 version = "0.2.1"
 
 [graphql]
 submodule = "extensions/graphql"
-version = "1.0.3"
+version = "1.0.5"
 
 [graphviz]
 submodule = "extensions/graphviz"
@@ -1473,9 +1726,13 @@ version = "0.2.1"
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"
 version = "0.1.3"
 
+[green-theme]
+submodule = "extensions/green-theme"
+version = "0.0.3"
+
 [gren]
 submodule = "extensions/gren"
-version = "0.1.0"
+version = "0.2.0"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
@@ -1483,7 +1740,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.0"
+version = "0.1.6"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"
@@ -1499,6 +1756,10 @@ version = "1.3.0"
 
 [groq]
 submodule = "extensions/groq"
+version = "0.0.1"
+
+[grove-theme]
+submodule = "extensions/grove-theme"
 version = "0.0.1"
 
 [gruber-darker]
@@ -1545,9 +1806,9 @@ version = "0.3.1"
 submodule = "extensions/hacker-night-vision"
 version = "2.0.0"
 
-[hacker-theme]
-submodule = "extensions/hacker-theme"
-version = "1.0.1"
+[hackthebox-theme]
+submodule = "extensions/hackthebox-theme"
+version = "0.1.0"
 
 [haku-dark-theme]
 submodule = "extensions/haku-dark-theme"
@@ -1556,6 +1817,10 @@ version = "0.0.1"
 [halcyon]
 submodule = "extensions/halcyon"
 version = "0.2.3"
+
+[halloween-night-theme]
+submodule = "extensions/halloween-night-theme"
+version = "0.0.1"
 
 [hami-melon-theme]
 submodule = "extensions/hami-melon-theme"
@@ -1575,15 +1840,19 @@ version = "0.1.5"
 
 [haskell]
 submodule = "extensions/haskell"
-version = "0.2.1"
+version = "0.3.1"
 
 [haxe]
 submodule = "extensions/haxe"
-version = "0.3.1"
+version = "0.4.0"
 
 [hbuilderx-push-light]
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"
+
+[helios-theme]
+submodule = "extensions/helios-theme"
+version = "0.0.8"
 
 [helm]
 submodule = "extensions/helm"
@@ -1600,6 +1869,10 @@ version = "0.0.4"
 
 [hexpeek]
 submodule = "extensions/hexpeek"
+version = "0.1.0"
+
+[high-contrast-themes]
+submodule = "extensions/high-contrast-themes"
 version = "0.1.0"
 
 [hilleer-v-theme]
@@ -1626,6 +1899,10 @@ version = "0.0.1"
 submodule = "extensions/hocon"
 version = "0.2.0"
 
+[hoon]
+submodule = "extensions/hoon"
+version = "0.1.0"
+
 [horizon]
 submodule = "extensions/horizon"
 version = "0.0.1"
@@ -1633,6 +1910,10 @@ version = "0.0.1"
 [horizon-extended]
 submodule = "extensions/horizon-extended"
 version = "0.0.1"
+
+[horizon-theme]
+submodule = "extensions/horizon-theme"
+version = "1.0.0"
 
 [hot-dog-stand]
 submodule = "extensions/hot-dog-stand"
@@ -1658,10 +1939,6 @@ version = "0.1.0"
 [html-snippets]
 submodule = "extensions/html-snippets"
 version = "0.1.0"
-
-[htmx-lsp]
-submodule = "extensions/htmx-lsp"
-version = "1.0.1"
 
 [http]
 submodule = "extensions/http"
@@ -1711,6 +1988,18 @@ version = "0.0.1"
 submodule = "extensions/immigrant"
 version = "0.1.2"
 
+[import-cost-lsp]
+submodule = "extensions/import-cost-lsp"
+version = "0.0.2"
+
+[imzed]
+submodule = "extensions/imzed"
+version = "0.3.9"
+
+[inbedby7pm-theme]
+submodule = "extensions/inbedby7pm-theme"
+version = "0.1.0"
+
 [indigo]
 submodule = "extensions/indigo"
 version = "0.1.2"
@@ -1719,13 +2008,21 @@ version = "0.1.2"
 submodule = "extensions/inform6"
 version = "1.0.0"
 
+[infracost-ls]
+submodule = "extensions/infracost-ls"
+version = "0.1.0"
+
 [ini]
 submodule = "extensions/ini"
-version = "0.0.7"
+version = "0.0.8"
 
 [ink]
 submodule = "extensions/ink"
 version = "0.0.2"
+
+[inko]
+submodule = "extensions/inko"
+version = "0.0.1"
 
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
@@ -1738,7 +2035,11 @@ version = "0.1.0"
 [intl-lens]
 submodule = "extensions/intl-lens"
 path = "crates/intl-lens-extension"
-version = "0.1.3"
+version = "0.1.5"
+
+[inuzdev-coffee-theme]
+submodule = "extensions/inuzdev-coffee-theme"
+version = "1.1.3"
 
 [ion]
 submodule = "extensions/ion"
@@ -1748,13 +2049,17 @@ version = "0.1.2"
 submodule = "extensions/ir-black"
 version = "0.0.1"
 
+[irix-terminal-theme]
+submodule = "extensions/irix-terminal-theme"
+version = "0.1.0"
+
 [irodori-theme]
 submodule = "extensions/irodori-theme"
 version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [isle]
 submodule = "extensions/isle"
@@ -1783,7 +2088,7 @@ version = "0.1.1"
 
 [java]
 submodule = "extensions/java"
-version = "6.8.13"
+version = "6.8.20"
 
 [java-eclipse-jdtls]
 submodule = "extensions/java-eclipse-jdtls"
@@ -1803,11 +2108,19 @@ version = "0.0.1"
 
 [jellybeans-vim]
 submodule = "extensions/jellybeans-vim"
-version = "0.0.2"
+version = "0.0.3"
+
+[jemini-theme]
+submodule = "extensions/jemini-theme"
+version = "0.0.1"
+
+[jerry]
+submodule = "extensions/jerry"
+version = "0.8.0"
 
 [jetbrains-darcula-theme-by-bronya0]
 submodule = "extensions/jetbrains-darcula-theme-by-bronya0"
-version = "0.1.3"
+version = "0.1.4"
 
 [jetbrains-icons]
 submodule = "extensions/jetbrains-icons"
@@ -1823,7 +2136,7 @@ version = "0.0.2"
 
 [jetbrains-themes]
 submodule = "extensions/jetbrains-themes"
-version = "0.4.0"
+version = "1.1.0"
 
 [jinja2]
 submodule = "extensions/jinja2"
@@ -1841,6 +2154,10 @@ version = "0.1.0"
 submodule = "extensions/jq"
 version = "0.0.2"
 
+[json-tool-lsp]
+submodule = "extensions/json-tool-lsp"
+version = "0.0.3"
+
 [json5]
 submodule = "extensions/json5"
 version = "0.1.0"
@@ -1857,9 +2174,13 @@ version = "0.4.0"
 submodule = "extensions/jsp"
 version = "0.3.2"
 
+[jubby-theme]
+submodule = "extensions/jubby-theme"
+version = "0.1.0"
+
 [julia]
 submodule = "extensions/julia"
-version = "0.1.9"
+version = "0.1.10"
 
 [just]
 submodule = "extensions/just"
@@ -1881,9 +2202,18 @@ version = "0.0.1"
 submodule = "extensions/kanagawa-themes"
 version = "0.1.2"
 
+[kanagawa-wave-blur-theme]
+submodule = "extensions/kanagawa-wave-blur-theme"
+version = "0.1.0"
+
 [kanso]
 submodule = "extensions/kanso"
-version = "1.0.4"
+version = "1.0.5"
+
+[karma-theme]
+submodule = "extensions/karma-theme"
+path = "packages/zed"
+version = "3.1.1"
 
 [kcl]
 submodule = "extensions/kcl"
@@ -1901,9 +2231,17 @@ version = "0.1.0"
 submodule = "extensions/kdl"
 version = "0.0.1"
 
+[keep-a-changelog-snippets]
+submodule = "extensions/keep-a-changelog-snippets"
+version = "0.1.0"
+
 [keepcalm]
 submodule = "extensions/keepcalm"
 version = "1.0.1"
+
+[keo-theme]
+submodule = "extensions/keo-theme"
+version = "0.0.1"
 
 [kiro]
 submodule = "extensions/kiro"
@@ -1913,9 +2251,13 @@ version = "1.0.0"
 submodule = "extensions/kiselevka"
 version = "0.0.1"
 
+[koda-theme]
+submodule = "extensions/koda-theme"
+version = "0.0.1"
+
 [kokedera-icons]
 submodule = "extensions/kokedera-icons"
-version = "1.0.0"
+version = "1.0.1"
 
 [kokedera-theme]
 submodule = "extensions/kokedera-theme"
@@ -1923,7 +2265,7 @@ version = "1.0.1"
 
 [kotlin]
 submodule = "extensions/kotlin"
-version = "0.2.1"
+version = "0.3.0"
 
 [koto]
 submodule = "extensions/koto"
@@ -1932,6 +2274,10 @@ version = "0.0.2"
 [ktrz-monokai]
 submodule = "extensions/ktrz-monokai"
 version = "0.0.6"
+
+[kubernetes-snippets]
+version = "0.0.1"
+submodule = "extensions/kubernetes-snippets"
 
 [kubesong]
 submodule = "extensions/kubesong"
@@ -1945,12 +2291,20 @@ version = "0.0.1"
 submodule = "extensions/kvs-cyberpunk-2077"
 version = "1.0.3"
 
+[laravel]
+submodule = "extensions/laravel"
+version = "0.4.1"
+
 [latex]
 submodule = "extensions/latex"
 version = "0.2.3"
 
 [latte]
 submodule = "extensions/latte"
+version = "0.1.0"
+
+[lazyvim-theme]
+submodule = "extensions/lazyvim-theme"
 version = "0.1.0"
 
 [lean4]
@@ -1967,7 +2321,7 @@ version = "0.2.0"
 
 [leptos]
 submodule = "extensions/leptos"
-version = "0.1.0"
+version = "0.1.1"
 
 [less]
 submodule = "extensions/less"
@@ -1979,6 +2333,10 @@ version = "0.0.1"
 
 [lights-out]
 submodule = "extensions/lights-out"
+version = "0.0.1"
+
+[likec4]
+submodule = "extensions/likec4"
 version = "0.0.1"
 
 [lilypond]
@@ -2001,6 +2359,16 @@ version = "0.0.2"
 submodule = "extensions/liquidsoap"
 version = "0.1.0"
 
+[lisette]
+submodule = "extensions/lisette"
+path = "editors/zed"
+version = "0.1.1"
+
+[little-league-theme]
+submodule = "extensions/little-league-theme"
+path = "targets/zed"
+version = "1.5.1"
+
 [live-server]
 submodule = "extensions/live-server"
 version = "0.3.1"
@@ -2015,7 +2383,7 @@ version = "0.1.1"
 
 [log]
 submodule = "extensions/log"
-version = "0.0.6"
+version = "0.0.7"
 
 [logcat]
 submodule = "extensions/logcat"
@@ -2023,7 +2391,11 @@ version = "0.0.1"
 
 [logstash]
 submodule = "extensions/logstash"
-version = "0.0.1"
+version = "0.0.2"
+
+[loi-paper-theme]
+submodule = "extensions/loi-paper-theme"
+version = "0.3.1"
 
 [lonely-planet]
 submodule = "extensions/lonely-planet"
@@ -2052,7 +2424,11 @@ version = "0.1.9"
 
 [luau]
 submodule = "extensions/luau"
-version = "0.3.7"
+version = "0.3.8"
+
+[lume-theme]
+submodule = "extensions/lume-theme"
+version = "0.1.0"
 
 [lumina-theme]
 submodule = "extensions/lumina-theme"
@@ -2068,15 +2444,31 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.1.0"
+version = "0.2.1"
 
 [macos-classic]
 submodule = "extensions/macos-classic"
 version = "0.4.0"
 
+[magento2-snippets]
+submodule = "extensions/magento2-snippets"
+version = "0.1.0"
+
+[maho-lsp]
+submodule = "extensions/maho-lsp"
+version = "0.9.1"
+
+[mainframe-theme]
+submodule = "extensions/mainframe-theme"
+version = "0.1.0"
+
 [make]
 submodule = "extensions/make"
 version = "1.1.2"
+
+[mako]
+submodule = "extensions/mako"
+version = "0.0.3"
 
 [malibu]
 submodule = "extensions/malibu"
@@ -2116,7 +2508,7 @@ version = "0.0.5"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
-version = "0.0.7"
+version = "0.0.8"
 
 [markdownlint]
 submodule = "extensions/markdownlint"
@@ -2124,7 +2516,7 @@ version = "0.4.0"
 
 [marksman]
 submodule = "extensions/marksman"
-version = "0.3.1"
+version = "1.0.0"
 
 [martianized]
 submodule = "extensions/martianized"
@@ -2164,7 +2556,7 @@ version = "0.1.1"
 
 [mau]
 submodule = "extensions/mau"
-version = "0.0.4"
+version = "0.2.0"
 
 [maya]
 submodule = "extensions/maya"
@@ -2173,6 +2565,10 @@ version = "0.4.5"
 [maybe-material]
 submodule = "extensions/maybe-material"
 path = "extension/"
+version = "0.1.0"
+
+[mc-dp-icons-theme]
+submodule = "extensions/mc-dp-icons-theme"
 version = "0.1.0"
 
 [mcfunction]
@@ -2206,10 +2602,6 @@ version = "0.2.0"
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
 version = "0.0.4"
-
-[mcp-server-byterover]
-submodule = "extensions/mcp-server-byterover"
-version = "0.0.3"
 
 [mcp-server-code-runner]
 submodule = "extensions/mcp-server-code-runner"
@@ -2247,6 +2639,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-gitlab"
 version = "0.0.5"
 
+[mcp-server-godot]
+submodule = "extensions/mcp-server-godot"
+version = "0.1.0"
+
 [mcp-server-grafana]
 submodule = "extensions/mcp-server-grafana"
 version = "0.1.2"
@@ -2258,6 +2654,10 @@ version = "0.0.1"
 [mcp-server-master-go]
 submodule = "extensions/mcp-server-master-go"
 version = "0.0.1"
+
+[mcp-server-memory]
+submodule = "extensions/mcp-server-memory"
+version = "0.1.0"
 
 [mcp-server-miaoduo]
 submodule = "extensions/mcp-server-miaoduo"
@@ -2337,19 +2737,23 @@ version = "0.0.2"
 
 [mcp-server-threadbridge]
 submodule = "extensions/mcp-server-threadbridge"
-version = "0.1.0"
-
-[mcp-server-weave]
-submodule = "extensions/mcp-server-weave"
-version = "0.0.2"
+version = "0.2.1"
 
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"
 
+[mcp-server-zuraffa]
+submodule = "extensions/mcp-server-zuraffa"
+version = "5.2.1"
+
+[mdias-oled-theme]
+submodule = "extensions/mdias-oled-theme"
+version = "0.1.0"
+
 [mdx]
 submodule = "extensions/mdx"
-version = "0.3.0"
+version = "0.4.0"
 
 [melange]
 submodule = "extensions/melange"
@@ -2370,7 +2774,7 @@ version = "0.5.0"
 [metal]
 submodule = "extensions/metal"
 path = "editors/zed"
-version = "0.1.19"
+version = "0.1.21"
 
 [microscript]
 submodule = "extensions/microscript"
@@ -2396,14 +2800,30 @@ version = "0.1.0"
 submodule = "extensions/mint-theme"
 version = "0.1.1"
 
+[miramare-theme]
+submodule = "extensions/miramare-theme"
+version = "0.0.1"
+
+[mire-theme]
+submodule = "extensions/mire-theme"
+version = "0.1.0"
+
 [missing-theme]
 submodule = "extensions/missing-theme"
 version = "0.0.1"
 
 [mistral-vibe]
 submodule = "extensions/mistral-vibe"
-version = "2.7.3"
+version = "2.10.1"
 path = "distribution/zed"
+
+[mjml]
+submodule = "extensions/mjml"
+version = "0.1.0"
+
+[mlir-tablegen]
+submodule = "extensions/mlir-tablegen"
+version = "0.2.1"
 
 [mnemonic]
 submodule = "extensions/mnemonic"
@@ -2411,7 +2831,7 @@ version = "0.0.1"
 
 [modern-icons]
 submodule = "extensions/modern-icons"
-version = "0.6.0"
+version = "0.7.2"
 
 [modern-vesper]
 submodule = "extensions/modern-vesper"
@@ -2423,19 +2843,20 @@ version = "0.1.9"
 
 [modus-themes]
 submodule = "extensions/modus-themes"
-version = "0.1.6"
+version = "0.2.1"
 
 [molten-theme]
 submodule = "extensions/molten-theme"
 version = "1.0.0"
 
+[monochromator-theme]
+submodule = "extensions/monochromator-theme"
+path = "editors/zed"
+version = "0.2.2"
+
 [monokai-nebula]
 submodule = "extensions/monokai-nebula"
-version = "0.2.5"
-
-[monokai-night]
-submodule = "extensions/monokai-night"
-version = "0.2.2"
+version = "0.2.6"
 
 [monokai-og]
 submodule = "extensions/monokai-og"
@@ -2451,11 +2872,15 @@ version = "0.0.2"
 
 [monokai-sharp]
 submodule = "extensions/monokai-sharp"
-version = "1.0.0"
+version = "1.0.1"
 
 [monokai-vibrant-amped]
 submodule = "extensions/monokai-vibrant-amped"
 version = "0.0.3"
+
+[monokuro-theme]
+submodule = "extensions/monokuro-theme"
+version = "0.0.2"
 
 [monolith]
 submodule = "extensions/monolith"
@@ -2471,7 +2896,7 @@ version = "0.1.5"
 
 [monospace-theme]
 submodule = "extensions/monospace-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [moonbit]
 submodule = "extensions/moonbit"
@@ -2479,7 +2904,7 @@ version = "0.1.1"
 
 [moonlight]
 submodule = "extensions/moonlight"
-version = "0.0.4"
+version = "1.0.0"
 
 [mosel]
 submodule = "extensions/mosel"
@@ -2523,7 +2948,7 @@ version = "0.1.0"
 
 [napalm]
 submodule = "extensions/napalm"
-version = "0.0.2"
+version = "0.1.0"
 
 [navi]
 submodule = "extensions/navi"
@@ -2595,11 +3020,15 @@ version = "0.0.1"
 
 [night-owlz]
 submodule = "extensions/night-owlz"
-version = "0.0.4"
+version = "0.0.5"
 
 [night-shift]
 submodule = "extensions/night-shift"
 version = "1.0.3"
+
+[nightfall-theme]
+submodule = "extensions/nightfall-theme"
+version = "0.1.0"
 
 [nightfox]
 submodule = "extensions/nightfox"
@@ -2607,11 +3036,11 @@ version = "0.1.1"
 
 [nightfox-m]
 submodule = "extensions/nightfox-m"
-version = "0.2.0"
+version = "0.3.0"
 
 [nightingale]
 submodule = "extensions/nightingale"
-version = "0.1.3"
+version = "1.0.0"
 
 [nim]
 submodule = "extensions/nim"
@@ -2620,7 +3049,7 @@ version = "0.2.0"
 [ninja]
 submodule = "extensions/ninja"
 path = "zed"
-version = "1.0.0"
+version = "1.1.0"
 
 [niva]
 submodule = "extensions/niva"
@@ -2652,11 +3081,11 @@ version = "0.1.1"
 
 [nomad]
 submodule = "extensions/nomad"
-version = "0.0.2"
+version = "0.0.3"
 
 [nord]
 submodule = "extensions/nord"
-version = "0.1.4"
+version = "0.1.5"
 
 [nordic-nvim-theme]
 submodule = "extensions/nordic-nvim-theme"
@@ -2686,6 +3115,10 @@ version = "0.0.1"
 submodule = "extensions/not-too-shabby"
 version = "0.1.0"
 
+[noted-theme]
+submodule = "extensions/noted-theme"
+version = "0.1.0"
+
 [nova-theme]
 submodule = "extensions/nova-theme"
 version = "0.1.0"
@@ -2694,13 +3127,17 @@ version = "0.1.0"
 submodule = "extensions/npm-package-json-checker"
 version = "1.0.6"
 
+[nsis]
+submodule = "extensions/nsis"
+version = "0.2.0"
+
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
 version = "0.0.2"
 
 [nu]
 submodule = "extensions/nu"
-version = "0.0.9"
+version = "0.0.10"
 
 [nu-lint]
 submodule = "extensions/nu-lint"
@@ -2720,7 +3157,7 @@ version = "0.0.1"
 
 [nvim-nightfox]
 submodule = "extensions/nvim-nightfox"
-version = "0.8.0"
+version = "0.10.0"
 
 [nyxvamp-theme]
 submodule = "extensions/nyxvamp-theme"
@@ -2734,21 +3171,29 @@ version = "0.0.1"
 submodule = "extensions/oat"
 version = "0.0.4"
 
+[oberon]
+submodule = "extensions/oberon"
+version = "0.0.1"
+
 [objective-c]
 submodule = "extensions/objective-c"
 version = "1.0.1"
 
 [objectscript]
 submodule = "extensions/objectscript"
-version = "1.2.0"
+version = "1.4.0"
 
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"
 
+[oc-2-theme]
+submodule = "extensions/oc-2-theme"
+version = "0.0.1"
+
 [ocaml]
 submodule = "extensions/ocaml"
-version = "0.3.1"
+version = "0.4.0"
 
 [ocean-dark-motifs]
 submodule = "extensions/ocean-dark-motifs"
@@ -2760,11 +3205,15 @@ version = "0.0.1"
 
 [oceanic-next]
 submodule = "extensions/oceanic-next"
-version = "1.0.0"
+version = "1.1.0"
+
+[oceans-of-andromeda-theme]
+submodule = "extensions/oceans-of-andromeda-theme"
+version = "1.0.1"
 
 [odin]
 submodule = "extensions/odin"
-version = "0.3.11"
+version = "0.3.12"
 
 [odoo]
 submodule = "extensions/odoo"
@@ -2809,7 +3258,7 @@ version = "0.1.0"
 
 [one-dark-pro]
 submodule = "extensions/one-dark-pro"
-version = "0.0.10"
+version = "0.0.11"
 
 [one-dark-pro-enhanced]
 submodule = "extensions/one-dark-pro-enhanced"
@@ -2825,7 +3274,7 @@ version = "0.1.1"
 
 [one-dark-pro-vivid-theme]
 submodule = "extensions/one-dark-pro-vivid-theme"
-version = "0.1.0"
+version = "0.3.0"
 
 [one-hunter]
 submodule = "extensions/one-hunter"
@@ -2846,14 +3295,10 @@ version = "0.1.0"
 [opencode]
 submodule = "extensions/opencode"
 path = "packages/extensions/zed"
-version = "1.4.1"
+version = "1.15.13"
 
 [openfga]
 submodule = "extensions/openfga"
-version = "0.2.0"
-
-[openmoji-icons]
-submodule = "extensions/openmoji-icons"
 version = "0.2.0"
 
 [openscad]
@@ -2862,7 +3307,11 @@ version = "0.0.1"
 
 [opentofu]
 submodule = "extensions/opentofu"
-version = "0.2.0"
+version = "1.0.0"
+
+[opentype-feature]
+submodule = "extensions/opentype-feature"
+version = "0.1.0"
 
 [optima-theme]
 submodule = "extensions/optima-theme"
@@ -2876,21 +3325,29 @@ version = "0.0.1"
 submodule = "extensions/orng"
 version = "0.0.2"
 
+[osaka-jade-theme]
+submodule = "extensions/osaka-jade-theme"
+version = "0.1.0"
+
 [oscura]
 submodule = "extensions/oscura"
 version = "0.2.0"
 
 [oso]
 submodule = "extensions/oso"
-version = "0.1.1"
+version = "0.2.0"
 
 [outrun]
 submodule = "extensions/outrun"
 version = "0.0.3"
 
+[outrun-vscode-theme]
+submodule = "extensions/outrun-vscode-theme"
+version = "0.1.0"
+
 [oxc]
 submodule = "extensions/oxc"
-version = "0.4.6"
+version = "0.4.7"
 
 [oxocarbon]
 submodule = "extensions/oxocarbon"
@@ -2903,6 +3360,10 @@ version = "0.0.1"
 [pace-pro-theme]
 submodule = "extensions/pace-pro-theme"
 version = "0.1.0"
+
+[package-json-upgrade-lsp]
+submodule = "extensions/package-json-upgrade-lsp"
+version = "0.1.7"
 
 [package-swift-lsp]
 submodule = "extensions/package-swift-lsp"
@@ -2944,6 +3405,11 @@ version = "0.1.0"
 submodule = "extensions/path-of-exile"
 version = "0.0.1"
 
+[path-server-lsp]
+submodule = "extensions/path-server-lsp"
+path = "extensions/zed"
+version = "1.3.1"
+
 [pathy]
 submodule = "extensions/pathy"
 version = "0.1.0"
@@ -2956,6 +3422,10 @@ version = "0.2.0"
 submodule = "extensions/pearish-theme"
 version = "0.0.1"
 
+[pelpsi-night-theme]
+submodule = "extensions/pelpsi-night-theme"
+version = "0.0.2"
+
 [penumbra]
 submodule = "extensions/penumbra"
 version = "0.1.1"
@@ -2964,13 +3434,17 @@ version = "0.1.1"
 submodule = "extensions/penumbra-plus"
 version = "0.0.6"
 
+[peppermint-theme]
+submodule = "extensions/peppermint-theme"
+version = "0.0.1"
+
 [perfect-dusk]
 submodule = "extensions/perfect-dusk"
 version = "1.0.1"
 
 [perl]
 submodule = "extensions/perl"
-version = "0.2.0"
+version = "0.3.0"
 
 [perm]
 submodule = "extensions/perm"
@@ -2996,6 +3470,10 @@ version = "0.0.1"
 submodule = "extensions/phosphor-icons-theme"
 version = "0.0.2"
 
+[phosphor-theme]
+submodule = "extensions/phosphor-theme"
+version = "1.0.0"
+
 [php]
 submodule = "extensions/php"
 version = "0.4.10"
@@ -3006,11 +3484,16 @@ version = "0.1.0"
 
 [phpcs]
 submodule = "extensions/phpcs"
-version = "0.4.1"
+version = "0.4.4"
+
+[phpmago-lsp]
+submodule = "extensions/phpmago-lsp"
+path = "php-mago"
+version = "0.1.0"
 
 [phpmd]
 submodule = "extensions/phpmd"
-version = "0.1.0"
+version = "0.1.4"
 
 [pica200]
 submodule = "extensions/pica200"
@@ -3019,7 +3502,7 @@ version = "0.0.2"
 [pierre-theme]
 submodule = "extensions/pierre-theme"
 path = "zed"
-version = "0.0.23"
+version = "0.0.29"
 
 [pigs-in-space]
 submodule = "extensions/pigs-in-space"
@@ -3029,9 +3512,21 @@ version = "0.1.0"
 submodule = "extensions/pinata-theme"
 version = "0.0.1"
 
+[pink-candy-theme]
+submodule = "extensions/pink-candy-theme"
+version = "0.2.0"
+
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"
 version = "1.3.0"
+
+[pinkzuna-theme]
+submodule = "extensions/pinkzuna-theme"
+version = "1.0.0"
+
+[pioasm]
+submodule = "extensions/pioasm"
+version = "0.0.1"
 
 [pkl]
 submodule = "extensions/pkl"
@@ -3069,6 +3564,10 @@ version = "0.1.0"
 submodule = "extensions/poimandres"
 version = "0.0.4"
 
+[pointer-theme]
+submodule = "extensions/pointer-theme"
+version = "1.0.0"
+
 [polar-context-server]
 submodule = "extensions/polar-context-server"
 version = "0.0.1"
@@ -3079,7 +3578,11 @@ version = "0.8.1"
 
 [pollinations-mcp]
 submodule = "extensions/pollinations-mcp"
-version = "1.0.10"
+version = "1.0.12"
+
+[polycarbonate-dark-theme]
+submodule = "extensions/polycarbonate-dark-theme"
+version = "0.0.2"
 
 [pony]
 submodule = "extensions/pony"
@@ -3097,9 +3600,13 @@ version = "0.0.5"
 submodule = "extensions/postgres-language-server"
 version = "0.1.0"
 
+[postman-context-server]
+submodule = "extensions/postman-context-server"
+version = "0.1.0"
+
 [powershell]
 submodule = "extensions/powershell"
-version = "0.4.2"
+version = "0.4.3"
 
 [prime-dark-theme]
 submodule = "extensions/prime-dark-theme"
@@ -3128,7 +3635,7 @@ version = "0.0.2"
 [proto]
 submodule = "extensions/zed"
 path = "extensions/proto"
-version = "0.3.1"
+version = "0.3.2"
 
 [psalm]
 submodule = "extensions/psalm"
@@ -3136,7 +3643,7 @@ version = "0.0.2"
 
 [pug]
 submodule = "extensions/pug"
-version = "0.0.1"
+version = "0.0.3"
 
 [puppet]
 submodule = "extensions/puppet"
@@ -3150,13 +3657,13 @@ version = "0.0.1"
 submodule = "extensions/purescript"
 version = "0.1.3"
 
-[purr]
-submodule = "extensions/purr"
-version = "0.0.4"
-
 [px-to-rem]
 submodule = "extensions/px-to-rem"
 version = "0.1.0"
+
+[pyatlas-lsp]
+submodule = "extensions/pyatlas-lsp"
+version = "0.1.1"
 
 [pycharm-modern-themes]
 submodule = "extensions/pycharm-modern-themes"
@@ -3173,7 +3680,11 @@ version = "0.0.1"
 [pytest-language-server]
 submodule = "extensions/pytest-language-server"
 path = "extensions/zed-extension"
-version = "0.22.0"
+version = "0.23.0"
+
+[python-autodoc-lsp]
+submodule = "extensions/python-autodoc-lsp"
+version = "0.1.1"
 
 [python-refactoring]
 submodule = "extensions/python-refactoring"
@@ -3181,11 +3692,11 @@ version = "0.0.3"
 
 [python-requirements]
 submodule = "extensions/python-requirements"
-version = "0.0.4"
+version = "0.0.5"
 
 [python-snippets]
 submodule = "extensions/python-snippets"
-version = "0.1.1"
+version = "0.1.3"
 
 [qlik]
 submodule = "extensions/qlik"
@@ -3202,7 +3713,7 @@ path = "distribution/zed"
 
 [quadlet]
 submodule = "extensions/quadlet"
-version = "0.2.3"
+version = "0.4.0"
 
 [quakec]
 submodule = "extensions/quakec"
@@ -3214,7 +3725,7 @@ version = "0.0.1"
 
 [quasi-monochrome]
 submodule = "extensions/quasi-monochrome"
-version = "0.0.1"
+version = "0.0.2"
 
 [qubik-theme]
 submodule = "extensions/qubik-theme"
@@ -3256,9 +3767,18 @@ version = "1.1.0"
 submodule = "extensions/rapture-theme"
 version = "1.0.1"
 
+[rasi]
+submodule = "extensions/rasi"
+version = "0.1.1"
+
 [rcl]
 submodule = "extensions/rcl"
 version = "0.12.0"
+
+[react-component-lens-lsp]
+submodule = "extensions/react-component-lens-lsp"
+path = "packages/zed"
+version = "1.0.5"
 
 [react-snippets]
 submodule = "extensions/react-snippets"
@@ -3296,9 +3816,21 @@ version = "0.11.11"
 submodule = "extensions/rego"
 version = "0.0.2"
 
+[relaxed-theme]
+submodule = "extensions/relaxed-theme"
+version = "0.1.0"
+
 [relay]
 submodule = "extensions/relay"
 version = "0.0.5"
+
+[remedy-theme]
+submodule = "extensions/remedy-theme"
+version = "0.2.0"
+
+[remix-min-darker-theme]
+submodule = "extensions/remix-min-darker-theme"
+version = "0.0.4"
 
 [replicant]
 submodule = "extensions/replicant"
@@ -3306,10 +3838,18 @@ version = "0.0.2"
 
 [rescript]
 submodule = "extensions/rescript"
-version = "0.4.3"
+version = "0.4.4"
+
+[resonance-with-hatsune-miku-theme]
+submodule = "extensions/resonance-with-hatsune-miku-theme"
+version = "0.1.0"
 
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
+version = "0.0.1"
+
+[retropc-theme]
+submodule = "extensions/retropc-theme"
 version = "0.0.1"
 
 [rewrite-theme]
@@ -3333,6 +3873,11 @@ version = "0.0.2"
 submodule = "extensions/riverpod-dart-flutter-snippets"
 version = "0.0.1"
 
+[rlsp-yaml]
+submodule = "extensions/rlsp-yaml"
+path = "rlsp-yaml/integrations/zed"
+version = "0.1.2"
+
 [robot-framework]
 submodule = "extensions/robot-framework"
 version = "0.0.1"
@@ -3341,17 +3886,29 @@ version = "0.0.1"
 submodule = "extensions/roc"
 version = "0.0.6"
 
+[rockide-language-server]
+submodule = "extensions/rockide-language-server"
+version = "0.1.0"
+
 [ron]
 submodule = "extensions/ron"
 version = "0.0.1"
 
+[rose-pine-recast-theme]
+submodule = "extensions/rose-pine-recast-theme"
+version = "0.0.1"
+
 [rose-pine-theme]
 submodule = "extensions/rose-pine-theme"
-version = "1.3.2"
+version = "1.4.0"
 
 [rosevin]
 submodule = "extensions/rosevin"
 version = "0.1.0"
+
+[rosewood-theme]
+submodule = "extensions/rosewood-theme"
+version = "0.0.1"
 
 [roto]
 submodule = "extensions/roto"
@@ -3361,13 +3918,18 @@ version = "0.1.0"
 submodule = "extensions/rover"
 version = "0.1.0"
 
+[rovo-lsp]
+submodule = "extensions/rovo-lsp"
+path = "zed-rovo"
+version = "0.0.1"
+
 [rpmspec]
 submodule = "extensions/rpmspec"
 version = "0.0.1"
 
 [rshtml]
 submodule = "extensions/rshtml"
-version = "0.1.5"
+version = "0.1.6"
 
 [rst]
 submodule = "extensions/rst"
@@ -3375,7 +3937,7 @@ version = "0.0.2"
 
 [ruby]
 submodule = "extensions/ruby"
-version = "0.16.11"
+version = "0.16.13"
 
 [rumdl]
 submodule = "extensions/rumdl"
@@ -3395,11 +3957,15 @@ version = "0.0.4"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
-version = "1.0.3"
+version = "2.0.0"
 
 [sagemath]
 submodule = "extensions/sagemath"
 version = "0.1.0"
+
+[salesforce]
+submodule = "extensions/salesforce"
+version = "0.0.4"
 
 [scala]
 submodule = "extensions/scala"
@@ -3417,13 +3983,21 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.2.0"
 
+[selene-abyss-theme]
+submodule = "extensions/selene-abyss-theme"
+version = "0.0.3"
+
 [semgrep]
 submodule = "extensions/semgrep"
 version = "0.0.2"
 
+[senkai-theme]
+submodule = "extensions/senkai-theme"
+version = "1.0.0"
+
 [sentry-mcp]
 submodule = "extensions/sentry-mcp"
-version = "0.1.1"
+version = "0.1.2"
 
 [seoul256]
 submodule = "extensions/seoul256"
@@ -3449,6 +4023,10 @@ version = "1.0.0"
 submodule = "extensions/serendipity-icons"
 version = "0.0.1"
 
+[sergio-tech-code-black-theme]
+submodule = "extensions/sergio-tech-code-black-theme"
+version = "1.0.0"
+
 [seti-icons]
 submodule = "extensions/seti-icons"
 version = "0.0.1"
@@ -3467,7 +4045,11 @@ version = "0.1.0"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
-version = "0.0.6"
+version = "0.0.7"
+
+[shale-theme]
+submodule = "extensions/shale-theme"
+version = "0.1.0"
 
 [shapels]
 submodule = "extensions/shapels"
@@ -3487,11 +4069,15 @@ version = "0.0.2"
 
 [short-giraffe-theme]
 submodule = "extensions/short-giraffe-theme"
-version = "2.2.0"
+version = "2.2.1"
 
 [sieve]
 submodule = "extensions/sieve"
 version = "0.1.7"
+
+[silverstripe]
+submodule = "extensions/silverstripe"
+version = "0.1.0"
 
 [simple-darker]
 submodule = "extensions/simple-darker"
@@ -3528,7 +4114,11 @@ version = "1.0.1"
 [slint]
 submodule = "extensions/slint"
 path = "editors/zed"
-version = "1.15.1"
+version = "1.16.1"
+
+[slipstream-theme]
+submodule = "extensions/slipstream-theme"
+version = "0.1.0"
 
 [smalisp]
 submodule = "extensions/smalisp"
@@ -3583,6 +4173,10 @@ version = "0.2.0"
 submodule = "extensions/solarized-fp"
 version = "0.0.1"
 
+[solarized-osaka-theme]
+submodule = "extensions/solarized-osaka-theme"
+version = "0.0.1"
+
 [solid-typescript-snippets]
 submodule = "extensions/solid-typescript-snippets"
 version = "0.1.0"
@@ -3593,7 +4187,7 @@ version = "0.2.0"
 
 [soma]
 submodule = "extensions/soma"
-version = "0.5.0"
+version = "0.6.0"
 
 [sonder-theme]
 submodule = "extensions/sonder-theme"
@@ -3602,6 +4196,10 @@ version = "0.1.1"
 [sonokai]
 submodule = "extensions/sonokai"
 version = "0.0.7"
+
+[sora-theme]
+submodule = "extensions/sora-theme"
+version = "0.1.0"
 
 [sorbet]
 submodule = "extensions/sorbet"
@@ -3639,10 +4237,6 @@ version = "0.2.0"
 submodule = "extensions/sqlmesh"
 version = "0.1.4"
 
-[sqruff]
-submodule = "extensions/sqruff"
-version = "0.1.0"
-
 [squirrel]
 submodule = "extensions/squirrel"
 version = "0.1.0"
@@ -3653,7 +4247,7 @@ version = "0.0.3"
 
 [ssh-config]
 submodule = "extensions/ssh-config"
-version = "0.1.0"
+version = "0.2.0"
 
 [stakpak]
 submodule = "extensions/stakpak"
@@ -3689,7 +4283,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "2.0.2"
+version = "3.0.0"
 
 [styx]
 submodule = "extensions/styx"
@@ -3707,6 +4301,10 @@ version = "0.1.15"
 [sumi-light]
 submodule = "extensions/sumi-light"
 version = "0.0.2"
+
+[sunrise-bloom-theme]
+submodule = "extensions/sunrise-bloom-theme"
+version = "0.0.1"
 
 [sunset-drive]
 submodule = "extensions/sunset-drive"
@@ -3726,11 +4324,15 @@ version = "0.1.0"
 
 [superior-green-theme]
 submodule = "extensions/superior-green-theme"
-version = "0.0.10"
+version = "0.0.20"
 
 [supertheme4]
 submodule = "extensions/supertheme4"
 version = "0.0.3"
+
+[surpassone-theme]
+submodule = "extensions/surpassone-theme"
+version = "0.3.5"
 
 [surrealql]
 submodule = "extensions/surrealql"
@@ -3743,6 +4345,11 @@ version = "0.0.1"
 [svelte]
 submodule = "extensions/svelte"
 version = "0.2.11"
+
+[svelte-effect-runtime-language-server]
+submodule = "extensions/svelte-effect-runtime-language-server"
+path = "modules/svelte-effect-runtime-zed"
+version = "2.3.0"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"
@@ -3762,7 +4369,7 @@ version = "0.1.0"
 
 [swift]
 submodule = "extensions/swift"
-version = "0.4.6"
+version = "0.4.9"
 
 [symbols]
 submodule = "extensions/symbols"
@@ -3772,6 +4379,11 @@ version = "1.1.0"
 submodule = "extensions/symposium"
 path = "zed-extension/prod"
 version = "1.3"
+
+[syntaqlite-lsp]
+submodule = "extensions/syntaqlite-lsp"
+path = "integrations/zed"
+version = "0.5.10"
 
 [syntax]
 submodule = "extensions/syntax"
@@ -3812,7 +4424,7 @@ version = "0.6.0"
 
 [tamarin]
 submodule = "extensions/tamarin"
-version = "0.1.0"
+version = "1.12.0"
 
 [tanuki]
 submodule = "extensions/tanuki"
@@ -3821,6 +4433,10 @@ version = "0.0.1"
 [taskfile]
 submodule = "extensions/taskfile"
 version = "0.1.0"
+
+[tbilisi-night]
+submodule = "extensions/tbilisi-night"
+version = "1.0.0"
 
 [tcl]
 submodule = "extensions/tcl"
@@ -3833,7 +4449,7 @@ path = "zed"
 
 [templ]
 submodule = "extensions/templ"
-version = "0.0.9"
+version = "0.0.11"
 
 [templeos-theme]
 submodule = "extensions/templeos-theme"
@@ -3845,11 +4461,11 @@ version = "1.3.0"
 
 [termux]
 submodule = "extensions/termux"
-version = "0.1.2"
+version = "0.1.3"
 
 [terraform]
 submodule = "extensions/terraform"
-version = "0.1.6"
+version = "0.1.8"
 
 [terraform-context-server]
 submodule = "extensions/terraform-context-server"
@@ -3873,7 +4489,7 @@ version = "0.1.0"
 
 [tflint]
 submodule = "extensions/tflint"
-version = "0.1.0"
+version = "0.1.1"
 
 [the-best-theme]
 submodule = "extensions/the-best-theme"
@@ -3915,6 +4531,11 @@ version = "0.0.2"
 submodule = "extensions/tmux"
 version = "0.0.2"
 
+[todo-highlight-language-server]
+submodule = "extensions/todo-highlight-language-server"
+version = "0.2.0"
+path = "extension"
+
 [todotxt]
 submodule = "extensions/todotxt"
 version = "0.2.3"
@@ -3926,20 +4547,24 @@ path = "packages/zed"
 
 [tokyo-night]
 submodule = "extensions/tokyo-night"
-version = "0.7.0"
+version = "0.8.0"
 
 [tokyo-night-dark]
 submodule = "extensions/tokyo-night-dark"
 version = "0.1.0"
 
+[tokyoppuccin-theme]
+submodule = "extensions/tokyoppuccin-theme"
+version = "0.1.0"
+
 [tombi]
 submodule = "extensions/tombi"
 path = "editors/zed"
-version = "0.2.2"
+version = "0.2.4"
 
 [toml]
 submodule = "extensions/toml"
-version = "1.0.2"
+version = "1.0.3"
 
 [tomorrow-min-theme]
 submodule = "extensions/tomorrow-min-theme"
@@ -3957,21 +4582,29 @@ version = "1.2.0"
 submodule = "extensions/ton"
 version = "0.3.1"
 
+[tonel-smalltalk]
+submodule = "extensions/tonel-smalltalk"
+version = "0.1.7"
+
 [toon]
 submodule = "extensions/toon"
 version = "0.0.2"
 
 [tql]
 submodule = "extensions/tql"
-version = "0.2.0"
+version = "0.4.2"
 
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"
 version = "0.1.1"
 
+[triumph-theme]
+submodule = "extensions/triumph-theme"
+version = "0.1.0"
+
 [tron-legacy]
 submodule = "extensions/tron-legacy"
-version = "1.1.7"
+version = "1.2.1"
 
 [ts-macro]
 submodule = "extensions/ts-macro"
@@ -3987,7 +4620,7 @@ version = "0.0.9"
 
 [tsgo]
 submodule = "extensions/tsgo"
-version = "0.0.4"
+version = "0.0.5"
 
 [turtle]
 submodule = "extensions/turtle"
@@ -4003,7 +4636,7 @@ version = "0.1.0"
 
 [txtar]
 submodule = "extensions/txtar"
-version = "0.1.0"
+version = "0.3.0"
 
 [ty]
 submodule = "extensions/ty"
@@ -4023,7 +4656,7 @@ version = "0.0.5"
 
 [typst]
 submodule = "extensions/typst"
-version = "0.1.1"
+version = "0.2.1"
 
 [tyranoscript]
 submodule = "extensions/tyranoscript"
@@ -4039,11 +4672,19 @@ version = "0.0.2"
 
 [ultimate-dark-neo]
 submodule = "extensions/ultimate-dark-neo"
-version = "0.1.0"
+version = "0.2.0"
 
 [ultralytics-snippets]
 submodule = "extensions/ultralytics-snippets"
 version = "0.0.2"
+
+[ultraviolet-theme]
+submodule = "extensions/ultraviolet-theme"
+version = "0.2.0"
+
+[umbra-theme]
+submodule = "extensions/umbra-theme"
+version = "0.1.1"
 
 [umbralkai]
 submodule = "extensions/umbralkai"
@@ -4052,6 +4693,10 @@ version = "0.1.0"
 [umka]
 submodule = "extensions/umka"
 version = "0.0.1"
+
+[umple]
+submodule = "extensions/umple"
+version = "0.1.5"
 
 [underground-theme]
 submodule = "extensions/underground-theme"
@@ -4067,11 +4712,11 @@ version = "0.1.5"
 
 [unison]
 submodule = "extensions/unison"
-version = "0.0.6"
+version = "0.0.9"
 
 [united-gnome]
 submodule = "extensions/united-gnome"
-version = "0.3.1"
+version = "0.5.10"
 
 [unity-snippets]
 submodule = "extensions/unity-snippets"
@@ -4085,13 +4730,17 @@ version = "0.0.5"
 submodule = "extensions/unoflat"
 version = "0.1.4"
 
+[urdf]
+submodule = "extensions/urdf"
+version = "0.1.0"
+
 [usd]
 submodule = "extensions/usd"
 version = "0.1.0"
 
 [utl]
 submodule = "extensions/utl"
-version = "0.1.0"
+version = "0.2.0"
 
 [v]
 submodule = "extensions/v"
@@ -4123,7 +4772,11 @@ version = "0.0.2"
 
 [valt]
 submodule = "extensions/valt"
-version = "1.0.0"
+version = "1.0.1"
+
+[vanta-theme]
+submodule = "extensions/vanta-theme"
+version = "1.0.2"
 
 [vapor-theme]
 submodule = "extensions/vapor-theme"
@@ -4132,6 +4785,10 @@ version = "0.0.2"
 [vcard]
 submodule = "extensions/vcard"
 version = "0.3.0"
+
+[veda-pro-theme]
+submodule = "extensions/veda-pro-theme"
+version = "0.1.1"
 
 [vento]
 submodule = "extensions/vento"
@@ -4147,7 +4804,11 @@ version = "1.0.0"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.16"
+version = "0.0.17"
+
+[version14-theme]
+submodule = "extensions/version14-theme"
+version = "0.1.0"
 
 [veryl]
 submodule = "extensions/veryl"
@@ -4161,6 +4822,10 @@ version = "0.0.2"
 [vesper-blur]
 submodule = "extensions/vesper-blur"
 version = "0.1.1"
+
+[vespertine-theme]
+submodule = "extensions/vespertine-theme"
+version = "0.0.1"
 
 [vhdl]
 submodule = "extensions/vhdl"
@@ -4204,15 +4869,19 @@ version = "0.0.2"
 
 [vitesse-theme-refined]
 submodule = "extensions/vitesse-theme-refined"
-version = "0.4.0"
+version = "0.5.0"
 
 [vitest-snippets]
 submodule = "extensions/vitest-snippets"
 version = "1.0.0"
 
+[vivid-void-theme]
+submodule = "extensions/vivid-void-theme"
+version = "0.0.1"
+
 [vrl]
 submodule = "extensions/vrl"
-version = "0.1.0"
+version = "0.1.1"
 
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
@@ -4234,13 +4903,17 @@ version = "0.0.1"
 submodule = "extensions/vscode-dark-polished"
 version = "0.0.9"
 
+[vscode-dark-siri-custom]
+submodule = "extensions/vscode-dark-siri-custom"
+version = "0.1.0"
+
 [vscode-great-icons]
 submodule = "extensions/vscode-great-icons"
-version = "0.2.7"
+version = "0.2.8"
 
 [vscode-icons]
 submodule = "extensions/vscode-icons"
-version = "12.17.0"
+version = "12.18.0"
 
 [vscode-light-modern]
 submodule = "extensions/vscode-light-modern"
@@ -4252,7 +4925,7 @@ version = "0.0.2"
 
 [vscode-modern]
 submodule = "extensions/vscode-modern"
-version = "0.1.1"
+version = "0.1.2"
 
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
@@ -4260,7 +4933,7 @@ version = "0.0.2"
 
 [vue]
 submodule = "extensions/vue"
-version = "0.3.2"
+version = "0.3.4"
 
 [vue-snippets]
 submodule = "extensions/vue-snippets"
@@ -4316,6 +4989,10 @@ version = "0.0.1"
 submodule = "extensions/webidl"
 version = "0.0.2"
 
+[webstorm-darker-theme]
+submodule = "extensions/webstorm-darker-theme"
+version = "0.0.1"
+
 [wgsl]
 submodule = "extensions/wgsl"
 version = "0.0.1"
@@ -4340,17 +5017,16 @@ version = "0.4.0"
 submodule = "extensions/witchesbrew-theme"
 version = "1.0.0"
 
+[woocommerce-snippets]
+submodule = "extensions/woocommerce-snippets"
+version = "0.1.0"
+
 [wow-toc]
 submodule = "extensions/wow-toc"
 version = "0.0.1"
 
 [wren]
 submodule = "extensions/wren"
-version = "0.0.1"
-
-[wren-lsp]
-submodule = "extensions/wren-lsp"
-path = "editors/zed"
 version = "0.0.1"
 
 [wxml]
@@ -4373,10 +5049,6 @@ version = "0.1.0"
 submodule = "extensions/xml"
 version = "0.1.0"
 
-[xonsh]
-submodule = "extensions/xonsh"
-version = "0.2.0"
-
 [xy-zed]
 submodule = "extensions/xy-zed"
 version = "0.1.4"
@@ -4391,7 +5063,7 @@ version = "0.0.2"
 
 [yang]
 submodule = "extensions/yang"
-version = "0.0.1"
+version = "0.0.2"
 
 [yara]
 submodule = "extensions/yara"
@@ -4420,6 +5092,10 @@ version = "1.2.1"
 [yugen]
 submodule = "extensions/yugen"
 version = "0.0.1"
+
+[yulang]
+submodule = "extensions/yulang"
+version = "0.0.3"
 
 [zabby]
 submodule = "extensions/zabby"
@@ -4467,11 +5143,15 @@ version = "0.0.1"
 
 [zen]
 submodule = "extensions/zen"
-version = "0.0.3"
+version = "0.0.4"
 
 [zen-abyssal]
 submodule = "extensions/zen-abyssal"
 version = "1.4.3"
+
+[zenburn-transparent-theme]
+submodule = "extensions/zenburn-transparent-theme"
+version = "1.0.0"
 
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
@@ -4483,6 +5163,14 @@ version = "0.4.2"
 
 [ziggy]
 submodule = "extensions/ziggy"
+version = "0.0.1"
+
+[zizmor]
+submodule = "extensions/zizmor"
+version = "0.0.1"
+
+[zk]
+submodule = "extensions/zk"
 version = "0.0.1"
 
 [zoegi-theme]


### PR DESCRIPTION
Adds the **imzed** extension providing syntax highlighting and language support for IBM mainframe languages: JCL, COBOL (IBM Enterprise with EXEC SQL/CICS), REXX, and HLASM.

- Repository: https://github.com/Infomanta/imzed
- License: MIT (present at repository root)
- Release: https://github.com/Infomanta/imzed/releases/tag/v0.3.9

### Checklist
- [x] Extension ID (`imzed`) does not contain "zed", "Zed", or "extension" as standalone words
- [x] Extension name (`IBM Mainframe Languages`) does not contain "zed", "Zed", or "extension"
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] Description is in English
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml` in alphabetical order (`pnpm sort-extensions` produces no changes)
- [x] Repository is public with a tagged release (v0.3.9)
- [x] License file present at repository root (MIT)
- [x] Extension tested locally as a dev extension