### PR TITLE
Add Blink IDL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/blink"]
+	path = extensions/blink
+	url = https://github.com/okhalri/zed-blink

--- a/extensions.toml
+++ b/extensions.toml
@@ -478,6 +478,10 @@ version = "0.0.6"
 submodule = "extensions/blinds-theme"
 version = "0.1.0"
 
+[blink]
+submodule = "extensions/blink"
+version = "0.1.0"
+
 [blk-theme]
 submodule = "extensions/blk-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds syntax highlighting for the Blink IDL language (`.blink` files) https://github.com/1Axen/blink.

- Extension: https://github.com/okhalri/zed-blink
- Grammar: https://github.com/okhalri/tree-sitter-blink

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
