### PR TITLE
Update phpmd to v0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3531,7 +3531,7 @@ version = "0.1.0"
 
 [phpmd]
 submodule = "extensions/phpmd"
-version = "0.1.4"
+version = "0.1.5"
 
 [pica200]
 submodule = "extensions/pica200"


### PR DESCRIPTION
Bumps `phpmd` to v0.1.5.

Release notes: https://github.com/mike-bronner/zed-phpmd-lsp/releases/tag/0.1.5