### PR TITLE
Add GCF (Graph Compact Format) syntax highlighting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1558,6 +1558,10 @@
 	path = extensions/gato-theme
 	url = https://github.com/DCCXXV/gato-zed.git
 
+[submodule "extensions/gcf"]
+	path = extensions/gcf
+	url = https://github.com/blackwell-systems/gcf-zed.git
+
 [submodule "extensions/gcode"]
 	path = extensions/gcode
 	url = https://github.com/ChocolateNao/zed-gcode.git
@@ -5153,6 +5157,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/gcf"]
-	path = extensions/gcf
-	url = https://github.com/blackwell-systems/gcf-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5153,3 +5153,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/gcf"]
+	path = extensions/gcf
+	url = https://github.com/blackwell-systems/gcf-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1584,13 +1584,13 @@ version = "0.2.0"
 submodule = "extensions/gato-theme"
 version = "0.3.0"
 
-[gcode]
-submodule = "extensions/gcode"
-version = "0.0.1"
-
 [gcf]
 submodule = "extensions/gcf"
 version = "0.1.0"
+
+[gcode]
+submodule = "extensions/gcode"
+version = "0.0.1"
 
 [gdscript]
 submodule = "extensions/gdscript"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1588,6 +1588,10 @@ version = "0.3.0"
 submodule = "extensions/gcode"
 version = "0.0.1"
 
+[gcf]
+submodule = "extensions/gcf"
+version = "0.1.0"
+
 [gdscript]
 submodule = "extensions/gdscript"
 version = "0.9.0"


### PR DESCRIPTION
## Summary

Adds syntax highlighting for [GCF (Graph Compact Format)](https://gcformat.com) files.

GCF is a token-optimized wire format for LLM tool responses. Used by [knowing](https://github.com/blackwell-systems/knowing), [agent-lsp](https://github.com/blackwell-systems/agent-lsp), and [bb (Bitbucket CLI)](https://github.com/payfacto/bb).

- Tree-sitter grammar: [blackwell-systems/tree-sitter-gcf](https://github.com/blackwell-systems/tree-sitter-gcf)
- Extension repo: [blackwell-systems/gcf-zed](https://github.com/blackwell-systems/gcf-zed)
- File extension: `.gcf`
- License: MIT