### PR TITLE
Add OptionsAhoy extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3286,6 +3286,10 @@
 	path = extensions/optima-theme
 	url = https://github.com/iftekhar-ifat/optima-theme.git
 
+[submodule "extensions/optionsahoy"]
+	path = extensions/optionsahoy
+	url = https://github.com/AlvisoOculus/optionsahoy-zed.git
+
 [submodule "extensions/org"]
 	path = extensions/org
 	url = https://github.com/hron/zed-org

--- a/extensions.toml
+++ b/extensions.toml
@@ -3337,6 +3337,10 @@ version = "0.1.0"
 submodule = "extensions/optima-theme"
 version = "0.0.1"
 
+[optionsahoy]
+submodule = "extensions/optionsahoy"
+version = "0.0.1"
+
 [org]
 submodule = "extensions/org"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This adds **OptionsAhoy**, a context-server extension that connects Zed's agent to the OptionsAhoy MCP server — an equity-compensation tax and trade optimizer (ISO/AMT exercise, NSO, RSU, QSBS, concentration analysis, protective-put hedging, across all 50 states and DC).

OptionsAhoy runs as a remote streamable-HTTP MCP server at `https://optionsahoy.com/mcp` (no authentication). Since Zed context-server extensions launch a local stdio command, the extension bridges to the remote server using the `mcp-remote` npm shim, which Zed installs and updates automatically. No configuration is required after install.

- Extension repo: https://github.com/AlvisoOculus/optionsahoy-zed
- Built and validated locally against `zed_extension_api` 0.7.0, target `wasm32-wasip1`.