### PR TITLE
Add One Dark Pro Full theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3258,6 +3258,10 @@
 	path = extensions/one-dark-pro-enhanced
 	url = https://github.com/hadez8877/one-dark-pro-enhanced.git
 
+[submodule "extensions/one-dark-pro-full-theme"]
+	path = extensions/one-dark-pro-full-theme
+	url = https://github.com/Alivers/one-dark-pro-full-theme.git
+
 [submodule "extensions/one-dark-pro-max"]
 	path = extensions/one-dark-pro-max
 	url = https://github.com/kussumma/one-dark-pro-max.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3311,6 +3311,10 @@ version = "0.0.11"
 submodule = "extensions/one-dark-pro-enhanced"
 version = "0.0.12"
 
+[one-dark-pro-full-theme]
+submodule = "extensions/one-dark-pro-full-theme"
+version = "0.3.1"
+
 [one-dark-pro-max]
 submodule = "extensions/one-dark-pro-max"
 version = "0.0.2"


### PR DESCRIPTION
Adds **One Dark Pro Full** — a faithful Zed port of Binaryify's VS Code [One Dark Pro](https://github.com/Binaryify/OneDark-Pro) theme.

Includes all five upstream variants as a single theme family:

- One Dark Pro
- One Dark Pro Darker
- One Dark Pro Flat
- One Dark Pro Mix
- One Dark Pro Night Flat

All colors (backgrounds, syntax, terminal ANSI, git/diagnostic states, italics) are extracted directly from the upstream theme JSON files rather than approximated, so each variant matches its VS Code counterpart. The theme conforms to `themes/v0.2.0.json`.

- Extension id: `one-dark-pro-full-theme` (unique; distinct from the existing `one-dark-pro`)
- Repo: https://github.com/Alivers/one-dark-pro-full-theme
- License: MIT

Checklist:
- [x] Submodule uses an HTTPS URL on a non-detached branch commit
- [x] `extensions.toml` version matches `extension.toml` (0.3.0)
- [x] Ran `pnpm sort-extensions`