### PR TITLE
Add Dark 2026 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -982,6 +982,10 @@
 	path = extensions/darcula-forest-theme
 	url = https://github.com/oryanm/darcula-forest-zed
 
+[submodule "extensions/dark-2026-theme"]
+	path = extensions/dark-2026-theme
+	url = https://github.com/MukileshT/dark-2026-theme.git
+
 [submodule "extensions/dark-castle-theme"]
 	path = extensions/dark-castle-theme
 	url = https://github.com/malucard/dark-castle-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1000,6 +1000,10 @@ version = "0.1.4"
 submodule = "extensions/darcula-forest-theme"
 version = "0.1.0"
 
+[dark-2026-theme]
+submodule = "extensions/dark-2026-theme"
+version = "0.1.0"
+
 [dark-castle-theme]
 submodule = "extensions/dark-castle-theme"
 version = "0.0.4"


### PR DESCRIPTION
## Summary
Adds the 'Dark 2026 theme' extension, closely inspired by VS Code's Dark 2026 theme.

### Features
- Eye-comfort focused dark theme
- Balanced syntax highlighting
- Includes Dark 2026 theme

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
