### PR TITLE
Add one-dark-pro-night-flat theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3250,6 +3250,10 @@
 	path = extensions/one-dark-pro-monokai-darker
 	url = https://github.com/9ssi7/zed-one-dark-pro-monokai-darker.git
 
+[submodule "extensions/one-dark-pro-night-flat"]
+	path = extensions/one-dark-pro-night-flat
+	url = https://github.com/LaurenceRawlings/zed-one-dark-pro-night-flat.git
+
 [submodule "extensions/one-dark-pro-vivid-theme"]
 	path = extensions/one-dark-pro-vivid-theme
 	url = https://github.com/navinpeiris/zed-one-dark-pro-vivid.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3301,6 +3301,10 @@ version = "0.0.2"
 submodule = "extensions/one-dark-pro-monokai-darker"
 version = "0.1.1"
 
+[one-dark-pro-night-flat]
+submodule = "extensions/one-dark-pro-night-flat"
+version = "1.0.0"
+
 [one-dark-pro-vivid-theme]
 submodule = "extensions/one-dark-pro-vivid-theme"
 version = "0.3.0"


### PR DESCRIPTION
## Summary

Adds the **OneDark Pro Night Flat** theme for Zed, a theme ported from [One Dark Pro](https://github.com/Binaryify/OneDark-Pro).

- **Extension id:** `one-dark-pro-night-flat`
- **Repository:** https://github.com/LaurenceRawlings/zed-one-dark-pro-night-flat

## Checklist

- [x] Extension has `extension.toml` with valid metadata
- [x] Theme JSON follows the Zed theme schema
- [x] MIT license included in the extension repository
- [x] Submodule added under `extensions/one-dark-pro-night-flat` and registered in `extensions.toml`
- [x] `extensions.toml` and `.gitmodules` sorted via `pnpm sort-extensions`
- [x] Tested locally as a dev extension

## Note

The `-theme` suffix for the id was left out to match the other theme extensions surrounding it in `extensions.toml`. This can be added if required.
