### PR TITLE
Add vercel-geist-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4794,6 +4794,10 @@
 	path = extensions/vercel-carbon-theme
 	url = https://github.com/SwiftlyDaniel/zed-vercel-theme.git
 
+[submodule "extensions/vercel-geist-theme"]
+	path = extensions/vercel-geist-theme
+	url = https://github.com/pol-cova/vercel-theme.git
+
 [submodule "extensions/vercel-theme"]
 	path = extensions/vercel-theme
 	url = https://github.com/NathanBrodin/zed-vercel-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4875,6 +4875,10 @@ version = "1.0.0"
 submodule = "extensions/vercel-carbon-theme"
 version = "0.1.0"
 
+[vercel-geist-theme]
+submodule = "extensions/vercel-geist-theme"
+version = "0.0.1"
+
 [vercel-theme]
 submodule = "extensions/vercel-theme"
 version = "1.1.0"


### PR DESCRIPTION
Adds `vercel-geist-theme` as a new Zed theme extension.

This theme includes:

- `Vercel Geist Light`
- `Vercel Geist Dark`

The extension is added as a Git submodule under `extensions/vercel-geist-theme` and registered in `extensions.toml` with version `0.0.1`.

Theme repository:
https://github.com/pol-cova/vercel-theme