### PR TITLE
Update laravel to v0.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2313,7 +2313,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.4.1"
+version = "0.5.0"
 
 [latex]
 submodule = "extensions/latex"


### PR DESCRIPTION
Bumps `laravel` to v0.5.0.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.5.0