### PR TITLE
Add CodeTime extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -786,6 +786,10 @@
 	path = extensions/codestackr
 	url = https://github.com/Pjort/codestackr-zed.git
 
+[submodule "extensions/codetime"]
+	path = extensions/codetime
+	url = https://github.com/codetime-dev/codetime-zed.git
+
 [submodule "extensions/coffeescript"]
 	path = extensions/coffeescript
 	url = https://github.com/svkozak/coffeescript-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 
 [1984-theme]
 submodule = "extensions/1984-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"
@@ -28,7 +28,7 @@ version = "0.1.1"
 
 [activitywatch]
 submodule = "extensions/activitywatch"
-version = "0.1.3"
+version = "0.1.4"
 
 [ad-astra-theme]
 submodule = "extensions/ad-astra-theme"
@@ -132,11 +132,11 @@ version = "0.3.2"
 
 [amber-monochrome-monitor-crt-phosphor]
 submodule = "extensions/amber-monochrome-monitor-crt-phosphor"
-version = "0.1.3"
+version = "0.1.4"
 
 [andromeda]
 submodule = "extensions/andromeda"
-version = "0.1.3"
+version = "0.1.4"
 
 [angular]
 submodule = "extensions/angular"
@@ -375,7 +375,7 @@ version = "1.3.1"
 
 [base16]
 submodule = "extensions/base16"
-version = "0.1.3"
+version = "0.1.4"
 
 [basher]
 submodule = "extensions/basher"
@@ -391,7 +391,7 @@ version = "0.0.1"
 
 [beancount]
 submodule = "extensions/beancount"
-version = "0.1.3"
+version = "0.1.4"
 
 [beanseeds-pro]
 submodule = "extensions/beanseeds-pro"
@@ -451,7 +451,7 @@ version = "0.1.0"
 
 [blackrain-theme]
 submodule = "extensions/blackrain-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [blackula]
 submodule = "extensions/blackula"
@@ -686,7 +686,7 @@ version = "0.10.0"
 
 [chatgpt]
 submodule = "extensions/chatgpt"
-version = "0.1.3"
+version = "0.1.4"
 
 [chawyehsu-vscode-icons]
 submodule = "extensions/chawyehsu-vscode-icons"
@@ -800,7 +800,7 @@ version = "0.0.1"
 
 [codetime]
 submodule = "extensions/codetime"
-version = "0.1.3"
+version = "0.1.4"
 
 [coffeescript]
 submodule = "extensions/coffeescript"
@@ -1346,7 +1346,7 @@ version = "0.2.1"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [eva-theme]
 submodule = "extensions/eva-theme"
@@ -1379,7 +1379,7 @@ version = "0.0.2"
 
 [exquisite]
 submodule = "extensions/exquisite"
-version = "0.1.3"
+version = "0.1.4"
 
 [eyecandy]
 submodule = "extensions/eyecandy"
@@ -1572,7 +1572,7 @@ version = "1.0.0"
 
 [furina-vibe-theme]
 submodule = "extensions/furina-vibe-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [gafelson]
 submodule = "extensions/gafelson"
@@ -1748,7 +1748,7 @@ version = "0.2.1"
 
 [green-monochrome-monitor-crt-phosphor]
 submodule = "extensions/green-monochrome-monitor-crt-phosphor"
-version = "0.1.3"
+version = "0.1.4"
 
 [green-theme]
 submodule = "extensions/green-theme"
@@ -1917,7 +1917,7 @@ version = "0.2.0"
 
 [hledger]
 submodule = "extensions/hledger"
-version = "0.1.3"
+version = "0.1.4"
 
 [hlsl]
 submodule = "extensions/hlsl"
@@ -2014,7 +2014,7 @@ version = "0.0.1"
 
 [immigrant]
 submodule = "extensions/immigrant"
-version = "0.1.3"
+version = "0.1.4"
 
 [import-cost-lsp]
 submodule = "extensions/import-cost-lsp"
@@ -2026,7 +2026,7 @@ version = "0.1.0"
 
 [indigo]
 submodule = "extensions/indigo"
-version = "0.1.3"
+version = "0.1.4"
 
 [inform6]
 submodule = "extensions/inform6"
@@ -2067,7 +2067,7 @@ version = "1.1.3"
 
 [ion]
 submodule = "extensions/ion"
-version = "0.1.3"
+version = "0.1.4"
 
 [ir-black]
 submodule = "extensions/ir-black"
@@ -2099,7 +2099,7 @@ version = "0.0.5"
 
 [jai]
 submodule = "extensions/jai"
-version = "0.1.3"
+version = "0.1.4"
 
 [janet]
 submodule = "extensions/janet"
@@ -2224,7 +2224,7 @@ version = "0.0.1"
 
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
-version = "0.1.3"
+version = "0.1.4"
 
 [kanagawa-wave-blur-theme]
 submodule = "extensions/kanagawa-wave-blur-theme"
@@ -2505,7 +2505,7 @@ version = "0.0.1"
 
 [mangoes]
 submodule = "extensions/mangoes"
