### PR TITLE
Added zed-obsidian-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zed-obsidian-theme"]
+	path = extensions/zed-obsidian-theme
+	url = https://github.com/SECT19N/zed-obsidian-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -5191,6 +5191,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-obsidian-theme]
+submodule = "extensions/zed-obsidian-theme"
+version = "1.0.0"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"


### PR DESCRIPTION
This PR adds the **Obsidian Theme** extension inspired by Notepad++'s Obsidian Theme with inspirations from the Zed Vercel theme.

- **Repo**: https://github.com/SECT19N/zed-obsidian-theme
- **License**: MIT (exists in Repo)
- Tested Locally as a **Dev Extension** in both Light and Dark variant.

### Dark mode:

<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/13e31dc7-f8a7-4959-83e0-4d6a7e039e82" />

### Light mode:

<img width="1920" height="1048" alt="image" src="https://github.com/user-attachments/assets/ae49ef76-e0eb-4351-9b28-516872a9ec1e" />

---
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
