### PR TITLE
Add fastapi-lsp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1374,6 +1374,10 @@
 	path = extensions/fantasticons-icons-theme
 	url = https://github.com/caiolandgraf/fantasticons-zed.git
 
+[submodule "extensions/fastapi-lsp"]
+	path = extensions/fastapi-lsp
+	url = https://github.com/alex-oleshkevich/fastapi-lsp
+
 [submodule "extensions/fastapi-snippets"]
 	path = extensions/fastapi-snippets
 	url = https://github.com/NarmadaWeb/fastapi-snippets-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1397,6 +1397,11 @@ version = "1.0.10"
 submodule = "extensions/fantasticons-icons-theme"
 version = "1.0.0"
 
+[fastapi-lsp]
+submodule = "extensions/fastapi-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
 version = "0.2.0"


### PR DESCRIPTION
Adds [fastapi-lsp](https://github.com/alex-oleshkevich/fastapi-lsp), a language server for FastAPI and Starlette.

Provides diagnostics, completions, and hover for Python, HTML, and Jinja2 files.

Tested locally as a dev extension in Zed.