### PR TITLE
Add Rose Pine Blue Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3882,6 +3882,10 @@
 	path = extensions/ron
 	url = https://github.com/onbjerg/zed-ron.git
 
+[submodule "extensions/rose-pine-blur"]
+	path = extensions/rose-pine-blur
+	url = https://github.com/Sataros221/rose-pine-blur.git
+
 [submodule "extensions/rose-pine-recast-theme"]
 	path = extensions/rose-pine-recast-theme
 	url = https://github.com/ng-hai/zed-rose-pine-recast.git
@@ -5197,6 +5201,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/rose-pine-blur"]
-	path = extensions/rose-pine-blur
-	url = https://github.com/Sataros221/rose-pine-blur.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/rose-pine-blur"]
+	path = extensions/rose-pine-blur
+	url = https://github.com/Sataros221/rose-pine-blur.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,7 +1,3 @@
-[rose-pine-blur]
-submodule = "extensions/rose-pine-theme-blur"
-version = "1.0.0"
-
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.6"
@@ -3951,6 +3947,10 @@ version = "0.1.0"
 [ron]
 submodule = "extensions/ron"
 version = "0.0.1"
+
+[rose-pine-blur]
+submodule = "extensions/rose-pine-theme-blur"
+version = "1.0.0"
 
 [rose-pine-recast-theme]
 submodule = "extensions/rose-pine-recast-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[rose-pine-blur]
+submodule = "extensions/rose-pine-theme-blur"
+version = "1.0.0"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.6"
@@ -3955,10 +3959,6 @@ version = "0.0.1"
 [rose-pine-theme]
 submodule = "extensions/rose-pine-theme"
 version = "1.4.0"
-
-[rose-pine-blur]
-submodule = "extensions/rose-pine-theme-blur"
-version = "0.0.0"
 
 [rosevin]
 submodule = "extensions/rosevin"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3956,6 +3956,10 @@ version = "0.0.1"
 submodule = "extensions/rose-pine-theme"
 version = "1.4.0"
 
+[rose-pine-blur]
+submodule = "extensions/rose-pine-theme-blur"
+version = "0.0.0"
+
 [rosevin]
 submodule = "extensions/rosevin"
 version = "0.1.0"


### PR DESCRIPTION
Add **Rose Pine Blur** a fork of the [Catppuccin Blur](https://github.com/jenslys/zed-catppuccin-blur) Theme but for the rose pine palette.

Includes all three upstream variants and ands a custom one:

- Rose Pine 
- Rose Pine Dawn
- Rose Pine Moon
- Rose Pine Dusk (Custom)

All colors (backgrounds, syntax, terminal ANSI, git/diagnostic states, italics) are extracted directly from the upstream theme JSON files.

- Extension id: `rose-pine-blur`
- Repo: https://github.com/Sataros221/rose-pine-blur
- License: MIT

Checklist:
- [x] Submodule uses an HTTPS URL on a non-detached branch commit
- [x] `extensions.toml` version matches `extension.toml` (1.0.0)
- [x] Ran `pnpm sort-extensions`