### PR TITLE
Update warplabs to v0.17.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5111,7 +5111,7 @@ version = "0.1.1"
 
 [warplabs]
 submodule = "extensions/warplabs"
-version = "0.14.0"
+version = "0.17.0"
 
 [wat]
 submodule = "extensions/wat"


### PR DESCRIPTION
## Update warplabs to 0.17.0

Bumps the `warplabs` extension to version **0.17.0**.

### Changes
- `extensions.toml`: `warplabs` version → `0.17.0`
- `extensions/warplabs` submodule pointer → `a0d678a`

### What's in 0.17.0
- Align WFL/WFG to the unified `tree-sitter-wfl` grammar (rev `4130020`)
- Update WFL/WFG queries and examples for renamed grammar nodes
- Add MoJu language support (queries, example, extension entry)
- Remove dead `[grammars.wfg]` config

Tested locally as a dev extension; grammar parse + query checks pass for all WFL/WFG examples.