### PR TITLE
Update tomorrow-theme to v1.2.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4650,7 +4650,7 @@ version = "0.0.1"
 
 [tomorrow-theme]
 submodule = "extensions/tomorrow-theme"
-version = "1.2.0"
+version = "1.2.1"
 
 [ton]
 submodule = "extensions/ton"


### PR DESCRIPTION
## Summary
- merged in [fix: resolve syntax highlight bleeding by explicitly defining structural captures](https://github.com/bIaqat/tomorrow-theme-zed/pull/9)

