### PR TITLE
Add CodeTrackr language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4334,6 +4334,10 @@
 	path = extensions/svelte-snippets
 	url = https://github.com/bobbymannino/svelte-snippets-for-zed.git
 
+[submodule "extensions/svg"]
+	path = extensions/svg
+	url = https://github.com/livrasand/zed-svg.git
+
 [submodule "extensions/sway"]
 	path = extensions/sway
 	url = https://github.com/FuelLabs/sway-zed-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4334,10 +4334,6 @@
 	path = extensions/svelte-snippets
 	url = https://github.com/bobbymannino/svelte-snippets-for-zed.git
 
-[submodule "extensions/svg"]
-	path = extensions/svg
-	url = https://github.com/livrasand/zed-svg.git
-
 [submodule "extensions/sway"]
 	path = extensions/sway
 	url = https://github.com/FuelLabs/sway-zed-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -786,6 +786,10 @@
 	path = extensions/codestackr
 	url = https://github.com/Pjort/codestackr-zed.git
 
+[submodule "extensions/codetrackr"]
+	path = extensions/codetrackr
+	url = https://github.com/livrasand/codetrackr-zed.git
+
 [submodule "extensions/coffeescript"]
 	path = extensions/coffeescript
 	url = https://github.com/svkozak/coffeescript-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4405,10 +4405,6 @@ version = "0.1.1"
 submodule = "extensions/svelte-snippets"
 version = "0.0.9"
 
-[svg]
-submodule = "extensions/svg"
-version = "0.1.0"
-
 [sway]
 submodule = "extensions/sway"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -798,6 +798,10 @@ version = "0.0.6"
 submodule = "extensions/codestackr"
 version = "0.0.1"
 
+[codetrackr]
+submodule = "extensions/codetrackr"
+version = "1.0.0"
+
 [coffeescript]
 submodule = "extensions/coffeescript"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4405,6 +4405,10 @@ version = "0.1.1"
 submodule = "extensions/svelte-snippets"
 version = "0.0.9"
 
+[svg]
+submodule = "extensions/svg"
+version = "0.1.0"
+
 [sway]
 submodule = "extensions/sway"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -801,7 +801,7 @@ version = "0.0.1"
 
 [codetrackr]
 submodule = "extensions/codetrackr"
-version = "1.0.0"
+version = "1.0.1"
 
 [coffeescript]
 submodule = "extensions/coffeescript"


### PR DESCRIPTION
This PR adds a new extension to the Zed ecosystem: **CodeTrackr**.

---

CodeTrackr is an open-source coding time tracker and developer analytics tool that automatically tracks your coding activity and provides insights into your language usage, projects, and productivity. It works across multiple editors (Zed, VS Code, Cursor, Windsurf, JetBrains, and more) with a unified dashboard at [codetrackr.fly.dev](https://codetrackr.fly.dev/).

* **Repository**: [github.com/livrasand/codetrackr-zed](https://github.com/livrasand/codetrackr-zed)
* **Language Server**: Implements a custom LSP for tracking activity across all supported languages.
* **Configuration**: Supports both environment variables (`CODETRACKR_API_KEY`, `CODETRACKR_BASE_URL`) and native Zed settings.

The extension have been tested and verified on macOS.