### PR TITLE
Add Jac language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2066,6 +2066,10 @@
 	path = extensions/iwe
 	url = https://github.com/iwe-org/zed-iwe.git
 
+[submodule "extensions/jac"]
+	path = extensions/jac
+	url = https://github.com/chess10kp/jac-zed.git
+
 [submodule "extensions/jai"]
 	path = extensions/jai
 	url = https://github.com/seg4lt/zed-jai.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2106,6 +2106,10 @@ version = "0.1.0"
 submodule = "extensions/iwe"
 version = "0.0.5"
 
+[jac]
+submodule = "extensions/jac"
+version = "0.1.0"
+
 [jai]
 submodule = "extensions/jai"
 version = "0.1.3"


### PR DESCRIPTION
## Summary

Adds support for the [Jac](https://www.jac-lang.org/) programming language to Zed.

Extension repository: https://github.com/chess10kp/jac-zed

### What Jac is

Jac is a programming language designed for humans and AI to build together. It compiles to Python bytecode, JavaScript, and native machine code, with built-in support for graph-based Object-Spatial Programming and AI integration.

### What this extension provides

- Tree-sitter grammar for `.jac` files (via [tree-sitter-jac](https://github.com/jaseci-labs/tree-sitter-jac))
- Language server support via the `jac lsp` command from the `jaclang` CLI
- Syntax highlighting and language configuration

### Installation notes

Users need to install the `jaclang` package and have `jac` available on their `PATH`:

```bash
pip install jaclang
```

Zed will then automatically start `jac lsp` for `.jac` files.

## Test plan

- [x] Extension has a valid `extension.toml` manifest
- [x] Repository includes an MIT license
- [x] Submodule points to a public repository with the extension code
- [x] `pnpm sort-extensions` has been run
- [x] `pnpm test` passes
- [x] `pnpm package-extensions jac` validates the extension (license and manifest checks pass)