### PR TITLE
Update statamic-antlers to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4318,7 +4318,7 @@ version = "0.4.1"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
-version = "0.1.0"
+version = "0.2.0"
 
 [stimulus]
 submodule = "extensions/stimulus"


### PR DESCRIPTION
Bumps Statamic Antlers to 0.2.0.

Fixes a broken release: 0.1.0 installed a non-existent npm package (`vscode-antlers-language-server` -> 404) and pointed at a deleted grammar repo. 0.2.0 installs `antlers-language-server@1.3.14` and uses a live grammar fork. Verified locally in Zed: grammar compiles, syntax highlighting renders, and the language server starts cleanly.