### PR TITLE
Update todo-highlight-language-server to v0.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4606,7 +4606,7 @@ version = "0.0.2"
 
 [todo-highlight-language-server]
 submodule = "extensions/todo-highlight-language-server"
-version = "0.2.1"
+version = "0.2.2"
 path = "extension"
 
 [todotxt]


### PR DESCRIPTION
## Summary
- Updates `todo-highlight-language-server` submodule to `v0.2.2` and bumps `extensions.toml`.
- Linux binaries switched to fully-static musl targets (`*-unknown-linux-musl`), fixing launch failure on NixOS, Alpine, and other non-FHS distros that lack a system dynamic linker (follow-up to the issue reported in v0.2.1).
- Archive format changed to `.tar.gz` (macOS/Linux) / `.zip` (Windows), aligning with Zed extension best practices.
- Old version directories are cleaned up on upgrade.

## Test plan
- [x] `cargo check -p todo-highlight-extension --target wasm32-wasip1` passes
- [ ] Confirmed working on NixOS by original reporter