### PR TITLE
Add sqlalchemy language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4202,6 +4202,10 @@
 	path = extensions/sql
 	url = https://github.com/zed-extensions/sql.git
 
+[submodule "extensions/sqlalchemy-lsp"]
+	path = extensions/sqlalchemy-lsp
+	url = https://github.com/alex-oleshkevich/sqlalchemy-lsp
+
 [submodule "extensions/sqlc-snippets"]
 	path = extensions/sqlc-snippets
 	url = https://github.com/NarmadaWeb/sqlc-snippets-zed.git
@@ -5161,6 +5165,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sqlalchemy-lsp"]
-	path = extensions/sqlalchemy-lsp
-	url = https://github.com/alex-oleshkevich/sqlalchemy-lsp

--- a/.gitmodules
+++ b/.gitmodules
@@ -5161,3 +5161,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sqlalchemy-lsp"]
+	path = extensions/sqlalchemy-lsp
+	url = https://github.com/alex-oleshkevich/sqlalchemy-lsp

--- a/extensions.toml
+++ b/extensions.toml
@@ -4271,14 +4271,14 @@ version = "0.1.0"
 submodule = "extensions/sql"
 version = "1.1.7"
 
-[sqlc-snippets]
-submodule = "extensions/sqlc-snippets"
-version = "0.2.0"
-
 [sqlalchemy-lsp]
 submodule = "extensions/sqlalchemy-lsp"
 path = "editors/zed"
 version = "0.1.0"
+
+[sqlc-snippets]
+submodule = "extensions/sqlc-snippets"
+version = "0.2.0"
 
 [sqlmesh]
 submodule = "extensions/sqlmesh"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4275,6 +4275,11 @@ version = "1.1.7"
 submodule = "extensions/sqlc-snippets"
 version = "0.2.0"
 
+[sqlalchemy-lsp]
+submodule = "extensions/sqlalchemy-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [sqlmesh]
 submodule = "extensions/sqlmesh"
 version = "0.1.4"


### PR DESCRIPTION
Adds [sqlalchemy-lsp](https://github.com/alex-oleshkevich/sqlalchemy-lsp) — a language server for SQLAlchemy ORM intelligence in Python projects.