### PR TITLE
Add Buisson theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -546,6 +546,10 @@
 	path = extensions/bugstalker-dap
 	url = https://github.com/godzie44/BugStalker.git
 
+[submodule "extensions/buisson-theme"]
+	path = extensions/buisson-theme
+	url = https://github.com/Adriusops/buisson-zed.git
+
 [submodule "extensions/bun-docs-mcp"]
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git
@@ -5177,6 +5181,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/buisson-theme"]
-	path = extensions/buisson-theme
-	url = https://github.com/Adriusops/buisson-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5177,3 +5177,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/buisson-theme"]
+	path = extensions/buisson-theme
+	url = https://github.com/Adriusops/buisson-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -556,13 +556,13 @@ submodule = "extensions/bugstalker-dap"
 version = "0.1.0"
 path = "extension/zed"
 
-[bun-docs-mcp]
-submodule = "extensions/bun-docs-mcp"
-version = "1.0.0"
-
 [buisson-theme]
 submodule = "extensions/buisson-theme"
 version = "0.1.0"
+
+[bun-docs-mcp]
+submodule = "extensions/bun-docs-mcp"
+version = "1.0.0"
 
 [c3]
 submodule = "extensions/c3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -560,6 +560,10 @@ path = "extension/zed"
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"
 
+[buisson-theme]
+submodule = "extensions/buisson-theme"
+version = "0.1.0"
+
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Buisson

  An inky botanical color scheme with Evergarden soul and Flexoki accessibility.

  Designed for long coding and writing sessions without eye fatigue.
  Warm paper backgrounds × botanical ink accents × WCAG-calibrated contrasts.

<img width="5760" height="3240" alt="Zed-pres" src="https://github.com/user-attachments/assets/1ebcf26f-142d-46b8-9e8d-22a4158dabbc" />


  ### Palette

  6 botanical accent colors mapped to syntax roles:

  - 🌺 **Hibiscus** — keywords, booleans, exceptions
  - 🌿 **Sage** — functions, method calls
  - 🌊 **River Moss** — types, classes, interfaces
  - 🪨 **Slate Sky** — numbers, numeric constants
  - 💜 **Thistle** — operators, decorators
  - 🍂 **Ochre** — strings, template literals

<img width="3560" height="3132" alt="dark" src="https://github.com/user-attachments/assets/fdda80da-5e9b-41a9-8e92-19e5a1e4912c" />

<img width="3560" height="3132" alt="light" src="https://github.com/user-attachments/assets/fab6b914-5e34-4b99-9ef9-f52b4be947de" />


  ### Accessibility

  - Primary text: **11.55:1 AAA** (dark) / **15.15:1 AAA** (light)
  - All 6 accents: WCAG AA or above

  ### Repository

  https://github.com/Adriusops/buisson-zed
