### PR TITLE
Add excalidraw-preview extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1338,6 +1338,10 @@
 	path = extensions/evolved-theme
 	url = https://github.com/evoL/evolved-theme.git
 
+[submodule "extensions/excalidraw-preview"]
+	path = extensions/excalidraw-preview
+	url = https://github.com/yankeeinlondon/excalidraw-zed-extension.git
+
 [submodule "extensions/exograph"]
 	path = extensions/exograph
 	url = https://github.com/exograph/zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1361,6 +1361,11 @@ submodule = "extensions/evolved-theme"
 path = "dist/zed"
 version = "0.3.0"
 
+[excalidraw-preview]
+submodule = "extensions/excalidraw-preview"
+path = "extension"
+version = "0.4.2"
+
 [exograph]
 submodule = "extensions/exograph"
 version = "0.0.2"


### PR DESCRIPTION
Adds **Excalidraw Preview** (`excalidraw-preview`): previews `.excalidraw`, `.excalidraw.svg`, and `.excalidraw.png` files in a native WebView window with live reload on save, native export save dialogs, and a persistent shape library.

- Repo: https://github.com/yankeeinlondon/excalidraw-zed-extension
- Manifest is in the `extension/` subdirectory (`path = "extension"`).
- The companion native binary is downloaded at runtime from GitHub Releases (`v0.4.2`), not bundled.
- LICENSE present at repo root.

### Re-submission of #6468 — slash-command API removed

This re-opens #6468, which @MrSubidubi closed because the extension exposed `/preview-excalidraw` and `/new-excalidraw` via the slash-command API (reserved for agents). Thank you for that feedback.

Both slash commands have been **removed entirely**. The extension now provides only the `excalidraw-preview` language server, which opens the preview automatically on `didOpen`/`didSave` for `.excalidraw*` files — so the open-preview flow no longer depends on slash commands. The extension's only API surface is `language_server_command`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)