### PR TITLE
Add typo3-fluid extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4586,6 +4586,10 @@
 	path = extensions/typespec
 	url = https://github.com/rhodee/zed-typespec
 
+[submodule "extensions/typo3-fluid"]
+	path = extensions/typo3-fluid
+	url = https://github.com/balatD/zed-typo3-fluid.git
+
 [submodule "extensions/typos"]
 	path = extensions/typos
 	url = https://github.com/BaptisteRoseau/zed-typos.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4664,6 +4664,10 @@ version = "0.1.0"
 submodule = "extensions/typespec"
 version = "0.0.1"
 
+[typo3-fluid]
+submodule = "extensions/typo3-fluid"
+version = "0.0.1"
+
 [typos]
 submodule = "extensions/typos"
 version = "0.0.5"


### PR DESCRIPTION
Adds the **TYPO3 Fluid** extension — language support for the [TYPO3 Fluid](https://docs.typo3.org/permalink/t3coreapi:fluid) templating language.

Repo: https://github.com/balatD/zed-typo3-fluid

Features:
- Syntax highlighting via a dedicated `tree-sitter-fluid` grammar (extends tree-sitter-html) — `{expressions}`, inline ViewHelpers, pipelines, casts, arrays, `{namespace …}`, dynamic tags.
- Snippets, outline and folds.
- A dependency-free Node language server providing ViewHelper completion (tag + inline), hover docs, project-dynamic ViewHelper data (parsed from `typo3 fluid:schema:generate` XSDs, incl. custom ViewHelpers), schema-based type/required validation, live diagnostics via the project's `fluid`/`typo3` binary, and tag auto-closing.

Compliance:
- ID `typo3-fluid` contains no `zed`/`extension`.
- Repo is public; MIT `LICENSE` at the repo root.
- The language server is **not shipped** in the extension — it is downloaded at runtime from the extension repo's GitHub release (`download_file` + `latest_github_release`).
- Submodule uses an HTTPS URL and points at a commit on `main`.
- Ran `sort-extensions`.
- Built and tested locally as a dev extension.
