### PR TITLE
ci: Add workaround for Danger flakiness

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -35,9 +35,10 @@ jobs:
       - name: Run Danger
         uses: nick-fields/retry@1c62e0697831d444be410bc770cc1576ab22de08
         with:
+          command: pnpm run danger ci
           max_attempts: 3
           retry_wait_seconds: 30
-          command: pnpm run danger ci
+          timeout_minutes: 1
         env:
           # This GitHub token is not used, but the value needs to be here to prevent
           # Danger from throwing an error.

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -33,7 +33,11 @@ jobs:
         run: pnpm install
 
       - name: Run Danger
-        run: pnpm run danger ci
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        with:
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: pnpm run danger ci
         env:
           # This GitHub token is not used, but the value needs to be here to prevent
           # Danger from throwing an error.

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install
 
       - name: Run Danger
-        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3
+        uses: nick-fields/retry@1c62e0697831d444be410bc770cc1576ab22de08
         with:
           max_attempts: 3
           retry_wait_seconds: 30


### PR DESCRIPTION
We started seeing some flakiness in the danger checks and have been unable to determine the root cause in a brief analysis.

Since we currently do not have the time to dig into this deeper, this PR adds a retry policy to that job to instead retry the job on failure. 

Importantly, this will not influence "normal" danger fails - when there are danger checks failing, the step itself will succeed, instead danger will post a failing check to the check suites API.