### PR TITLE
Update apathy-theme to v3.9.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -164,7 +164,7 @@ version = "0.1.0"
 
 [apathy-theme]
 submodule = "extensions/apathy-theme"
-version = "3.8.0"
+version = "3.9.0"
 path = "packages/zed"
 
 [apisartisan]


### PR DESCRIPTION
Automated update of the apathy-theme extension to v3.9.0 (version 3.9.0).