### PR TITLE
Add Classic Light theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -718,6 +718,10 @@
 	path = extensions/clarity
 	url = https://github.com/stx-labs/clarity-zed.git
 
+[submodule "extensions/classic-light-intellij"]
+	path = extensions/classic-light-intellij
+	url = https://github.com/CyberAP/zed-classic-light-intellij.git
+
 [submodule "extensions/claude-code-inspired-dark"]
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.3"
+version = "0.1.4"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.0"
+version = "0.1.1"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.5"
+version = "0.1.6"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -729,6 +729,10 @@ version = "0.0.1"
 submodule = "extensions/clarity"
 version = "0.1.0"
 
+[classic-light-intellij]
+submodule = "extensions/classic-light-intellij"
+version = "0.1.0"
+
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.2"
+version = "0.1.3"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.1"
+version = "0.1.2"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"

--- a/extensions.toml
+++ b/extensions.toml
@@ -731,7 +731,7 @@ version = "0.1.0"
 
 [classic-light-intellij]
 submodule = "extensions/classic-light-intellij"
-version = "0.1.4"
+version = "0.1.5"
 
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"


### PR DESCRIPTION
This PR adds **Classic Light (IntelliJ-inspired)**, a light theme that ports the color values of JetBrains IntelliJ's **"Classic Light"** editor color scheme (the legacy *Default* scheme, shown as *Classic Light* in the New UI). Colors are taken from JetBrains' open-source `DefaultColorSchemesManager.xml`.

- Repository: https://github.com/CyberAP/zed-classic-light-intellij
- License: MIT (colors derived from the Apache-2.0 IntelliJ Community scheme)

### Not a duplicate of existing extensions

The registry already has `intellij-light-theme`, `intellij-newui-theme`, and `jetbrains-themes`, but all of those port the **New UI "Light"** scheme. This is the distinct **Classic Light** palette:

| | keyword | string |
| --- | --- | --- |
| existing New UI "Light" ports | `#0033B3` (normal) | `#067D17` |
| **this theme (Classic Light)** | `#000080` **bold** | `#008000` **bold** |

Classic Light keeps most code black, coloring only keywords (navy bold), strings (green bold), numbers, comments (grey italic), and fields/constants (purple) — matching the legacy IntelliJ look.

### Checklist

- [x] Tested locally as a dev extension
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] Accepted open-source license (MIT) at the repo root
- [x] Entry added to `extensions.toml`; version matches `extension.toml` (0.1.0)
- [x] `extensions.toml` and `.gitmodules` sorted with `pnpm sort-extensions`