### PR TITLE
Add Vyper extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4946,6 +4946,10 @@
 	path = extensions/vynora
 	url = https://github.com/QuarkPixel/Vynora.git
 
+[submodule "extensions/vyper"]
+	path = extensions/vyper
+	url = https://github.com/0xpantera/zed-vyper.git
+
 [submodule "extensions/wakatime"]
 	path = extensions/wakatime
 	url = https://github.com/wakatime/zed-wakatime.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5029,6 +5029,10 @@ version = "0.0.1"
 submodule = "extensions/vynora"
 version = "0.0.3"
 
+[vyper]
+submodule = "extensions/vyper"
+version = "0.0.1"
+
 [wakatime]
 submodule = "extensions/wakatime"
 version = "0.1.10"


### PR DESCRIPTION
## Summary

Adds the Vyper language extension to the Zed extension registry.

Extension repository: https://github.com/0xpantera/zed-vyper

The extension provides:

- `.vy` file detection
- Tree-sitter grammar support via a pinned Vyper grammar fork
- Syntax highlighting, bracket matching, outline, indentation, and text objects
- `vyper-lsp` startup, preferring `PATH` and falling back to an extension-local `uv` virtual environment

## Local validation

Ran in the extension repo:

- `cargo fmt`
- `cargo check`
- `cargo build --target wasm32-wasip2`
- `bash scripts/validate.sh`

Ran in this registry repo:

- `pnpm build`
- `pnpm test`
- `RUSTUP_TOOLCHAIN=1.90 REF_NAME=add-vyper-extension pnpm package-extensions vyper`
- sorted `.gitmodules` / `extensions.toml` via `pnpm sort-extensions`
- Git LFS check equivalent from CI

Package output produced `output/manifest.json` and `output/archive.tar.gz` successfully.
