### PR TITLE
Update angular-snippets to v21.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -144,7 +144,7 @@ version = "0.0.5"
 
 [angular-snippets]
 submodule = "extensions/angular-snippets"
-version = "21.0.0"
+version = "21.1.0"
 
 [ansible]
 submodule = "extensions/ansible"


### PR DESCRIPTION
# Bump angular-snippets to 21.1.0

## Features

- Adds `a-signal` snippet to generate a `protected` Angular signal
- Adds `a-computed` snippet to generate `protected` computed signal
- Adds `a-linkedSignal` snippet to generate `protected` linkedSignal
- Adds `a-inject` snippet to generate `private` `inject` function

## Bug Fixes

- Fix "Angular HttpInterceptor for Logging" snippet