### PR TITLE
Update yulang to v0.0.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5137,7 +5137,7 @@ version = "0.0.1"
 
 [yulang]
 submodule = "extensions/yulang"
-version = "0.0.3"
+version = "0.0.10"
 
 [zabby]
 submodule = "extensions/zabby"


### PR DESCRIPTION
## Summary

- update the `yulang` extension submodule to `momota1029/yulang-zed@4855fb7`
- bump the registry version from `0.0.3` to `0.0.10`

## Notes

This picks up the Yulang language server integration and recent fixes so the extension defaults to launching `yulang server`.

## Checks

- `npx pnpm@11.1.0 sort-extensions`
- `npx pnpm@11.1.0 build`