### PR TITLE
Update dracula to v1.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1168,7 +1168,7 @@ version = "0.0.1"
 
 [dracula]
 submodule = "extensions/dracula"
-version = "1.1.1"
+version = "1.1.2"
 
 [dracula-flat]
 submodule = "extensions/dracula-flat"


### PR DESCRIPTION
Bumps the Dracula theme extension to v1.1.2.

Changes in this release:
- Bump extension version to 1.1.2
- Adjust multiple color tokens across themes/dracula.json
- Updated element hover/selected colors
- Panel focused border alpha
- Ignored color/background
- Attribute color for dark and light variants
- Hint color/font_style/font_weight adjustments (now italic)
- Various syntax color tweaks
- Light theme name string update