### PR TITLE
Update moonbit to v0.1.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.2.0"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.1"
+version = "0.1.6"
 
 [moonlight]
 submodule = "extensions/moonlight"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2475,7 +2475,7 @@ version = "0.2.0"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.6"
+version = "0.1.7"
 
 [moonlight]
 submodule = "extensions/moonlight"


### PR DESCRIPTION
## Summary
This updates the existing MoonBit extension to `v0.1.7`.

Since the previous discussion, I have joined the existing `quirk-lab/zed-moonbit` repository as a maintainer, and the MoonBit 0.10 support has been merged there. This keeps MoonBit support consolidated into a single maintained extension.

## Changes
- Update MoonBit extension to `v0.1.7`
- Update the extension submodule to the latest release commit
- Keep the extension pointing to `quirk-lab/zed-moonbit`
- Includes MoonBit 0.10 grammar and syntax support
- Restores automatic MoonBit language server installation
- Restores MoonBit workspace configuration forwarding
- Restores the `moonbit` language server ID for compatibility with existing Zed settings

This PR updates the existing extension only; it does not introduce a second MoonBit extension.

## Validation
- `git diff --check`
- Verified `.gitmodules` points to `https://github.com/quirk-lab/zed-moonbit.git`
- Verified `[moonbit].version = "0.1.7"` in `extensions.toml`
- Verified `extensions/moonbit` points to tag `v0.1.7` commit `4d2e9cb40c16adbfa4c16f6c5fabc1c975e3419a`
- Verified tracked diff is limited to `extensions.toml` and `extensions/moonbit`
- In `quirk-lab/zed-moonbit`: `cargo fmt --check`, `cargo check`, `just validate-queries`, `just test-syntax`

`pnpm build` could not complete locally due to an unrelated existing TypeScript environment issue: `TS2688: Cannot find type definition file for 'minimatch'`. The MoonBit update diff is limited to the extension version and submodule pointer.