### PR TITLE
Add Ox Content language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3342,6 +3342,10 @@
 	path = extensions/outrun-vscode-theme
 	url = https://github.com/exkungen/outrun-vscode-zed.git
 
+[submodule "extensions/ox-content"]
+	path = extensions/ox-content
+	url = https://github.com/ubugeeei-prod/ox-content.git
+
 [submodule "extensions/oxc"]
 	path = extensions/oxc
 	url = https://github.com/oxc-project/oxc-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3395,6 +3395,11 @@ version = "0.0.3"
 submodule = "extensions/outrun-vscode-theme"
 version = "0.1.0"
 
+[ox-content]
+submodule = "extensions/ox-content"
+path = "editors/zed"
+version = "2.73.0"
+
 [oxc]
 submodule = "extensions/oxc"
 version = "0.4.7"


### PR DESCRIPTION
## Summary

Add the Ox Content Zed extension from `ubugeeei-prod/ox-content` at version `2.73.0`.

The extension lives under `editors/zed` in the source repository, so the registry entry uses `path = "editors/zed"`.

## About Ox Content

repo: https://github.com/ubugeeei-prod/ox-content

docs: https://ox-content.void.app

A framework agnostic fastest and beautiful documentation & markdown tooling.

Parser, Compiler (Renderer), MDC Frontmatter LSP, Checker, Document Generations

## Validation

- `corepack pnpm sort-extensions`
- `corepack pnpm build`
- `corepack pnpm test`
- `cargo build --manifest-path extensions/ox-content/editors/zed/Cargo.toml --target wasm32-wasip2`
- `cargo build --manifest-path extensions/ox-content/editors/zed/Cargo.toml --target wasm32-unknown-unknown`