### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+<!-- Please confirm the checklist below, then remove this comment. -->
+
+- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.


### PR DESCRIPTION
It repeatedly happens that despite our `CONTRIBUTING.md`, people do not read or follow our documentation on extensions at all. The situation overall has improved since we added this, however, most people still do not read this at all. 

Thus, this PR adds a pull request template to also prompt users to read the contribution guidelines in an attempt to get better initial submissions from people for adding their extensions.