### PR TITLE
Add VSCode Dark+ theme (vscode-dark-plus-zed)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5193,3 +5193,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/dark-plus"]
+	path = extensions/dark-plus
+	url = https://github.com/rommyarb/dark-plus

--- a/.gitmodules
+++ b/.gitmodules
@@ -5193,6 +5193,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/dark-plus"]
-	path = extensions/dark-plus
-	url = https://github.com/rommyarb/dark-plus
+[submodule "extensions/vscode-dark-plus-zed"]
+	path = extensions/vscode-dark-plus-zed
+	url = https://github.com/rommyarb/vscode-dark-plus-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1027,10 +1027,6 @@ version = "0.0.1"
 submodule = "extensions/dark-oled"
 version = "0.1.0"
 
-[dark-plus]
-submodule = "extensions/dark-plus"
-version = "0.1.0"
-
 [dark-pop-ui]
 submodule = "extensions/dark-pop-ui"
 version = "0.0.2"
@@ -4979,6 +4975,10 @@ version = "0.1.2"
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"
 version = "0.0.1"
+
+[vscode-dark-plus-zed]
+submodule = "extensions/vscode-dark-plus-zed"
+version = "0.1.0"
 
 [vscode-dark-polished]
 submodule = "extensions/vscode-dark-polished"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1027,6 +1027,10 @@ version = "0.0.1"
 submodule = "extensions/dark-oled"
 version = "0.1.0"
 
+[dark-plus]
+submodule = "extensions/dark-plus"
+version = "0.1.0"
+
 [dark-pop-ui]
 submodule = "extensions/dark-pop-ui"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds the **VSCode Dark+** theme (`vscode-dark-plus-zed`) — a faithful, complete port of Visual Studio Code's iconic Dark+ theme to Zed.

## Why a new theme?

The existing `vscode-dark-plus` extension ([d1y/vscode_dark_plus.zed](https://github.com/d1y/vscode_dark_plus.zed)) has not been updated since **May 2024** (2+ years ago). The author has left 10 open issues and 2 open PRs unaddressed. This new extension is a fresh, actively maintained alternative.

## What's different / better

- Colors sourced directly from VS Code's own `dark_plus.json` + `dark_vs.json`
- Correct comment color (`#6A9955` green, not near-invisible `#505050`)
- Correct operator color (`#D4D4D4`, not purple `#C586C0`)
- Correct constant/enum color (`#4FC1FF`, not generic blue)
- Correct constructor color (`#DCDCAA`, same as functions)
- Correct regex color (`#D16969`, not same as strings)
- Full UI coverage: borders, panels, tabs, title bar, scrollbars, status bar
- Full terminal ANSI palette using VS Code's actual built-in terminal colors
- Additional tokens: `enum`, `namespace`, `selector`, `label`, `emphasis`, `diff.plus/minus`, and more
- Uses schema `v0.2.0` (existing uses outdated `v0.1.0`)

## Extension details

- **ID**: `vscode-dark-plus-zed`
- **Repository**: https://github.com/rommyarb/vscode-dark-plus-zed