### PR TITLE
Add Abide extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,10 @@
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme
 
+[submodule "extensions/abide"]
+	path = extensions/abide
+	url = https://github.com/briancray/abide.git
+
 [submodule "extensions/abysswalker-theme"]
 	path = extensions/abysswalker-theme
 	url = https://github.com/ModusTeam/abysswalker-zed.git
@@ -5197,6 +5201,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/abide"]
-	path = extensions/abide
-	url = https://github.com/briancray/abide.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/abide"]
+	path = extensions/abide
+	url = https://github.com/briancray/abide.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -18,6 +18,11 @@ version = "0.1.0"
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"
 
+[abide]
+submodule = "extensions/abide"
+path = "editors/zed/abide"
+version = "0.0.1"
+
 [abysswalker-theme]
 submodule = "extensions/abysswalker-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **Abide** extension, which registers the `.abide` language and runs the `abide lsp` language server for type-check diagnostics and semantic-token highlighting of `.abide` components.

- Repository: https://github.com/briancray/abide (MIT licensed)
- Extension source: `editors/zed/abide` (pinned via submodule)
- Reuses `tree-sitter-html` for element/attribute/`<script>`/`<style>` structure; abide-specific `{#…}` blocks and `{expr}` interiors are highlighted by `abide lsp` via LSP semantic tokens (requires `"semantic_tokens": "combined"`).

Tested locally as a dev extension.