### PR TITLE
Add nexus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2986,6 +2986,10 @@
 	path = extensions/nextjs-react-snippets
 	url = https://github.com/Konstantinos-Ps/zed-nextjs-react-snippets
 
+[submodule "extensions/nexus"]
+	path = extensions/nexus
+	url = https://github.com/paulmanoni/nexus-zed.git
+
 [submodule "extensions/nginx"]
 	path = extensions/nginx
 	url = https://github.com/d1y/nginx-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3035,6 +3035,10 @@ version = "1.0.9"
 submodule = "extensions/nextjs-react-snippets"
 version = "0.1.0"
 
+[nexus]
+submodule = "extensions/nexus"
+version = "0.2.0"
+
 [nginx]
 submodule = "extensions/nginx"
 version = "0.0.3"


### PR DESCRIPTION
Adds the **Nexus** extension — editor support for the [nexus](https://github.com/paulmanoni/nexus) Go framework: `//@` decorator handlers and
  `nexus.toml` (diagnostics, outline, hover, completion). It attaches a small companion language server (`nexus-lsp`) that auto-downloads its prebuilt
  binary, so install is zero-setup. Repo: https://github.com/paulmanoni/nexus-zed