### PR TITLE
Add Vesper Golden theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4810,6 +4810,10 @@
 	path = extensions/vesper-blur
 	url = https://github.com/taras-tereschenko/vesper-blur.git
 
+[submodule "extensions/vesper-golden"]
+	path = extensions/vesper-golden
+	url = https://github.com/EveryDayApps/vesper-golden.git
+
 [submodule "extensions/vespertine-theme"]
 	path = extensions/vespertine-theme
 	url = https://github.com/filipeveronezi/vespertine.git
@@ -5185,6 +5189,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/vesper-golden"]
-	path = extensions/vesper-golden
-	url = https://github.com/EveryDayApps/vesper-golden

--- a/.gitmodules
+++ b/.gitmodules
@@ -5185,3 +5185,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/vesper-golden"]
+	path = extensions/vesper-golden
+	url = https://github.com/EveryDayApps/vesper-golden

--- a/extensions.toml
+++ b/extensions.toml
@@ -4893,6 +4893,11 @@ version = "0.0.2"
 submodule = "extensions/vesper-blur"
 version = "0.1.1"
 
+[vesper-golden]
+submodule = "extensions/vesper-golden"
+path = "platforms/zed"
+version = "1.0.0"
+
 [vespertine-theme]
 submodule = "extensions/vespertine-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds **Vesper Golden**, a warm gold-on-black theme family (dark + light) covering editor syntax, terminal ANSI, and app chrome.

- Repo: https://github.com/EveryDayApps/vesper-golden
- Extension lives under `platforms/zed/` (hence the `path` in the entry).
- Tested locally as a dev extension in both variants.
- Licensed (LICENSE in repo).