### PR TITLE
Add es-js-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1326,6 +1326,10 @@
 	path = extensions/erlang
 	url = https://github.com/zed-extensions/erlang.git
 
+[submodule "extensions/es-js-snippets"]
+	path = extensions/es-js-snippets
+	url = https://github.com/jhomudev/es-js-snippets-zed.git
+
 [submodule "extensions/esmerald-theme"]
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1349,6 +1349,10 @@ version = "0.1.0"
 submodule = "extensions/erlang"
 version = "0.2.1"
 
+[es-js-snippets]
+submodule = "extensions/es-js-snippets"
+version = "0.1.0"
+
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
 version = "0.1.2"


### PR DESCRIPTION
Adds the ES JS Snippets extension, a Zed port of the vscode-react-javascript-snippets extension by r5n-labs.\n\nIt provides 197 snippets for React 17-19, React Native, Redux Toolkit, React Router v6, PropTypes, modern JavaScript/ES7+, TypeScript and TSX.\n\nRepository: https://github.com/jhomudev/es-js-snippets-zed