### PR TITLE
Add eclipsa-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1190,6 +1190,10 @@
 	path = extensions/eclat
 	url = https://github.com/utakotoba/eclat-zed.git
 
+[submodule "extensions/eclipsa-theme"]
+	path = extensions/eclipsa-theme
+	url = https://github.com/yummacss/eclipsa-zed.git
+
 [submodule "extensions/edge"]
 	path = extensions/edge
 	url = https://github.com/Hexacker/zed-edge.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1211,6 +1211,10 @@ version = "1.0.0"
 submodule = "extensions/eclat"
 version = "0.1.0"
 
+[eclipsa-theme]
+submodule = "extensions/eclipsa-theme"
+version = "0.1.0"
+
 [edge]
 submodule = "extensions/edge"
 version = "1.0.1"


### PR DESCRIPTION
Adds the Eclipsa theme extension for Zed.

This PR adds the [eclipsa-theme](https://github.com/yummacss/eclipsa-zed) extension, a variant of the Ariake Dark theme.

- Extension ID: \eclipsa-theme\
- Version: 0.1.0
- Repository: https://github.com/yummacss/eclipsa-zed