### PR TITLE
Add babel-lsp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5161,3 +5161,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/babel-lsp"]
+	path = extensions/babel-lsp
+	url = https://github.com/alex-oleshkevich/babel-lsp

--- a/.gitmodules
+++ b/.gitmodules
@@ -354,6 +354,10 @@
 	path = extensions/azutiku-theme
 	url = https://github.com/bwind/zed-azutiku-theme.git
 
+[submodule "extensions/babel-lsp"]
+	path = extensions/babel-lsp
+	url = https://github.com/alex-oleshkevich/babel-lsp
+
 [submodule "extensions/bamboo-theme"]
 	path = extensions/bamboo-theme
 	url = https://github.com/LoamStudios/zed-bamboo-theme
@@ -5161,6 +5165,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/babel-lsp"]
-	path = extensions/babel-lsp
-	url = https://github.com/alex-oleshkevich/babel-lsp

--- a/extensions.toml
+++ b/extensions.toml
@@ -365,6 +365,11 @@ version = "0.1.0"
 submodule = "extensions/bamboo-theme"
 version = "0.1.0"
 
+[babel-lsp]
+submodule = "extensions/babel-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [baml]
 submodule = "extensions/baml"
 version = "0.222.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -361,13 +361,13 @@ version = "1.0.0"
 submodule = "extensions/azutiku-theme"
 version = "0.1.0"
 
-[bamboo-theme]
-submodule = "extensions/bamboo-theme"
-version = "0.1.0"
-
 [babel-lsp]
 submodule = "extensions/babel-lsp"
 path = "editors/zed"
+version = "0.1.0"
+
+[bamboo-theme]
+submodule = "extensions/bamboo-theme"
 version = "0.1.0"
 
 [baml]


### PR DESCRIPTION
Adds [babel-lsp](https://github.com/alex-oleshkevich/babel-lsp), a language server for Python Babel i18n workflows.

It provides diagnostics, completions, and hover info for `.po`/`.pot` translation catalogs.

Tested locally as a dev extension in Zed.