### PR TITLE
Add HFST plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1858,6 +1858,10 @@
 	path = extensions/hexpeek
 	url = https://github.com/A-23187/zed-hexpeek.git
 
+[submodule "extensions/hfst"]
+	path = extensions/hfst
+	url = https://github.com/tachyons/zed-hfst
+
 [submodule "extensions/high-contrast-themes"]
 	path = extensions/high-contrast-themes
 	url = https://github.com/rakshit087/high-contrast-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1893,6 +1893,10 @@ version = "0.0.4"
 submodule = "extensions/hexpeek"
 version = "0.1.0"
 
+[hfst]
+submodule = "extensions/hfst"
+version = "0.0.1"
+
 [high-contrast-themes]
 submodule = "extensions/high-contrast-themes"
 version = "0.1.0"


### PR DESCRIPTION
Adds grammar support for lexc and twol files which are used in morphological analyser. 

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
