### PR TITLE
Add VSCode Dark+ Themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4862,6 +4862,9 @@
 	path = extensions/vscode-dark-plus
 	url = https://github.com/d1y/vscode_dark_plus.zed.git
 
+[submodule "extensions/vscode-dark-plus-themes"]
+	path = extensions/vscode-dark-plus-themes
+	url = https://github.com/LordMikkel/vscode-dark-plus-themes.git
 [submodule "extensions/vscode-dark-polished"]
 	path = extensions/vscode-dark-polished
 	url = https://github.com/yayashn/vscode-dark-polished.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4865,6 +4865,7 @@
 [submodule "extensions/vscode-dark-plus-themes"]
 	path = extensions/vscode-dark-plus-themes
 	url = https://github.com/LordMikkel/vscode-dark-plus-themes.git
+
 [submodule "extensions/vscode-dark-polished"]
 	path = extensions/vscode-dark-polished
 	url = https://github.com/yayashn/vscode-dark-polished.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4941,6 +4941,10 @@ version = "0.1.2"
 submodule = "extensions/vscode-dark-plus"
 version = "0.0.1"
 
+[vscode-dark-plus-themes]
+submodule = "extensions/vscode-dark-plus-themes"
+version = "0.1.0"
+
 [vscode-dark-polished]
 submodule = "extensions/vscode-dark-polished"
 version = "0.0.9"


### PR DESCRIPTION
Adds my VSCode Dark+ Themes extension.

Repo: [https://github.com/LordMikkel/vscode-dark-plus-themes](https://github.com/LordMikkel/vscode-dark-plus-themes)

It includes VSCode Dark+ and VSCode Dark Modern+.