### PR TITLE
Add epitech-header-snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1290,6 +1290,10 @@
 	path = extensions/env
 	url = https://github.com/zarifpour/zed-env
 
+[submodule "extensions/epitech-header-snippets"]
+	path = extensions/epitech-header-snippets
+	url = https://github.com/JordanMar1/epitech-header-snippets.git
+
 [submodule "extensions/erb-snippets"]
 	path = extensions/erb-snippets
 	url = https://github.com/enderahmetyurt/zed-erb-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1312,6 +1312,10 @@ version = "1.1.1"
 submodule = "extensions/env"
 version = "0.0.1"
 
+[epitech-header-snippets]
+submodule = "extensions/epitech-header-snippets"
+version = "1.0.0"
+
 [erb-snippets]
 submodule = "extensions/erb-snippets"
 version = "0.1.0"


### PR DESCRIPTION
## Summary :

- Adds the header used as a norm at the school named epitech for multiple languages with ```$epi``` with the exception of C and C++ where there is two cases: ```$epiC``` for C++ classic header and ```$epiH``` for C++ header with a class builder (usefull for .hpp files) in case of C, we just create the double indentation and the includes

## Languages supported list :
- C
- C++
- CSS
- Elixir
- Go
- Haskell
- HTML
- Java
- Javascript
- Kotlin
- Lua
- Makefile
- OCaml
- PHP
- Python
- Ruby
- Rust
- Shell
- SQL
- TOML
- Typescript
- YAML

## Checklist :
- [x] Extension ID does not contain **"zed"** or **"extension"**
- [x] The HTTPS Submodule was used as URL
- [x] Submodule commit is on a branch
- [x] Added MIT Licence
- [x] ```pnpm sort-extensions``` was run
- [x] Tested Locally with "Install Dev Extension" in Zed