### PR TITLE
Add Tech49 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4402,8 +4402,8 @@
 	path = extensions/tcl
 	url = https://github.com/richnou/kissb-zed-tcl.git
 
-[submodule "extensions/tech49"]
-	path = extensions/tech49
+[submodule "extensions/tech49-theme"]
+	path = extensions/tech49-theme
 	url = https://github.com/timdang/tech49_theme.git
 
 [submodule "extensions/technicolor-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -5153,3 +5153,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/tech49"]
+	path = extensions/tech49
+	url = https://github.com/timdang/tech49_theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4402,6 +4402,10 @@
 	path = extensions/tcl
 	url = https://github.com/richnou/kissb-zed-tcl.git
 
+[submodule "extensions/tech49"]
+	path = extensions/tech49
+	url = https://github.com/timdang/tech49_theme.git
+
 [submodule "extensions/technicolor-theme"]
 	path = extensions/technicolor-theme
 	url = https://github.com/phaux/technicolor.git
@@ -5153,6 +5157,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/tech49"]
-	path = extensions/tech49
-	url = https://github.com/timdang/tech49_theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4476,6 +4476,11 @@ version = "1.0.0"
 submodule = "extensions/tcl"
 version = "0.0.2"
 
+[tech49]
+submodule = "extensions/tech49"
+version = "0.1.0"
+path = "zed"
+
 [technicolor-theme]
 submodule = "extensions/technicolor-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4478,7 +4478,7 @@ version = "0.0.2"
 
 [tech49]
 submodule = "extensions/tech49"
-version = "0.2.0"
+version = "0.2.1"
 path = "zed"
 
 [technicolor-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4476,9 +4476,9 @@ version = "1.0.0"
 submodule = "extensions/tcl"
 version = "0.0.2"
 
-[tech49]
-submodule = "extensions/tech49"
-version = "0.2.1"
+[tech49-theme]
+submodule = "extensions/tech49-theme"
+version = "0.2.2"
 path = "zed"
 
 [technicolor-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4478,7 +4478,7 @@ version = "0.0.2"
 
 [tech49]
 submodule = "extensions/tech49"
-version = "0.1.0"
+version = "0.2.0"
 path = "zed"
 
 [technicolor-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4478,7 +4478,7 @@ version = "0.0.2"
 
 [tech49-theme]
 submodule = "extensions/tech49-theme"
-version = "0.2.2"
+version = "0.2.3"
 path = "zed"
 
 [technicolor-theme]


### PR DESCRIPTION
Adds **Tech49**, a dark color theme inspired by the movie *Oblivion* (ships the "Tower" variant). It's the Zed port of the existing [Tech49 VS Code theme](https://github.com/timdang/tech49_theme).

The extension lives in the `zed/` subdirectory of the source repo (`path = "zed"`), keeping the VS Code and Zed themes in one repo.

Notes:
- `extension.toml` is complete (id, name, version, schema_version, authors, description, repository).
- Submodule is pinned to a tagged release commit (`zed-v0.1.0`).
- The theme JSON validates against the v0.2.0 schema. It has not yet been visually verified in the Zed GUI as a dev extension — happy to address any rendering tweaks reviewers flag.