### PR TITLE
Update vscode-dark-modern to v0.1.13

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4975,7 +4975,7 @@ version = "1.0.0"
 
 [vscode-dark-modern]
 submodule = "extensions/vscode-dark-modern"
-version = "0.1.2"
+version = "0.1.3"
 
 [vscode-dark-plus]
 submodule = "extensions/vscode-dark-plus"


### PR DESCRIPTION
Bumps `vscode-dark-modern` to `v0.1.13`.
- adds `tag.component.jsx` highlighting
- update `punctuation.special` to be lighter
- update `text.muted`  to be lighter

By @belizariogr in https://github.com/kevcamel/vscode_dark_modern.zed/pull/33