### PR TITLE
Update roc to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3938,7 +3938,7 @@ version = "0.0.1"
 
 [roc]
 submodule = "extensions/roc"
-version = "0.0.6"
+version = "0.1.2"
 
 [rockide-language-server]
 submodule = "extensions/rockide-language-server"


### PR DESCRIPTION
Updates the **Roc** extension to **v0.1.2**.

### Changes
- `extensions.toml`: `roc` version `0.0.6` → `0.1.2`
- `extensions/roc` submodule pointer → [`f6a07bf`](https://github.com/h2000/zed-roc/commit/f6a07bfb336549724f9c5694084bfb1869614b5d) (the commit whose `extension.toml` declares `version = "0.1.2"`)

This release updates the extension for the latest Roc LSP (now integrated into the Roc CLI) and switches to the upstream `faldor20/tree-sitter-roc` grammar.

I'm the owner/maintainer of the [h2000/zed-roc](https://github.com/h2000/zed-roc) repository.

- [x] `version` in `extensions.toml` matches `version` in the extension's own `extension.toml`
- [x] Submodule points to a public, pushed commit