### PR TITLE
Update perl to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3482,7 +3482,7 @@ version = "1.0.1"
 
 [perl]
 submodule = "extensions/perl"
-version = "0.3.0"
+version = "0.4.0"
 
 [perm]
 submodule = "extensions/perm"


### PR DESCRIPTION
Bumps the Perl extension to `0.4.0`.

Changes since `0.3.0`:
- **Opt-in `perl-lsp` language server** — an alternative to Perl Navigator ([perl-lsp](https://github.com/tree-sitter-perl/perl-tree-sitter-lsp)). It stays dormant unless the user opts in (PATH binary via `cargo install perl-lsp`, or an explicit `download` setting), so existing Perl Navigator users are unaffected.
- **Text objects** — Perl tree-sitter text objects for functions (subs/methods), classes (block `package`/`class`), and comments.
- Bumps `zed_extension_api` to 0.7.0.

Submodule `extensions/perl` updated `0187d62` → `eb27a19` (https://github.com/tree-sitter-perl/zed-perl).

🤖 Generated with [Claude Code](https://claude.com/claude-code)