### PR TITLE
Add vercel-italics-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4974,6 +4974,10 @@
 	path = extensions/vercel-carbon-theme
 	url = https://github.com/SwiftlyDaniel/zed-vercel-theme.git
 
+[submodule "extensions/vercel-italics-theme"]
+	path = extensions/vercel-italics-theme
+	url = https://github.com/CibiAananth/zed-vercel-italics.git
+
 [submodule "extensions/vercel-theme"]
 	path = extensions/vercel-theme
 	url = https://github.com/NathanBrodin/zed-vercel-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5064,6 +5064,10 @@ version = "1.0.0"
 submodule = "extensions/vercel-carbon-theme"
 version = "0.1.0"
 
+[vercel-italics-theme]
+submodule = "extensions/vercel-italics-theme"
+version = "0.1.0"
+
 [vercel-theme]
 submodule = "extensions/vercel-theme"
 version = "1.1.0"


### PR DESCRIPTION
## Summary

Adds `vercel-italics-theme`, a theme-only extension with Vercel light/dark colors and Night Owl-style italic syntax highlighting.

Repository: https://github.com/CibiAananth/zed-vercel-italics

This is separate from the existing `vercel-theme` extension. Same palette and UI, with italics applied to keywords, functions, comments, and related syntax tokens.

Includes:
- `Vercel Italics Dark`
- `Vercel Italics Light`
- MIT license at repo root
- Version `0.1.0`

## Testing

Installed the extension locally in Zed as a dev extension and checked both theme variants across TypeScript, Python, Go, and Rust.

## Test plan

- [x] CI passes
- [x] Dark and light variants appear in the theme picker
- [x] Tested locally as a dev extension
- [x] extension.toml includes id, name, version, schema_version, authors, description, repository
- [x] Accepted open-source license (MIT) at the repo root
- [x] Entry added to extensions.toml; version matches extension.toml (0.1.0)
- [x] extensions.toml and .gitmodules sorted with pnpm sort-extensions