### PR TITLE
Add imzed — IBM mainframe language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1954,6 +1954,10 @@
 	path = extensions/import-cost-lsp
 	url = https://github.com/gcampes/zed-import-cost.git
 
+[submodule "extensions/imzed"]
+	path = extensions/imzed
+	url = https://github.com/Infomanta/imzed.git
+
 [submodule "extensions/inbedby7pm-theme"]
 	path = extensions/inbedby7pm-theme
 	url = https://github.com/ChocolateNao/inbedby7pm-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1992,6 +1992,10 @@ version = "0.1.2"
 submodule = "extensions/import-cost-lsp"
 version = "0.0.2"
 
+[imzed]
+submodule = "extensions/imzed"
+version = "0.3.9"
+
 [inbedby7pm-theme]
 submodule = "extensions/inbedby7pm-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **imzed** extension providing syntax highlighting and language support for IBM mainframe languages: JCL, COBOL (IBM Enterprise with EXEC SQL/CICS), REXX, and HLASM.

- Repository: https://github.com/Infomanta/imzed
- License: MIT (present at repository root)
- Release: https://github.com/Infomanta/imzed/releases/tag/v0.3.9

### Checklist
- [x] Extension ID (`imzed`) does not contain "zed", "Zed", or "extension" as standalone words
- [x] Extension name (`IBM Mainframe Languages`) does not contain "zed", "Zed", or "extension"
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] Description is in English
- [x] Submodule added via HTTPS URL
- [x] Entry added to `extensions.toml` in alphabetical order (`pnpm sort-extensions` produces no changes)
- [x] Repository is public with a tagged release (v0.3.9)
- [x] License file present at repository root (MIT)
- [x] Extension tested locally as a dev extension