### PR TITLE
Add check: anti-hallucination firewall

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5193,3 +5193,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/check"]
+	path = extensions/check
+	url = https://github.com/golproductions/check-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -696,6 +696,10 @@ version = "0.5.0"
 submodule = "extensions/cherri"
 version = "0.1.0"
 
+[check]
+submodule = "extensions/check"
+version = "1.0.0"
+
 [chocolate]
 submodule = "extensions/chocolate"
 version = "0.0.2"


### PR DESCRIPTION
## Extension

**check** — Anti-hallucination firewall for AI coding agents. Validates AI-generated commands before execution via the `/check` slash command.

- **Repository**: https://github.com/golproductions/check-zed
- **Version**: 1.0.0

## What it does

Provides a `/check` slash command that validates commands against real system state before execution. Catches hallucinated packages, wrong flags, fake APIs, and unsafe operations.

- Slash command: `/check <command>`
- Calls the Check API (`triage.golproductions.com/preflight`)
- Returns runnable/blocked verdict with reason
- Requires `GOL_CLIENT_ID` env var (free at golproductions.com/check)

## Checklist

- [x] Extension compiles to WASM (`cargo build --target wasm32-wasip1`)
- [x] `extension.toml` present with valid metadata
- [x] Submodule added and entry in `extensions.toml` in alphabetical order