### PR TITLE
Add dns-zone extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1102,6 +1102,10 @@
 	path = extensions/djot
 	url = https://github.com/nzoschke/zed-djot.git
 
+[submodule "extensions/dns-zone"]
+	path = extensions/dns-zone
+	url = https://github.com/goulinkh/zed-dns-zone.git
+
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose
 	url = https://github.com/eth0net/zed-docker-compose.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1122,6 +1122,10 @@ version = "0.0.1"
 submodule = "extensions/djot"
 version = "0.1.0"
 
+[dns-zone]
+submodule = "extensions/dns-zone"
+version = "0.1.0"
+
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the **DNS Zone Files** extension, providing syntax highlighting for BIND / RFC 1035 DNS zone (master) files in Zed.

- Extension repo: https://github.com/goulinkh/zed-dns-zone
- Grammar repo: https://github.com/goulinkh/tree-sitter-dns-zone (custom tree-sitter grammar)
- License: MIT (present at repo root)

### What it does
Records are parsed into their structural parts: `[owner] [ttl] [class] type rdata`, and highlighted by **role** (owner, TTL, class, record type, and rdata, with IPv4/IPv6 literals distinguished from domain targets). Also handles comments (`;`), control directives (`$TTL`, `$ORIGIN`, `$INCLUDE`, `$GENERATE`), quoted character strings, the `@` origin shorthand, `$GENERATE` iterators, and multi-line parenthesized records (SOA).

### File suffixes
`*.domain`, `*.zone`, `*.zonefile`, `*.db`, `*.arpa`, plus a first-line heuristic for `$TTL`/`$ORIGIN`/`$GENERATE`/`$INCLUDE`.

### Testing
- Grammar parses 490 real-world zone files with 0 errors.
- Verified working locally as a dev extension in Zed.

### Checklist
- [x] Submodule added under `extensions/dns-zone` (HTTPS URL, on `main` branch)
- [x] Entry added to `extensions.toml`
- [x] `pnpm sort-extensions` run
- [x] Accepted license (MIT) at repo root
- [x] Extension ID/name contain no `zed`/`extension`