### PR TITLE
Add gol-check extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1710,6 +1710,10 @@
 	path = extensions/godot-theme
 	url = https://github.com/D4r3NPo/zed-godot-theme.git
 
+[submodule "extensions/gol-check"]
+	path = extensions/gol-check
+	url = https://github.com/golproductions/check-zed.git
+
 [submodule "extensions/golangci-lint"]
 	path = extensions/golangci-lint
 	url = https://github.com/zed-extensions/golangci-lint.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1744,6 +1744,10 @@ version = "0.1.5"
 submodule = "extensions/godot-theme"
 version = "1.3.0"
 
+[gol-check]
+submodule = "extensions/gol-check"
+version = "1.0.1"
+
 [golangci-lint]
 submodule = "extensions/golangci-lint"
 version = "0.2.0"


### PR DESCRIPTION
Adds [gol-check](https://github.com/golproductions/check-zed) to the Zed extension registry.

Check is the anti-hallucination layer for AI coding agents. It stops hallucinated commands, imports, and function calls before they reach your project. Deterministic, sub-100ms, no AI inside.

- [Product page](https://www.golproductions.com/check.html)
- [npm package](https://www.npmjs.com/package/@golproductions/check)