### PR TITLE
Add Elsa language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1274,6 +1274,10 @@
 	path = extensions/elm
 	url = https://github.com/zed-extensions/elm.git
 
+[submodule "extensions/elsa-lang"]
+	path = extensions/elsa-lang
+	url = https://github.com/MrPoloGit/elsa-lang.git
+
 [submodule "extensions/ember"]
 	path = extensions/ember
 	url = https://github.com/jylamont/zed-ember.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1296,6 +1296,10 @@ version = "0.1.0"
 submodule = "extensions/elm"
 version = "0.2.2"
 
+[elsa-lang]
+submodule = "extensions/elsa-lang"
+version = "0.1.0"
+
 [ember]
 submodule = "extensions/ember"
 version = "0.1.0"


### PR DESCRIPTION
Adds Elsa (elsa): syntax highlighting and completion for the Elsa (https://github.com/ucsd-progsys/elsa) lambda calculus teaching language (.lc files).

Repo: https://github.com/MrPoloGit/elsa-lang

Tree-sitter grammar: https://github.com/MrPoloGit/tree-sitter-elsa

The companion language server [elsa-lsp](https://github.com/MrPoloGit/elsa-lsp) is downloaded at runtime from GitHub Releases (v0.1.0), not bundled. It provides completion for let bindings defined in the current file.

LICENSE is present at every repo root.