### PR TITLE
Add Itá Semantic theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2058,6 +2058,10 @@
 	path = extensions/isle
 	url = https://github.com/eagr/zed-isle.git
 
+[submodule "extensions/ita-theme"]
+	path = extensions/ita-theme
+	url = https://github.com/ita-lang/ita-theme.git
+
 [submodule "extensions/iterm2-default-theme"]
 	path = extensions/iterm2-default-theme
 	url = https://github.com/EtanHey/zed-iterm-default-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2100,6 +2100,10 @@ version = "0.2.0"
 submodule = "extensions/isle"
 version = "0.0.1"
 
+[ita-theme]
+submodule = "extensions/ita-theme"
+version = "0.1.0"
+
 [iterm2-default-theme]
 submodule = "extensions/iterm2-default-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the **Itá Semantic** color theme (Dark & Light) for the [Itá](https://github.com/ita-lang) language.

The theme maps the language's tree-sitter captures to a palette **by family** — value/reference, async/stream, functional, error, unsafe. Both variants meet **WCAG AA** contrast.

Pairs with the Itá language extension (#6660), but also works as a standalone theme.

Repo: https://github.com/ita-lang/ita-theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)