-version = "0.1.3"
+version = "0.1.4"
 
 [mantle-theme]
 submodule = "extensions/mantle-theme"
@@ -2674,7 +2674,7 @@ version = "0.1.0"
 
 [mcp-server-grafana]
 submodule = "extensions/mcp-server-grafana"
-version = "0.1.3"
+version = "0.1.4"
 
 [mcp-server-markitdown]
 submodule = "extensions/mcp-server-markitdown"
@@ -2921,7 +2921,7 @@ version = "0.0.4"
 
 [monosami]
 submodule = "extensions/monosami"
-version = "0.1.3"
+version = "0.1.4"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
@@ -2973,7 +2973,7 @@ version = "0.0.1"
 
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
-version = "0.1.3"
+version = "0.1.4"
 
 [nanowise]
 submodule = "extensions/nanowise"
@@ -3384,7 +3384,7 @@ version = "0.4.7"
 
 [oxocarbon]
 submodule = "extensions/oxocarbon"
-version = "0.1.3"
+version = "0.1.4"
 
 [p4]
 submodule = "extensions/p4"
@@ -3596,7 +3596,7 @@ version = "0.0.1"
 
 [playdate]
 submodule = "extensions/playdate"
-version = "0.1.3"
+version = "0.1.4"
 
 [po]
 submodule = "extensions/po"
@@ -3668,7 +3668,7 @@ version = "0.0.1"
 
 [processing]
 submodule = "extensions/processing"
-version = "0.1.3"
+version = "0.1.4"
 
 [prolog]
 submodule = "extensions/prolog"
@@ -3697,7 +3697,7 @@ version = "0.0.1"
 
 [purescript]
 submodule = "extensions/purescript"
-version = "0.1.3"
+version = "0.1.4"
 
 [px-to-rem]
 submodule = "extensions/px-to-rem"
@@ -3738,7 +3738,7 @@ version = "0.0.5"
 
 [python-snippets]
 submodule = "extensions/python-snippets"
-version = "0.1.3"
+version = "0.1.4"
 
 [qlik]
 submodule = "extensions/qlik"
@@ -3922,7 +3922,7 @@ version = "0.0.1"
 [rlsp-yaml]
 submodule = "extensions/rlsp-yaml"
 path = "rlsp-yaml/integrations/zed"
-version = "0.1.3"
+version = "0.1.4"
 
 [robot-framework]
 submodule = "extensions/robot-framework"
@@ -4043,7 +4043,7 @@ version = "1.0.0"
 
 [sentry-mcp]
 submodule = "extensions/sentry-mcp"
-version = "0.1.3"
+version = "0.1.4"
 
 [seoul256]
 submodule = "extensions/seoul256"
@@ -4189,7 +4189,7 @@ version = "0.1.0"
 
 [snazzy]
 submodule = "extensions/snazzy"
-version = "0.1.3"
+version = "0.1.4"
 
 [snazzy-light]
 submodule = "extensions/snazzy-light"
@@ -4507,7 +4507,7 @@ version = "1.3.0"
 
 [termux]
 submodule = "extensions/termux"
-version = "0.1.3"
+version = "0.1.4"
 
 [terraform]
 submodule = "extensions/terraform"
@@ -4710,7 +4710,7 @@ version = "0.1.0"
 
 [ucode]
 submodule = "extensions/ucode"
-version = "0.1.3"
+version = "0.1.4"
 
 [uiua]
 submodule = "extensions/uiua"
@@ -4939,7 +4939,7 @@ version = "1.0.0"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.1.3"
+version = "0.1.4"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"
@@ -4971,7 +4971,7 @@ version = "0.0.2"
 
 [vscode-modern]
 submodule = "extensions/vscode-modern"
-version = "0.1.3"
+version = "0.1.4"
 
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
@@ -5149,7 +5149,7 @@ version = "0.0.3"
 
 [zarcula-theme]
 submodule = "extensions/zarcula-theme"
-version = "0.1.3"
+version = "0.1.4"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -800,7 +800,7 @@ version = "0.0.1"
 
 [codetime]
 submodule = "extensions/codetime"
-version = "0.1.1"
+version = "0.1.2"
 
 [coffeescript]
 submodule = "extensions/coffeescript"

--- a/extensions.toml
+++ b/extensions.toml
@@ -28,7 +28,7 @@ version = "0.1.1"
 
 [activitywatch]
 submodule = "extensions/activitywatch"
-version = "0.1.2"
+version = "0.1.3"
 
 [ad-astra-theme]
 submodule = "extensions/ad-astra-theme"
@@ -136,7 +136,7 @@ version = "0.1.3"
 
 [andromeda]
 submodule = "extensions/andromeda"
-version = "0.1.2"
+version = "0.1.3"
 
 [angular]
 submodule = "extensions/angular"
@@ -375,7 +375,7 @@ version = "1.3.1"
 
 [base16]
 submodule = "extensions/base16"
-version = "0.1.2"
+version = "0.1.3"
 
 [basher]
 submodule = "extensions/basher"
@@ -391,7 +391,7 @@ version = "0.0.1"
 
 [beancount]
 submodule = "extensions/beancount"
