### PR TITLE
Add cursor-theme-zed theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -934,6 +934,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/cursor-theme"]
+	path = extensions/cursor-theme
+	url = https://github.com/pol-cova/cursor-theme-zed.git
+
 [submodule "extensions/cyan-light-theme"]
 	path = extensions/cyan-light-theme
 	url = https://github.com/biaqat/cyan-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -951,6 +951,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[cursor-theme]
+submodule = "extensions/cursor-theme"
+version = "0.0.1"
+
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"


### PR DESCRIPTION
Adds `cursor-theme-zed` as a new Zed theme extension.

This theme includes:

- `cursor-theme-zed Light`
- `cursor-theme-zed Dark`

The extension is added as a Git submodule under `extensions/cursor-theme-zed` and registered in `extensions.toml` with version `0.0.1`.

Theme repository:
https://github.com/pol-cova/cursor-theme-zed