### PR TITLE
Add zed-vertical-viewer extension

### DIFF
--- a/extensions/zed-vertical-viewer/Cargo.toml
+++ b/extensions/zed-vertical-viewer/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "zed-vertical-viewer"
+version = "1.0.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.7.0"

--- a/extensions/zed-vertical-viewer/extension.toml
+++ b/extensions/zed-vertical-viewer/extension.toml
@@ -1,0 +1,16 @@
+id = "zed-vertical-viewer"
+name = "Zed Vertical Viewer"
+description = "A vertical-writing preview window that supports Japanese ruby text."
+version = "1.0.0"
+schema_version = 1
+authors = ["DroicheadNua <mirrorshard.dev@gmail.com>"]
+repository = "https://github.com/DroicheadNua/zed-vertical-viewer"
+
+# Markdownファイルが開かれたら、このLSP（Viewer）を自動起動する
+[language_servers.zed-vertical-viewer]
+languages = ["Markdown"]
+
+[[capabilities]]
+kind = "process:exec"
+command = "zed-vertical-viewer"
+args = ["**"]

--- a/extensions/zed-vertical-viewer/src/lib.rs
+++ b/extensions/zed-vertical-viewer/src/lib.rs
@@ -1,0 +1,30 @@
+use zed_extension_api as zed;
+
+struct ZedVerticalViewerExtension;
+
+impl zed::Extension for ZedVerticalViewerExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    // ZedがMarkdownファイルを開いたときに自動的に呼び出すコマンド
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> zed::Result<zed::Command> {
+        // ユーザーの環境変数（PATH）から "zed-vertical-viewer" の実行ファイルを探索する
+        let path = worktree
+            .which("zed-vertical-viewer")
+            .ok_or_else(|| "Could not find zed-vertical-viewer binary in PATH".to_string())?;
+
+        // 起動コマンドをZed本体に返して、代わりに起動してもらう
+        Ok(zed::Command {
+            command: path,
+            args: vec![],
+            env: worktree.shell_env(),
+        })
+    }
+}
+
+zed::register_extension!(ZedVerticalViewerExtension);


### PR DESCRIPTION
Hello!
I've built zed-vertical-viewer, a Zed extension that previews Markdown files in vertical writing (tategumi) layout with support for Japanese ruby/furigana (Aozora Bunko format). It's aimed at Japanese novelists, writers, and translators who write in Markdown.
The extension runs as a custom LSP for .md files, communicating with a standalone Tauri-based viewer via stdio. The viewer is fully local — no network access, no data leaves the machine.

- Source code: https://github.com/DroicheadNua/zed-vertical-viewer
- Built with: Tauri v2 + Rust + WASM

Happy to make any adjustments needed for review. Thanks for taking a look!