### PR TITLE
Add Vize language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4874,6 +4874,10 @@
 	path = extensions/vivid-void-theme
 	url = https://github.com/fn-jakubkarp/zed-vivid-void-theme.git
 
+[submodule "extensions/vize"]
+	path = extensions/vize
+	url = https://github.com/ubugeeei-prod/vize.git
+
 [submodule "extensions/vrl"]
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4956,6 +4956,11 @@ version = "1.0.0"
 submodule = "extensions/vivid-void-theme"
 version = "0.0.1"
 
+[vize]
+submodule = "extensions/vize"
+path = "editors/zed"
+version = "0.251.0"
+
 [vrl]
 submodule = "extensions/vrl"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

Add the Vize Zed extension from `ubugeeei-prod/vize`.

The extension lives under `editors/zed` in the source repository, so the registry entry uses `path = "editors/zed"`. This PR remains a draft while the source-side extension layout is finalized.

## About Vize

repo: https://github.com/ubugeeei-prod/vize
docs: https://vizejs.dev/

Vize is a Rust-native Vue toolchain that provides an opt-in lane for Vue single-file component diagnostics and language support. The Zed extension starts the `vize lsp` command from `PATH` or from user settings, and registers Vize for both `Vue` and `Art Vue` files.

Vize is currently in its Real World Testing phase. The extension is intentionally opt-in so users can evaluate linting, type checking, hover, definitions, references, and ecosystem-aware Vue diagnostics alongside their existing Vue language server setup.

## Validation

- `corepack pnpm sort-extensions`
- `corepack pnpm build`
- `corepack pnpm test`
- `cargo build --manifest-path extensions/vize/editors/zed/Cargo.toml --target wasm32-wasip2`
- `cargo build --manifest-path extensions/vize/editors/zed/Cargo.toml --target wasm32-unknown-unknown`
