### PR TITLE
Add deep-slate-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/deep-slate-theme"]
+	path = extensions/deep-slate-theme
+	url = https://github.com/Roter-S/deep-slate-theme.git
+	branch = zed


### PR DESCRIPTION
Adding my own **Deep Slate** theme for Zed, which I adapted from my original VS Code version. 

The extension has been tested locally as a dev extension and the repository includes the required MIT License.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
