### PR TITLE
Update todo-highlight-language-server to v0.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4529,7 +4529,7 @@ version = "0.0.2"
 
 [todo-highlight-language-server]
 submodule = "extensions/todo-highlight-language-server"
-version = "0.2.0"
+version = "0.2.1"
 path = "extension"
 
 [todotxt]


### PR DESCRIPTION
## Summary
- Updates the `todo-highlight-language-server` extension submodule to `v0.2.1` and bumps its `extensions.toml` version entry.
- This release fixes an install failure on a clean setup: `zed::download_file` writes via `File::create`, which doesn't create missing parent directories, so downloading the bundled `todo-highlight-lsp` binary into `bin/` failed with `No such file or directory` when `bin/` didn't exist yet (shionit/zed-todo-highlight#11).

## Test plan
- [x] `cargo check -p todo-highlight-extension --target wasm32-wasip1` passes in the upstream repo
- [ ] Installed as a dev extension and confirmed the language server downloads and starts on a clean machine