### PR TITLE
Add everyapi extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1338,6 +1338,10 @@
 	path = extensions/everforest-theme
 	url = https://github.com/ThomasAlban/everforest-zed.git
 
+[submodule "extensions/everyapi"]
+	path = extensions/everyapi
+	url = https://github.com/everyapi-ai/zed-everyapi.git
+
 [submodule "extensions/evil-rabbit-theme"]
 	path = extensions/evil-rabbit-theme
 	url = https://github.com/kettanaito/zed-theme-evil-rabbit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1360,6 +1360,10 @@ version = "0.1.0"
 submodule = "extensions/everforest-theme"
 version = "0.0.3"
 
+[everyapi]
+submodule = "extensions/everyapi"
+version = "0.1.0"
+
 [evil-rabbit-theme]
 submodule = "extensions/evil-rabbit-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds **EveryAPI** — a context server extension for the Agent Panel that exposes the [EveryAPI](https://everyapi.ai) gateway over MCP: check wallet balance, summarize recent usage, and list the 240+ models available through the gateway. Model chat itself goes through Zed's built-in `language_models.openai_compatible` provider.

- Extension repo: https://github.com/everyapi-ai/zed-everyapi (Rust → WASM, `zed_extension_api`)
- Launches the published MCP server [`@everyapi-ai/mcp`](https://www.npmjs.com/package/@everyapi-ai/mcp) via the bundled Node runtime
- Read-only tools; API key is supplied through the context server `settings` (`api_key`)
