### PR TITLE
Add navigator-lsp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2950,6 +2950,10 @@
 	path = extensions/navi
 	url = https://github.com/navi-language/zed-navi.git
 
+[submodule "extensions/navigator-lsp"]
+	path = extensions/navigator-lsp
+	url = https://github.com/neon-law-foundation/zed-navigator-lsp.git
+
 [submodule "extensions/naysayer-theme"]
 	path = extensions/naysayer-theme
 	url = https://github.com/darzaccaro/naysayer-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3001,6 +3001,10 @@ version = "0.1.0"
 submodule = "extensions/navi"
 version = "0.4.1"
 
+[navigator-lsp]
+submodule = "extensions/navigator-lsp"
+version = "26.6.28"
+
 [naysayer-theme]
 submodule = "extensions/naysayer-theme"
 version = "1.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Navigator LSP** (`navigator-lsp`) — Markdown diagnostics and `source.fixAll` for every Markdown file, with a stricter notation-template superset layered on top, powered by the `navigator-lsp` language server.

- Repository: https://github.com/neon-law-foundation/zed-navigator-lsp
- License: dual Apache-2.0 / MIT (both `LICENSE-APACHE` and `LICENSE-MIT` in the repo root)
- No bundled language server: on first run the extension downloads the matching prebuilt `navigator-lsp` binary from the upstream GitHub Release and caches it per version, or uses one already on `$PATH` / a configured `binary.path`.
- Tested locally as a dev extension in Zed (`zed: install dev extension`) against Markdown buffers.