### PR TITLE
Add Claude Code Usage extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -722,6 +722,10 @@
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git
 
+[submodule "extensions/claude-code-usage"]
+	path = extensions/claude-code-usage
+	url = https://github.com/wheelbarrel00/ClaudeCodeUsageTool.git
+
 [submodule "extensions/claude-vellum-theme"]
 	path = extensions/claude-vellum-theme
 	url = https://github.com/leisure462/zed-claude-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -733,6 +733,10 @@ version = "0.1.0"
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"
 
+[claude-code-usage]
+submodule = "extensions/claude-code-usage"
+version = "0.1.0"
+
 [claude-vellum-theme]
 submodule = "extensions/claude-vellum-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **Claude Code Usage** extension.

A context server (MCP) extension that surfaces Claude Code usage inside Zed's agent: today's token usage and estimated cost, plan-limit utilization (5-hour, weekly, and per-model weekly windows) with reset times and a pace projection, recent burn rate, and current context-window fill. It reads Claude Code's local logs under `~/.claude` and Anthropic's OAuth usage endpoint, exposing two tools: `get_claude_usage` and `get_usage_breakdown`.

The extension embeds a bundled MCP server and launches it with Zed's own Node runtime, so no separate Node installation is required.

- Repository: https://github.com/wheelbarrel00/ClaudeCodeUsageTool
- License: MIT
- Tested locally as a dev extension.