### PR TITLE
Add Flynt theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1486,6 +1486,10 @@
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets
 
+[submodule "extensions/flynt"]
+	path = extensions/flynt
+	url = https://github.com/flynt-theme/flynt-zed
+
 [submodule "extensions/focus-theme"]
 	path = extensions/focus-theme
 	url = https://github.com/jigyansunanda/focus.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1486,8 +1486,8 @@
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets
 
-[submodule "extensions/flynt"]
-	path = extensions/flynt
+[submodule "extensions/flynt-theme"]
+	path = extensions/flynt-theme
 	url = https://github.com/flynt-theme/flynt-zed
 
 [submodule "extensions/focus-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1512,6 +1512,10 @@ version = "1.0.0"
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"
 
+[flynt]
+submodule = "extensions/flynt"
+version = "0.1.0"
+
 [focus-theme]
 submodule = "extensions/focus-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1512,9 +1512,9 @@ version = "1.0.0"
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"
 
-[flynt]
-submodule = "extensions/flynt"
-version = "0.1.0"
+[flynt-theme]
+submodule = "extensions/flynt-theme"
+version = "0.1.1"
 
 [focus-theme]
 submodule = "extensions/focus-theme"


### PR DESCRIPTION
Adds the [Flynt](https://github.com/flynt-theme/flynt-zed) theme extension.

Flynt is a warm, minimal color palette with dark and light variants. Warm tones, zero visual noise. Tested locally as a dev extension.

- Extension repo: https://github.com/flynt-theme/flynt-zed
- Docs: https://flynt-theme.github.io/flynt
- License: MIT