-version = "0.1.2"
+version = "0.1.3"
 
 [beanseeds-pro]
 submodule = "extensions/beanseeds-pro"
@@ -800,7 +800,7 @@ version = "0.0.1"
 
 [codetime]
 submodule = "extensions/codetime"
-version = "0.1.2"
+version = "0.1.3"
 
 [coffeescript]
 submodule = "extensions/coffeescript"
@@ -1346,7 +1346,7 @@ version = "0.2.1"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
-version = "0.1.2"
+version = "0.1.3"
 
 [eva-theme]
 submodule = "extensions/eva-theme"
@@ -1572,7 +1572,7 @@ version = "1.0.0"
 
 [furina-vibe-theme]
 submodule = "extensions/furina-vibe-theme"
-version = "0.1.2"
+version = "0.1.3"
 
 [gafelson]
 submodule = "extensions/gafelson"
@@ -2014,7 +2014,7 @@ version = "0.0.1"
 
 [immigrant]
 submodule = "extensions/immigrant"
-version = "0.1.2"
+version = "0.1.3"
 
 [import-cost-lsp]
 submodule = "extensions/import-cost-lsp"
@@ -2026,7 +2026,7 @@ version = "0.1.0"
 
 [indigo]
 submodule = "extensions/indigo"
-version = "0.1.2"
+version = "0.1.3"
 
 [inform6]
 submodule = "extensions/inform6"
@@ -2067,7 +2067,7 @@ version = "1.1.3"
 
 [ion]
 submodule = "extensions/ion"
-version = "0.1.2"
+version = "0.1.3"
 
 [ir-black]
 submodule = "extensions/ir-black"
@@ -2224,7 +2224,7 @@ version = "0.0.1"
 
 [kanagawa-themes]
 submodule = "extensions/kanagawa-themes"
-version = "0.1.2"
+version = "0.1.3"
 
 [kanagawa-wave-blur-theme]
 submodule = "extensions/kanagawa-wave-blur-theme"
@@ -2505,7 +2505,7 @@ version = "0.0.1"
 
 [mangoes]
 submodule = "extensions/mangoes"
-version = "0.1.2"
+version = "0.1.3"
 
 [mantle-theme]
 submodule = "extensions/mantle-theme"
@@ -2674,7 +2674,7 @@ version = "0.1.0"
 
 [mcp-server-grafana]
 submodule = "extensions/mcp-server-grafana"
-version = "0.1.2"
+version = "0.1.3"
 
 [mcp-server-markitdown]
 submodule = "extensions/mcp-server-markitdown"
@@ -2973,7 +2973,7 @@ version = "0.0.1"
 
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
-version = "0.1.2"
+version = "0.1.3"
 
 [nanowise]
 submodule = "extensions/nanowise"
@@ -3596,7 +3596,7 @@ version = "0.0.1"
 
 [playdate]
 submodule = "extensions/playdate"
-version = "0.1.2"
+version = "0.1.3"
 
 [po]
 submodule = "extensions/po"
@@ -3668,7 +3668,7 @@ version = "0.0.1"
 
 [processing]
 submodule = "extensions/processing"
-version = "0.1.2"
+version = "0.1.3"
 
 [prolog]
 submodule = "extensions/prolog"
@@ -3922,7 +3922,7 @@ version = "0.0.1"
 [rlsp-yaml]
 submodule = "extensions/rlsp-yaml"
 path = "rlsp-yaml/integrations/zed"
-version = "0.1.2"
+version = "0.1.3"
 
 [robot-framework]
 submodule = "extensions/robot-framework"
@@ -4043,7 +4043,7 @@ version = "1.0.0"
 
 [sentry-mcp]
 submodule = "extensions/sentry-mcp"
-version = "0.1.2"
+version = "0.1.3"
 
 [seoul256]
 submodule = "extensions/seoul256"
@@ -4939,7 +4939,7 @@ version = "1.0.0"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.1.2"
+version = "0.1.3"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"
@@ -4971,7 +4971,7 @@ version = "0.0.2"
 
 [vscode-modern]
 submodule = "extensions/vscode-modern"
-version = "0.1.2"
+version = "0.1.3"
 
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
@@ -5149,7 +5149,7 @@ version = "0.0.3"
 
 [zarcula-theme]
 submodule = "extensions/zarcula-theme"
-version = "0.1.2"
+version = "0.1.3"
 
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"

--- a/extensions.toml
+++ b/extensions.toml
@@ -798,6 +798,10 @@ version = "0.0.6"
 submodule = "extensions/codestackr"
 version = "0.0.1"
 
+[codetime]
+submodule = "extensions/codetime"
+version = "0.1.1"
+
 [coffeescript]
 submodule = "extensions/coffeescript"
 version = "0.0.1"


### PR DESCRIPTION
Adds CodeTime (https://codetime.dev) coding-time tracking, ported from the existing VS Code extension.

Zed extensions can't hook editor events directly, so this works through a language server (codetime-ls) that turns document open/change/save into events and posts them to the CodeTime API. The server binary is downloaded from the repo's GitHub releases, not bundled.

Repo: https://github.com/codetime-dev/codetime-zed