### PR TITLE
Add composer-update-checker extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -826,6 +826,10 @@
 	path = extensions/compline
 	url = https://github.com/jblais493/compline.git
 
+[submodule "extensions/composer-update-checker"]
+	path = extensions/composer-update-checker
+	url = https://github.com/babul/zed-composer-update-checker.git
+
 [submodule "extensions/confluence-context-server"]
 	path = extensions/confluence-context-server
 	url = https://github.com/mouhamadalmounayar/confluence-context-server

--- a/extensions.toml
+++ b/extensions.toml
@@ -840,6 +840,10 @@ submodule = "extensions/compline"
 path = "zed"
 version = "0.1.0"
 
+[composer-update-checker]
+submodule = "extensions/composer-update-checker"
+version = "0.1.0"
+
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"
 version = "1.0.0"


### PR DESCRIPTION
Adds **Composer composer.json Update Checker** — highlights outdated [Composer](https://getcomposer.org) packages directly in `composer.json` and offers one-click version bumps. Latest versions come from the Packagist v2 metadata API.

Features:
- Diagnostics on outdated `require` / `require-dev` packages (platform reqs like `php`/`ext-*` skipped), linked to the package's Packagist page
- Hover with update status plus Packagist and source-repository links
- Version completion listing every published version (newest-first, latest stable preselected), preserving your operator
- A `Update …` code action and an inline Code Lens for one-click bumps

Details:
- Repository: https://github.com/babul/zed-composer-update-checker
- License: MIT
- The extension is a thin WASM wrapper that downloads its `tower-lsp` language-server binary from the repo's GitHub Releases (pinned to the extension version), for macOS (arm64/x64), Linux (x64/arm64), and Windows (x64).
- Tested locally as a dev extension.

A Composer counterpart to the existing npm update checker extension.