### PR TITLE
Update apathy-theme to v3.15.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -168,7 +168,7 @@ version = "0.1.0"
 
 [apathy-theme]
 submodule = "extensions/apathy-theme"
-version = "3.11.1"
+version = "3.15.2"
 path = "packages/zed"
 
 [apisartisan]


### PR DESCRIPTION
Automated update of the apathy-theme extension to v3.15.2 (version 3.15.2).