### PR TITLE
Add css-modules language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -878,6 +878,10 @@
 	path = extensions/cspell
 	url = https://github.com/mantou132/zed-cspell
 
+[submodule "extensions/css-modules"]
+	path = extensions/css-modules
+	url = https://github.com/gugahoi/zed-css-modules-lsp.git
+
 [submodule "extensions/css-modules-kit"]
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -978,6 +978,10 @@
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git
 
+[submodule "extensions/css-modules-lsp"]
+	path = extensions/css-modules-lsp
+	url = https://github.com/gugahoi/zed-css-modules-lsp.git
+
 [submodule "extensions/css-variables"]
 	path = extensions/css-variables
 	url = https://github.com/lmn451/css-variables-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -893,6 +893,10 @@ version = "1.2.4"
 submodule = "extensions/cspell"
 version = "0.0.7"
 
+[css-modules]
+submodule = "extensions/css-modules"
+version = "0.0.1"
+
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
 version = "0.1.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1000,6 +1000,10 @@ submodule = "extensions/css-modules-kit"
 version = "0.1.1"
 path = "crates/zed"
 
+[css-modules-lsp]
+submodule = "extensions/css-modules-lsp"
+version = "0.0.1"
+
 [css-variables]
 submodule = "extensions/css-variables"
 version = "0.1.1"


### PR DESCRIPTION
Adds the `css-modules-lsp` extension, which provides a language server for CSS Modules in JS/TS files (go-to-definition, hover, and completions from `.tsx`/`.ts`/`.js` to `*.module.css`).

The extension wraps [`cssmodules-language-server`](https://github.com/antonk52/cssmodules-language-server) via npm, using Zed's bundled Node runtime as a fallback when the binary isn't on `$PATH`.

- Extension id: `css-modules-lsp`
- Source repo: https://github.com/gugahoi/zed-css-modules-lsp
- License: MIT