### PR TITLE
Add Obsidian Theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3182,6 +3182,10 @@
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git
 
+[submodule "extensions/obsidian-theme"]
+	path = extensions/obsidian-theme
+	url = https://github.com/SECT19N/zed-obsidian-theme.git
+
 [submodule "extensions/oc-2-theme"]
 	path = extensions/oc-2-theme
 	url = https://github.com/nstlgy/oc-2-theme
@@ -5197,6 +5201,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/zed-obsidian-theme"]
-	path = extensions/zed-obsidian-theme
-	url = https://github.com/SECT19N/zed-obsidian-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zed-obsidian-theme"]
+	path = extensions/zed-obsidian-theme
+	url = https://github.com/SECT19N/zed-obsidian-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -5191,6 +5191,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-obsidian-theme]
+submodule = "extensions/zed-obsidian-theme"
+version = "1.0.0"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5191,9 +5191,9 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
-[zed-obsidian-theme]
-submodule = "extensions/zed-obsidian-theme"
-version = "1.0.0"
+[obsidian-theme]
+submodule = "extensions/obsidian-theme"
+version = "1.2.0"
 
 [zedbox]
 submodule = "extensions/zedbox"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3234,6 +3234,10 @@ version = "1.4.0"
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"
 
+[obsidian-theme]
+submodule = "extensions/obsidian-theme"
+version = "1.2.0"
+
 [oc-2-theme]
 submodule = "extensions/oc-2-theme"
 version = "0.0.1"
@@ -5190,10 +5194,6 @@ version = "0.1.2"
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
-
-[obsidian-theme]
-submodule = "extensions/obsidian-theme"
-version = "1.2.0"
 
 [zedbox]
 submodule = "extensions/zedbox"


### PR DESCRIPTION
Adds the **Obsidian Theme** extension, a dark theme inspired by the Notepad++ Obsidian Theme (specifically Nickc01's VS Code port) and the Zed Vercel Theme.

Theme repo: https://github.com/SECT19N/zed-obsidian-theme
---
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
