### PR TITLE
Update subliminal-nightfall to v0.1.16

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4338,7 +4338,8 @@ version = "1.1.4"
 
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
-version = "0.1.15"
+path = "zed"
+version = "0.1.16"
 
 [sumi-light]
 submodule = "extensions/sumi-light"


### PR DESCRIPTION
## Summary

Updates Subliminal Nightfall to v0.1.16 and fixes the nested extension layout by adding `path = "zed"`.

