### PR TITLE
Add VSCode Dark+ theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5193,3 +5193,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/dark-plus"]
+	path = extensions/dark-plus
+	url = https://github.com/rommyarb/dark-plus

--- a/extensions.toml
+++ b/extensions.toml
@@ -1027,6 +1027,10 @@ version = "0.0.1"
 submodule = "extensions/dark-oled"
 version = "0.1.0"
 
+[dark-plus]
+submodule = "extensions/dark-plus"
+version = "0.1.0"
+
 [dark-pop-ui]
 submodule = "extensions/dark-pop-ui"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

- Adds the **VSCode Dark+** theme by rommyarb
- A faithful port of Visual Studio Code's iconic Dark+ theme to Zed
- All syntax colors mapped directly from VS Code's source (`dark_plus.json` + `dark_vs.json`)
- Full UI color coverage, terminal ANSI palette, and editor chrome

## Extension details

- **ID**: `dark-plus`
- **Repository**: https://github.com/rommyarb/dark-plus