### PR TITLE
Add angular-ng extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -138,6 +138,10 @@
 	path = extensions/angular
 	url = https://github.com/nathansbradshaw/zed-angular.git
 
+[submodule "extensions/angular-ng"]
+	path = extensions/angular-ng
+	url = https://github.com/ArielJMR/zed-angular.git
+
 [submodule "extensions/angular-snippets"]
 	path = extensions/angular-snippets
 	url = https://github.com/hudson-newey/angular-snippets-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -142,6 +142,10 @@ version = "0.1.2"
 submodule = "extensions/angular"
 version = "0.0.5"
 
+[angular-ng]
+submodule = "extensions/angular-ng"
+version = "0.1.0"
+
 [angular-snippets]
 submodule = "extensions/angular-snippets"
 version = "21.0.0"


### PR DESCRIPTION
This adds **angular-ng**, an Angular Language support extension with project-aware version auto-detection.

It is a fork of the existing `angular` extension that addresses a common pain point: the original pins a fixed, modern `@angular/language-server` version, which breaks on projects using older Angular. `angular-ng` instead:

- **Auto-detects the project's Angular version** — it prefers a `@angular/language-server` already installed in the project's `node_modules` (exact match, covers monorepos), otherwise derives a compatible language-server + TypeScript pair from the project's `package.json` (Angular 13 → latest), falling back to a modern default.
- **Forwards the Angular Language Service settings** like the official VSCode extension: feature flags (`forceStrictTemplates`, `autoImports`, snippet/optional-chain completions, suppressed diagnostics), `--angularCoreVersion`, and inlay hints (on by default, configurable via `initialization_options`).

The internal language server name remains `angular`. A separate `id` (`angular-ng`) is used so it does not collide with the existing `angular` entry in the registry.

Repository: https://github.com/ArielJMR/zed-angular
License: MIT