### PR TITLE
Add holocron extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1886,6 +1886,10 @@
 	path = extensions/hocon
 	url = https://github.com/tomatitito/hocon-zed-extension.git
 
+[submodule "extensions/holocron"]
+	path = extensions/holocron
+	url = https://github.com/holocron-lang/zed-holocron.git
+
 [submodule "extensions/hoon"]
 	path = extensions/hoon
 	url = https://github.com/TisaneFruitRouge/hoon-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1921,6 +1921,10 @@ version = "0.0.1"
 submodule = "extensions/hocon"
 version = "0.2.0"
 
+[holocron]
+submodule = "extensions/holocron"
+version = "0.1.0"
+
 [hoon]
 submodule = "extensions/hoon"
 version = "0.1.0"


### PR DESCRIPTION
- [x] Read the [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions) docs.

## What this is

[Holocron](https://github.com/holocron-lang/holocron) is a declarative
schema and query compiler — one YAML file is the single source of truth
for a SQL schema and a type-checked query catalog. Available on
[crates.io](https://crates.io/crates/holocron).

This extension wires
[`holocron-lsp`](https://crates.io/crates/holocron-lsp) into Zed as a
language server for `*.holocron.yaml` files, so schema errors (unknown
columns, duplicate aliases, unknown types, etc.) show as live red
squiggles in the editor with rustc-style diagnostics underlining the
exact YAML token at fault.

## Repo

- **Source:** https://github.com/holocron-lang/zed-holocron
- **License:** MPL-2.0
- **Version:** 0.1.0 (matches `extension.toml`)
- **LSP binary:** resolved from `PATH` via `worktree.which("holocron-lsp")`; users install with `cargo install holocron-lsp` or `brew install holocron-lang/holocron/holocron-lsp`.

## Checklist

- [x] Forked `zed-industries/extensions` to a personal account.
- [x] Added the extension as a git submodule under `extensions/holocron`.
- [x] Added entry in `extensions.toml` matching `extension.toml` version.
- [x] Ran `pnpm sort-extensions` — both files alphabetized.
- [x] Builds cleanly on `wasm32-wasip1` (`cargo build --target wasm32-wasip1 --release`).
- [x] Source repo is public.
- [x] License file present.