### PR TITLE
Update mach to v0.4.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2391,7 +2391,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.1.0"
+version = "0.2.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.4.0"
+version = "0.4.2"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Updates the **Mach** extension `0.4.0` → `0.4.2` (repo: [octalide/mach-zed](https://github.com/octalide/mach-zed), tag `v0.4.2`).

Changes since the published 0.4.0:
- Indentation fix: scope the closing-delimiter dedent to its container (`@end` idiom) instead of a blanket `@outdent`, removing spurious dedents on non-indented bracket constructs.
- Highlight fixes: method/qualified call targets render as `@function.method` (not `@property`); add `projection_expression`; decorator `#[` as `@punctuation.special`.
- `#[ … ]` decorator bracket pair.

`extensions.toml` version matches `extension.toml` at the pinned commit. Tested locally as a dev extension.