### PR TITLE
Subliminal Nightfall version bump and extension path

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4330,6 +4330,7 @@ version = "1.1.4"
 
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
+path = "zed"
 version = "0.1.15"
 
 [sumi-light]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4331,7 +4331,7 @@ version = "1.1.4"
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
 path = "zed"
-version = "0.1.15"
+version = "0.1.16"
 
 [sumi-light]
 submodule = "extensions/sumi-light"


### PR DESCRIPTION
## Summary

Adds `path = "zed"` to the `subliminal-nightfall` entry in `extensions.toml` and updates the registry version to `0.1.16`.

The Subliminal Nightfall repository now keeps the Zed extension metadata under the `zed` directory. The source theme repo has also merged the `0.1.16` extension metadata bump in mhamrah/subliminal-nightfall#8.

## Current Status

- Adds `path = "zed"` for the nested Zed extension layout.
- Updates `version = "0.1.16"` to match the latest Subliminal Nightfall Zed metadata.
- mhamrah/subliminal-nightfall#8 fixed the publish workflow so future colorloom-generated theme changes trigger a Zed/Cursor version bump.
- The earlier generated Zed action branch `mhamrah:update-subliminal-nightfall-1781563634` did not open a duplicate PR; it failed because upstream had no existing `subliminal-nightfall` entry to replace until this path fix lands.

## Notes

- No duplicate open `subliminal-nightfall` PR exists.