### PR TITLE
Add zed-elsa extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5062,6 +5062,10 @@
 	path = extensions/zed
 	url = https://github.com/zed-industries/zed.git
 
+[submodule "extensions/zed-elsa"]
+	path = extensions/zed-elsa
+	url = https://github.com/MrPoloGit/zed-elsa.git
+
 [submodule "extensions/zed-legacy-themes"]
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1296,6 +1296,10 @@ version = "0.1.0"
 submodule = "extensions/elm"
 version = "0.2.2"
 
+[elsa]
+submodule = "extensions/zed-elsa"
+version = "0.1.0"
+
 [ember]
 submodule = "extensions/ember"
 version = "0.1.0"
@@ -5138,10 +5142,6 @@ version = "0.0.3"
 [zarcula-theme]
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
-
-[zed-elsa]
-submodule = "extensions/zed-elsa"
-version = "0.1.0"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5139,6 +5139,10 @@ version = "0.0.3"
 submodule = "extensions/zarcula-theme"
 version = "0.1.2"
 
+[zed-elsa]
+submodule = "extensions/zed-elsa"
+version = "0.1.0"
+
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"


### PR DESCRIPTION
Adds Elsa (elsa): syntax highlighting and completion for the Elsa (https://github.com/ucsd-progsys/elsa) lambda calculus teaching language (.lc files).

Repo: https://github.com/MrPoloGit/zed-elsa

Tree-sitter grammar: https://github.com/MrPoloGit/tree-sitter-elsa

The companion language server [elsa-lsp](https://github.com/MrPoloGit/elsa-lsp) is downloaded at runtime from GitHub Releases (v0.1.0), not bundled. It provides completion for let bindings defined in the current file.

LICENSE is present at every repo root.