### PR TITLE
Update mach to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.2.2"
+version = "0.4.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
Re-submits the Mach 0.4.0 version bump, superseding the closed #6554.

The previous PR was closed because it only moved the `extensions/mach` submodule gitlink without updating the `version` field in the root `extensions.toml`. Per the [updating an extension](https://zed.dev/docs/extensions/developing-extensions#updating-an-extension) guide, both must change and must match. This PR updates BOTH:

- `extensions/mach` submodule gitlink advanced to `965fcdabf8e07bbfa1c3f1ee70634d57e3273bb2` (Mach v0.4.0).
- `extensions.toml` `[mach]` `version` bumped from `0.2.2` to `0.4.0`, matching the submodule's `extension.toml`.

This release migrates decorator highlighting to Mach's new `#[attr]` syntax. The grammar passes tree-sitter 221/221.