### PR TITLE
feat: add nand2tetris language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5157,3 +5157,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/nand2tetris"]
+	path = extensions/nand2tetris
+	url = https://github.com/ronketer/nand2tetris-for-Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2967,6 +2967,10 @@ version = "0.0.1"
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"
 
+[nand2tetris]
+submodule = "extensions/nand2tetris"
+version = "0.1.0"
+
 [nanowise]
 submodule = "extensions/nanowise"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the Nand2Tetris language extension. This extension provides syntax highlighting support for the following languages used in the "The Elements of Computing Systems" curriculum:
-  HDL (.hdl)
-  Hack Assembly (.asm)
- Jack (.jack)

Testing:
The extension has been tested locally and verified to provide correct syntax highlighting for all three languages.

License
The extension code includes an MIT license.