### PR TITLE
Add codefree-agent extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -758,6 +758,10 @@
 	path = extensions/codebuddy
 	url = https://github.com/jasonwang82/codebuddy-code-zed.git
 
+[submodule "extensions/codefree-agent"]
+	path = extensions/codefree-agent
+	url = https://github.com/witchope/zed-codefree-agent.git
+
 [submodule "extensions/codely-theme"]
 	path = extensions/codely-theme
 	url = https://github.com/GOI17/codely-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -770,6 +770,10 @@ version = "0.2.12"
 submodule = "extensions/codebuddy"
 version = "2.19.1"
 
+[codefree-agent]
+submodule = "extensions/codefree-agent"
+version = "0.1.1"
+
 [codely-theme]
 submodule = "extensions/codely-theme"
 version = "0.0.1"


### PR DESCRIPTION
## codefree-agent

Agent server extension for [codefree-o](https://www.npmjs.com/package/@srdcloud/codefree-o) - a software engineering AI assistant by China Telecom.

### Features
- ACP (Agent Communication Protocol) bridge between Zed and codefree-o
- Image routing to @ui-screenshot-analyzer subagent for multimodal support
- YOLO mode (auto-approve all tool calls)
- Question routing (clickable choice buttons via MCP)
- Slash command routing (/skillname triggers skill loading)
- Cross-platform: macOS, Linux, Windows

### Prerequisites
Users need to install codefree-o globally: `npm i -g @srdcloud/codefree-o`

### License
MIT