### PR TITLE
Update Svelte Effect Runtime to v3.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4383,7 +4383,7 @@ version = "0.2.11"
 [svelte-effect-runtime-language-server]
 submodule = "extensions/svelte-effect-runtime-language-server"
 path = "modules/svelte-effect-runtime-zed"
-version = "3.0.1"
+version = "3.0.2"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4383,7 +4383,7 @@ version = "0.2.11"
 [svelte-effect-runtime-language-server]
 submodule = "extensions/svelte-effect-runtime-language-server"
 path = "modules/svelte-effect-runtime-zed"
-version = "2.3.0"
+version = "3.0.1"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"


### PR DESCRIPTION
Updates the Svelte Effect Runtime Zed extension to 3.0.1.

Changes:
- Bumps the registry entry from 2.3.0 to 3.0.1.
- Moves the submodule to usebarekey/svelte-effect-runtime@8ffedd5.
- Installs the SER language server from npm instead of relying on a bundled GitHub release asset.
- Declares the Rust extension lib metadata and keeps the module-local BSD-3-Clause license.

Validation run locally:
- corepack pnpm build
- corepack pnpm test
- cargo check --target wasm32-wasip2 in modules/svelte-effect-runtime-zed
- cargo build --target wasm32-wasip2 --release in modules/svelte-effect-runtime-zed