### PR TITLE
Add Neon Context Server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2922,6 +2922,10 @@
 	path = extensions/neon-comfy-soft-themes
 	url = https://github.com/guustavocl/zed-neon-comfy-soft-themes
 
+[submodule "extensions/neon-context-server"]
+	path = extensions/neon-context-server
+	url = https://github.com/peterkyle01/neon-context-server.git
+
 [submodule "extensions/neon-cyberpunk"]
 	path = extensions/neon-cyberpunk
 	url = https://github.com/arunk140/neon-zed-theme
@@ -5117,6 +5121,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/neon-context-server"]
-	path = extensions/neon-context-server
-	url = https://github.com/peterkyle01/neon-context-server.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5117,3 +5117,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/neon-context-server"]
+	path = extensions/neon-context-server
+	url = https://github.com/peterkyle01/neon-context-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2970,6 +2970,10 @@ version = "1.0.0"
 submodule = "extensions/neon-comfy-soft-themes"
 version = "0.1.0"
 
+[neon-context-server]
+submodule = "extensions/neon-context-server"
+version = "0.1.0"
+
 [neon-cyberpunk]
 submodule = "extensions/neon-cyberpunk"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2972,7 +2972,7 @@ version = "0.1.0"
 
 [neon-context-server]
 submodule = "extensions/neon-context-server"
-version = "0.1.0"
+version = "0.1.1"
 
 [neon-cyberpunk]
 submodule = "extensions/neon-cyberpunk"


### PR DESCRIPTION
Adds the Neon Context Server extension: MCP server for Neon serverless Postgres with 10 tools - read-only SQL, schema exploration, project/branch management, EXPLAIN plans, and masked connection strings.

Source: https://github.com/peterkyle01/neon-context-server (pinned to tag v0.1.0).
The server binary is auto-downloaded from GitHub releases (linux-x86_64, macos-arm64, macos-x86_64) via the extension wrapper.

Only NEON_API_KEY is required; project, branch, and database are auto-discovered.

Tested locally as a dev extension against live Neon databases.
