### PR TITLE
Update greycat to v0.1.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1760,7 +1760,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.6"
+version = "0.1.7"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
Bumps GreyCat to v0.1.7.

Updates the bundled tree-sitter-greycat grammar (c346a0c): `fn` is now
accepted as an attribute name (`type Foo { fn: String; }`) and as an
object-field key (`Foo { fn: 1 }`), which previously produced parse errors.