### PR TITLE
Add Monokai extension that has all monokai themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2850,8 +2850,8 @@
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git
 
-[submodule "extensions/monokai-for-zed"]
-	path = extensions/monokai-for-zed
+[submodule "extensions/monokai"]
+	path = extensions/monokai
 	url = https://github.com/shariqnaiyer/monokai-for-zed.git
 
 [submodule "extensions/monokai-nebula"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -2850,6 +2850,10 @@
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git
 
+[submodule "extensions/monokai-for-zed"]
+	path = extensions/monokai-for-zed
+	url = https://github.com/shariqnaiyer/monokai-for-zed.git
+
 [submodule "extensions/monokai-nebula"]
 	path = extensions/monokai-nebula
 	url = https://github.com/JacobCallahan/monokai-nebula-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2901,6 +2901,10 @@ submodule = "extensions/monochromator-theme"
 path = "editors/zed"
 version = "0.2.2"
 
+[monokai-for-zed]
+submodule = "extensions/monokai-for-zed"
+version = "0.1.0"
+
 [monokai-nebula]
 submodule = "extensions/monokai-nebula"
 version = "0.2.6"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2901,8 +2901,8 @@ submodule = "extensions/monochromator-theme"
 path = "editors/zed"
 version = "0.2.2"
 
-[monokai-for-zed]
-submodule = "extensions/monokai-for-zed"
+[monokai]
+submodule = "extensions/monokai"
 version = "0.1.0"
 
 [monokai-nebula]


### PR DESCRIPTION
This PR adds **Monokai for Zed**, a theme extension bundling the full Monokai family in one extension:

- Monokai
- Monokai Classic
- Monokai Dimmed
- Monokai Pro
- Monokai Pro filters: Machine, Octagon, Ristretto, Spectrum
- Monokai Pro Light
- Light (Filter Sun)

All themes target the Zed `v0.2.0` theme schema and are generated from a single palette table.

None of the other extensions have all of the color themes.

Repository: https://github.com/shariqnaiyer/monokai-for-zed
License: MIT