### PR TITLE
Add CfxLua extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -634,6 +634,10 @@
 	path = extensions/cfml
 	url = https://github.com/cfmleditor/zed-cfml.git
 
+[submodule "extensions/cfxlua"]
+	path = extensions/cfxlua
+	url = https://github.com/jxnnyo/zed-cfxlua.git
+
 [submodule "extensions/chai-theme"]
 	path = extensions/chai-theme
 	url = https://github.com/rushabhcodes/zed-chai-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -644,6 +644,10 @@ version = "1.0.5"
 submodule = "extensions/cfml"
 version = "0.2.23"
 
+[cfxlua]
+submodule = "extensions/cfxlua"
+version = "0.1.0"
+
 [chai-theme]
 submodule = "extensions/chai-theme"
 version = "0.0.2"


### PR DESCRIPTION
Adds a CfxLua extension for CitizenFX Lua (FiveM / RedM).

- Syntax highlighting via a fork of tree-sitter-lua that adds the cfx syntax enabled in FiveM's Lua build: compound assignment, safe navigation (`?.` / `?[`), backtick joaat hash literals, C-style `/* */` comments, table-init sugar, and `in` unpacking.
- Auto-configures lua-language-server with the [fivem-lls-addon](https://github.com/overextended/fivem-lls-addon) (FiveM/RedM natives + Citizen runtime types) on first use.

Extension: https://github.com/jxnnyo/zed-cfxlua
Grammar: https://github.com/jxnnyo/tree-sitter-cfxlua