### PR TITLE
Update polycarbonate-dark-theme to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3616,7 +3616,7 @@ version = "1.0.12"
 
 [polycarbonate-dark-theme]
 submodule = "extensions/polycarbonate-dark-theme"
-version = "0.0.2"
+version = "0.0.3"
 
 [pony]
 submodule = "extensions/pony"


### PR DESCRIPTION
Update the polycarbonate-dark-theme extension entry to point at the latest upstream commit and bump the catalog version to 0.0.3.