### PR TITLE
Add Jannchie Code theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2062,6 +2062,10 @@
 	path = extensions/janet
 	url = https://github.com/vijaykiran/janet-zed.git
 
+[submodule "extensions/jannchie-code"]
+	path = extensions/jannchie-code
+	url = https://github.com/Jannchie/vscode-theme-jannchie.git
+
 [submodule "extensions/jarl"]
 	path = extensions/jarl
 	url = https://github.com/etiennebacher/jarl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2101,6 +2101,11 @@ version = "0.1.3"
 submodule = "extensions/janet"
 version = "0.0.1"
 
+[jannchie-code]
+submodule = "extensions/jannchie-code"
+path = "packages/zed"
+version = "3.2.0"
+
 [jarl]
 submodule = "extensions/jarl"
 path = "editors/zed"


### PR DESCRIPTION
Adds **Jannchie Code**, a theme extension with five variants (Dark, Dark Soft, Black, Light, Light Soft).

The theme lives in a monorepo subdirectory, so the entry uses `path = "packages/zed"`.

- Repository: https://github.com/Jannchie/vscode-theme-jannchie
- Also published as a VS Code theme and a Shiki theme from the same source.

Checklist:
- [x] Read the docs on developing & publishing extensions
- [x] Submodule added via HTTPS, pointing at a public repo on the `main` branch
- [x] `extensions.toml` version (`3.2.0`) matches `extension.toml` at the referenced commit
- [x] Ran `pnpm sort-extensions` so `extensions.toml` and `.gitmodules` stay ordered