### PR TITLE
Update monospace-icon-theme to v0.1.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2922,7 +2922,7 @@ version = "0.1.3"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
-version = "0.1.5"
+version = "0.1.6"
 
 [monospace-theme]
 submodule = "extensions/monospace-theme"


### PR DESCRIPTION
Release notes:

https://github.com/irmhonde/monospace-icon-theme/releases/tag/v0.1.6