### PR TITLE
Add AdonisJS Routes Goto extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,6 +50,10 @@
 	path = extensions/adech
 	url = https://github.com/adechlien/adech-theme-zed.git
 
+[submodule "extensions/adonisjs-routes-goto"]
+	path = extensions/adonisjs-routes-goto
+	url = https://github.com/wjchoi87-zed-extensions/zed-adonisjs-routes-goto.git
+
 [submodule "extensions/adventurex-theme"]
 	path = extensions/adventurex-theme
 	url = https://github.com/AdventureX-RGE/zed-adventurex-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -50,6 +50,10 @@ version = "0.2.3"
 submodule = "extensions/adech"
 version = "2.0.1"
 
+[adonisjs-routes-goto]
+submodule = "extensions/adonisjs-routes-goto"
+version = "0.2.0"
+
 [adventurex-theme]
 submodule = "extensions/adventurex-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the AdonisJS Routes Goto extension.

## Extension

- Repository: https://github.com/wjchoi87-zed-extensions/zed-adonisjs-routes-goto
- Version: 0.2.0
- Language server package: https://www.npmjs.com/package/@wjchoi87/adonisjs-routes-goto-ls/v/0.2.0

## Testing

- Installed as a Zed dev extension
- Verified route definition navigation in an AdonisJS project
- `cargo check`