### PR TITLE
ci: Use Node version from package.json instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "24.18"
+          node-version-file: "package.json"
           cache: "pnpm"
 
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version-file: "package.json"
           cache: "pnpm"
+          check-latest: true
 
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: "24.18"
+          node-version-file: "package.json"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version-file: "package.json"
           cache: "pnpm"
+          check-latest: true
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
This has the advantage that this will be in sync with the version locally and also benefit from the renovate version bumps.