### PR TITLE
Add Gentoo grammar extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1602,6 +1602,10 @@
 	path = extensions/gentle-dark
 	url = https://github.com/gentlelionstudios/gentle-dark-zed.git
 
+[submodule "extensions/gentoo-grammar"]
+	path = extensions/gentoo-grammar
+	url = https://github.com/democe/gentoo-grammar-zed.git
+
 [submodule "extensions/geode-theme"]
 	path = extensions/geode-theme
 	url = https://github.com/almeladev/geode-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1629,6 +1629,10 @@ version = "0.2.0"
 submodule = "extensions/gentle-dark"
 version = "1.2.2"
 
+[gentoo-grammar]
+submodule = "extensions/gentoo-grammar"
+version = "0.1.0"
+
 [geode-theme]
 submodule = "extensions/geode-theme"
 version = "2.0.1"


### PR DESCRIPTION
## Summary
- add the public democe/gentoo-grammar-zed extension as an HTTPS submodule
- register gentoo-grammar version 0.1.0 in extensions.toml
- include the extension README with attribution to gentoo/gentoo-syntax

## Validation
- npx pnpm sort-extensions
- npx pnpm build
- npx pnpm test
- npx pnpm package-extensions gentoo-grammar