### PR TITLE
Add croma-abc language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -866,6 +866,10 @@
 	path = extensions/crimson-theme
 	url = https://github.com/kaem-e/zed-crimson-theme.git
 
+[submodule "extensions/croma-abc"]
+	path = extensions/croma-abc
+	url = https://github.com/ro-ag/croma.git
+
 [submodule "extensions/crystal"]
 	path = extensions/crystal
 	url = https://github.com/crystal-lang-tools/zed-crystal.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -881,6 +881,11 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.4"
 
+[croma-abc]
+submodule = "extensions/croma-abc"
+path = "editors/zed"
+version = "1.0.0"
+
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"

--- a/extensions.toml
+++ b/extensions.toml
@@ -995,14 +995,14 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.5"
 
-[cron-sense-lsp]
-submodule = "extensions/cron-sense-lsp"
-version = "0.3.0"
-
 [croma-abc]
 submodule = "extensions/croma-abc"
 path = "editors/zed"
 version = "1.0.0"
+
+[cron-sense-lsp]
+submodule = "extensions/cron-sense-lsp"
+version = "0.3.0"
 
 [crystal]
 submodule = "extensions/crystal"


### PR DESCRIPTION
Adds **croma ABC** — ABC music notation support backed by [croma](https://github.com/ro-ag/croma) (Apache-2.0).

- **Grammar:** the reusable `tree-sitter-abc` grammar (highlighting, folds, brackets, Markdown ```abc injection).
- **Language server:** `croma-lsp` (diagnostics, formatting, semantic tokens, symbols, hover, completion, code actions), auto-downloaded from the croma GitHub Release.
- Submodule pinned to `v1.0.0`/`v1.0.1` (`croma-abc` extension v1.0.0); extension lives at `editors/zed`.
- Licensed Apache-2.0; tested locally as a dev extension.