### PR TITLE
Add Itá extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2058,6 +2058,10 @@
 	path = extensions/isle
 	url = https://github.com/eagr/zed-isle.git
 
+[submodule "extensions/ita"]
+	path = extensions/ita
+	url = https://github.com/ita-lang/zed-ita.git
+
 [submodule "extensions/iterm2-default-theme"]
 	path = extensions/iterm2-default-theme
 	url = https://github.com/EtanHey/zed-iterm-default-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2100,6 +2100,10 @@ version = "0.2.0"
 submodule = "extensions/isle"
 version = "0.0.1"
 
+[ita]
+submodule = "extensions/ita"
+version = "0.1.0"
+
 [iterm2-default-theme]
 submodule = "extensions/iterm2-default-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Itá** — a strongly-typed, immutable-by-default, functional-first language that compiles to Dart Kernel and runs on the Dart VM.

The extension provides:
- **Semantic syntax highlighting** via tree-sitter — captures grouped by family (value/reference, async/stream, functional, error, unsafe), with dotted captures that fall back gracefully on third-party themes.
- **Itá Semantic theme** (Dark + Light), with WCAG AA contrast.

Links:
- Extension: https://github.com/ita-lang/zed-ita
- Grammar: https://github.com/ita-lang/tree-sitter-ita

🤖 Generated with [Claude Code](https://claude.com/claude-code)
