### PR TITLE
Add Spark extension (spark-html)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4198,6 +4198,10 @@
 	path = extensions/spai-zero-theme
 	url = https://github.com/BasaiCorp/zed-spai-zero-theme.git
 
+[submodule "extensions/spark-html"]
+	path = extensions/spark-html
+	url = https://github.com/wilkinnovo/spark.git
+
 [submodule "extensions/spiceflow-theme"]
 	path = extensions/spiceflow-theme
 	url = https://github.com/remorses/spiceflow-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -4270,7 +4270,7 @@ version = "0.2.1"
 [spark-html]
 submodule = "extensions/spark-html"
 path = "editors/zed"
-version = "0.2.0"
+version = "0.3.0"
 
 [spiceflow-theme]
 submodule = "extensions/spiceflow-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4267,6 +4267,11 @@ version = "0.0.1"
 submodule = "extensions/spai-zero-theme"
 version = "0.2.1"
 
+[spark-html]
+submodule = "extensions/spark-html"
+path = "editors/zed"
+version = "0.2.0"
+
 [spiceflow-theme]
 submodule = "extensions/spiceflow-theme"
 version = "0.0.0"


### PR DESCRIPTION
This PR adds the **Spark** extension (`spark-html`) — language support for [spark-html](https://github.com/wilkinnovo/spark) single-file components.

`spark-html` components are plain `.html` files (HTML + `{expression}` interpolations + `<script>`/`<style>`), so they are a syntactic subset of Svelte. The extension reuses the well-tested **tree-sitter-svelte** grammar and ships Spark-tuned queries:

- `{interpolation}` highlighted as JavaScript
- `<script>` injected as JavaScript, `<style>` as CSS
- HTML tags, attributes, comments

Details:
- Extension lives at `editors/zed` in the source repo (declared via `path`).
- Grammar pinned by rev in `extension.toml`.
- MIT licensed (`editors/zed/LICENSE`).
- Tested locally as a dev extension.

### Checklist
- [x] I have tested my extension locally.
- [x] The extension repository includes an accepted license.