### PR TITLE
Add postgres extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3566,6 +3566,10 @@
 	path = extensions/popping-and-locking
 	url = https://github.com/randoneering/popping-and-locking-zed-theme.git
 
+[submodule "extensions/postgres"]
+	path = extensions/postgres
+	url = https://github.com/gmr/zed-postgres.git
+
 [submodule "extensions/postgres-context-server"]
 	path = extensions/postgres-context-server
 	url = https://github.com/zed-extensions/postgres-context-server.git
@@ -5153,6 +5157,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/postgres"]
-	path = extensions/postgres
-	url = https://github.com/gmr/zed-postgres.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5153,3 +5153,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/postgres"]
+	path = extensions/postgres
+	url = https://github.com/gmr/zed-postgres.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3622,6 +3622,10 @@ version = "0.6.1"
 submodule = "extensions/popping-and-locking"
 version = "1.0.3"
 
+[postgres]
+submodule = "extensions/postgres"
+version = "1.0.0"
+
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
 version = "0.0.5"


### PR DESCRIPTION
Adds the **postgres** extension: PostgreSQL and PL/pgSQL syntax highlighting powered by [`tree-sitter-postgres`](https://github.com/gmr/tree-sitter-postgres) (a grammar generated from PostgreSQL's own Bison grammar), plus highlighting of SQL/PL-pgSQL embedded in [`pglifecycle`](https://github.com/gmr/pglifecycle) project YAML.

- Repository: https://github.com/gmr/zed-postgres
- Version: 1.0.0
- Grammars: `postgres`, `plpgsql` (tree-sitter-postgres), and `yaml` (for the pglifecycle injections)

The `pglifecycle` language is selected only via an editor modeline, so it does not claim ordinary `.yaml`/`.yml` files.

- [x] I have tested my extension locally and it builds/compiles.
- [x] The extension id and grammar names do not collide with existing entries (`postgres` was unused).