### PR TITLE
Add zeroheight MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2726,6 +2726,10 @@
 	path = extensions/mcp-server-zephex
 	url = https://github.com/zephexMCP/mcp-server-zephex.git
 
+[submodule "extensions/mcp-server-zeroheight"]
+	path = extensions/mcp-server-zeroheight
+	url = https://github.com/zeroheight/ai-plugins.git
+
 [submodule "extensions/mcp-server-zuraffa"]
 	path = extensions/mcp-server-zuraffa
 	url = https://github.com/arrrrny/zuraffa-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2773,6 +2773,11 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-zephex"
 version = "0.0.1"
 
+[mcp-server-zeroheight]
+submodule = "extensions/mcp-server-zeroheight"
+path = "zed"
+version = "0.0.1"
+
 [mcp-server-zuraffa]
 submodule = "extensions/mcp-server-zuraffa"
 version = "5.2.2"


### PR DESCRIPTION
## Summary

Adds the **zeroheight MCP** extension, a context server that connects Zed's
agent to your [zeroheight](https://zeroheight.com) design system. It lets the AI
search components, retrieve implementation guidance, and generate code that
reflects your styleguide's components, patterns, and design tokens.

- **Submodule:** `extensions/mcp-server-zeroheight` → https://github.com/zeroheight/ai-plugins
- **Path:** `zed`
- **Version:** `0.0.1`

I've tested this locally and it works, the MCP does require a zeroheight enterprise account which I can help setting up for testing if needed :)  

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
