### PR TITLE
Add Monokai Clarity theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2826,6 +2826,10 @@
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git
 
+[submodule "extensions/monokai-clarity"]
+	path = extensions/monokai-clarity
+	url = https://github.com/quocmffx/monokai-clarity.git
+
 [submodule "extensions/monokai-nebula"]
 	path = extensions/monokai-nebula
 	url = https://github.com/JacobCallahan/monokai-nebula-zed.git
@@ -5153,6 +5157,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/monokai-clarity"]
-	path = extensions/monokai-clarity
-	url = https://github.com/quocmffx/monokai-clarity.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5153,3 +5153,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/monokai-clarity"]
+	path = extensions/monokai-clarity
+	url = https://github.com/quocmffx/monokai-clarity.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2875,6 +2875,10 @@ submodule = "extensions/monochromator-theme"
 path = "editors/zed"
 version = "0.2.2"
 
+[monokai-clarity]
+submodule = "extensions/monokai-clarity"
+version = "0.0.1"
+
 [monokai-nebula]
 submodule = "extensions/monokai-nebula"
 version = "0.2.6"


### PR DESCRIPTION
Adds **Monokai Clarity**, a high-contrast Monokai theme family with a light and a dark variant tuned for all-day readability.

- `Monokai Clarity Light` (day) and `Monokai Clarity Dark` (night), same Monokai hue map.
- All tokens meet WCAG AA against the editor background (most of the dark variant reaches AAA); contrast verified mechanically.
- Repo: https://github.com/quocmffx/monokai-clarity
- License: MIT (at repo root).
- Tested locally via `zed: install dev extension` on real TypeScript / PHP / JavaScript files (both variants).
- Theme id `monokai-clarity` (no "zed"/"extension" in id); `extensions.toml` kept alphabetically sorted.