### PR TITLE
Add restcraft extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5161,3 +5161,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/restcraft"]
+	path = extensions/restcraft
+	url = https://github.com/jidohyun/restcraft.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3886,6 +3886,10 @@ version = "0.4.4"
 submodule = "extensions/resonance-with-hatsune-miku-theme"
 version = "0.1.0"
 
+[restcraft]
+submodule = "extensions/restcraft"
+version = "0.1.0"
+
 [retrofit-theme]
 submodule = "extensions/retrofit-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds **restcraft** — a REST client for Zed that sends HTTP requests directly from `.http` / `.rest` files.

Unlike the existing highlighting-only `.http` extensions, restcraft actually **executes** requests through a native LSP server, surfacing the trigger as a standard **"Send Request" code lens + code action** (no extension command API is used — only standard LSP features, so it works within the current extension capabilities).

### Features
- Send / re-send requests via LSP code lens (`"code_lens": "on"`) and code actions
- Variable substitution: file variables, environments (`http-client.env.json` with `$shared`), and system variables (`{{$guid}}`, `{{$timestamp}}`, `{{$datetime}}`, `{{$processEnv}}`, `{{$dotenv}}`, …)
- Request variable chaining (`{{name.response.body.$.field}}`)
- Completion, hover, and diagnostics for variables
- Basic & Digest auth, persistent cookie jar
- cURL import (run `curl` blocks) and "Copy Request as cURL" export
- Request history
- GraphQL and external-file request bodies
- A dedicated **HTTP Response** language so responses open as syntax-highlighted `.http-response` documents with Content-Type-based body injection (JSON/HTML/XML)

### Implementation
- Thin WASM extension + native Rust LSP server (`restcraft-lsp`)
- The LSP binary is auto-downloaded from GitHub Releases for 5 targets (macOS arm64/x64, Linux musl x64/arm64, Windows x64), with a settings/`PATH` override fallback
- Grammar: separate public repo `tree-sitter-http-response`, pinned by `rev`

### Links
- Extension repo: https://github.com/jidohyun/restcraft
- Grammar repo: https://github.com/jidohyun/tree-sitter-http-response
- License: MIT (both repos)

I have read the docs, the extension repo has an MIT `LICENSE`, the `version` in `extensions.toml` matches `extension.toml` at the pinned commit, and the submodule uses an HTTPS URL.
