### PR TITLE
Add Macaulay2 language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2422,6 +2422,10 @@
 	path = extensions/lydia
 	url = https://github.com/dimitrisnl/lydia-zed-theme
 
+[submodule "extensions/macaulay2"]
+	path = extensions/macaulay2
+	url = https://github.com/d-torrance/zed-macaulay2
+
 [submodule "extensions/mach"]
 	path = extensions/mach
 	url = https://github.com/octalide/mach-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2468,6 +2468,10 @@ version = "0.6.1"
 submodule = "extensions/lydia"
 version = "0.0.4"
 
+[macaulay2]
+submodule = "extensions/macaulay2"
+version = "0.1.1"
+
 [mach]
 submodule = "extensions/mach"
 version = "0.2.2"


### PR DESCRIPTION
We add an extension for [Macaulay2](https://macaulay2.com/), a software platform for research in algebraic geometry and commutative algebra.  It supports the Macaulay2 [language server](https://macaulay2.com/doc/Macaulay2/share/doc/Macaulay2/LanguageServer/html/index.html), [tree-sitter grammar](https://github.com/AlexanderGolys/tree-sitter-macaulay2), and [Jupyter kernel](https://github.com/Macaulay2/Macaulay2-Jupyter-Kernel).

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
