### PR TITLE
Update mjml to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2848,7 +2848,7 @@ path = "distribution/zed"
 
 [mjml]
 submodule = "extensions/mjml"
-version = "0.1.0"
+version = "0.2.0"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"


### PR DESCRIPTION
Bumps the MJML extension from v0.1.0 to v0.2.0.

### Changes in v0.2.0

**Features**
- Hover support
- Completion support (all MJML attribute types)
- Quick fixes for unknown tags and missing attributes
- Snippets

**Bug Fixes**
- Managing multiple versions

Changelog: https://github.com/pataruco/zed-mjml/blob/zed-mjml-v0.2.0/CHANGELOG.md
