### PR TITLE
Add CodeTime language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -818,6 +818,10 @@
 	path = extensions/codestackr
 	url = https://github.com/Pjort/codestackr-zed.git
 
+[submodule "extensions/codetime-lsp"]
+	path = extensions/codetime-lsp
+	url = https://github.com/codetime-dev/codetime-zed.git
+
 [submodule "extensions/coding-in-the-sun-theme"]
 	path = extensions/coding-in-the-sun-theme
 	url = https://github.com/tgrecojs/coding-in-the-sun.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -832,6 +832,10 @@ version = "0.0.6"
 submodule = "extensions/codestackr"
 version = "0.0.1"
 
+[codetime-lsp]
+submodule = "extensions/codetime-lsp"
+version = "0.1.8"
+
 [coding-in-the-sun-theme]
 submodule = "extensions/coding-in-the-sun-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds CodeTime (https://codetime.dev) coding-time tracking, ported from the existing VS Code extension.

Zed extensions can't hook editor events directly, so this works through a language server (`codetime-ls`) that turns document open/change/save into events and posts them to the CodeTime API. The server binary is downloaded from the repo's GitHub releases, not bundled.

Repo: https://github.com/codetime-dev/codetime-zed

Extension ID is `codetime-lsp`, submodule at `extensions/codetime-lsp`, version 0.1.8.
