### PR TITLE
Add ep-133-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1302,6 +1302,10 @@
 	path = extensions/env
 	url = https://github.com/zarifpour/zed-env
 
+[submodule "extensions/ep-133-theme"]
+	path = extensions/ep-133-theme
+	url = https://github.com/evgenii-sergeev/zed-ep-133.git
+
 [submodule "extensions/erb-snippets"]
 	path = extensions/erb-snippets
 	url = https://github.com/enderahmetyurt/zed-erb-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1324,6 +1324,10 @@ version = "1.1.1"
 submodule = "extensions/env"
 version = "0.0.1"
 
+[ep-133-theme]
+submodule = "extensions/ep-133-theme"
+version = "0.0.1"
+
 [erb-snippets]
 submodule = "extensions/erb-snippets"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the **EP-133** theme extension for Zed.

A theme inspired by the [EP–133 K.O. II](https://teenage.engineering/products/ep-133) from Teenage Engineering. Includes two variants:

- **EP-133 Display** (dark)
- **EP-133 Chassis** (light)

Repository: https://github.com/evgenii-sergeev/zed-ep-133

The extension ID is `ep-133-theme` (suffixed with `-theme` per the extension publishing prerequisites).

---

- [x] Tested locally as a dev extension via `zed: install dev extension`
- [x] Extension ID is unique and suffixed with `-theme`; `id`/`name` contain no forbidden words (`zed`/`extension`)
- [x] `extension.toml` has all required fields filled in
- [x] Repository includes an accepted license (MIT)
- [x] Added as a submodule (HTTPS URL, on `main` branch) under `extensions/ep-133-theme`
- [x] Added an entry to `extensions.toml` and ran `pnpm sort-extensions`