### PR TITLE
Add Pine Script extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3506,6 +3506,10 @@
 	path = extensions/pinata-theme
 	url = https://github.com/stevedylandev/pinata-theme-zed
 
+[submodule "extensions/pine-script"]
+	path = extensions/pine-script
+	url = https://github.com/nuniesmith/pine-script-zed.git
+
 [submodule "extensions/pink-candy-theme"]
 	path = extensions/pink-candy-theme
 	url = https://github.com/paulovictor237/pink-candy-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3563,6 +3563,10 @@ version = "0.1.0"
 submodule = "extensions/pinata-theme"
 version = "0.0.1"
 
+[pine-script]
+submodule = "extensions/pine-script"
+version = "0.1.0"
+
 [pink-candy-theme]
 submodule = "extensions/pink-candy-theme"
 version = "0.2.0"


### PR DESCRIPTION
Adds a **Pine Script** extension providing TradingView Pine Script v6 support: syntax highlighting, diagnostics, hover docs, and completions.

- Extension repo: https://github.com/nuniesmith/pine-script-zed
- Language server: https://github.com/nuniesmith/pine-lsp (MIT, downloaded from GitHub Releases at runtime)
- Grammar: [kvarenzn/tree-sitter-pine](https://github.com/kvarenzn/tree-sitter-pine) (referenced by commit, not vendored)

### Resubmission of #5437

My earlier PR (#5437) was closed for not following the contributing guidelines. This is a fresh submission with those issues addressed:

- **Language server is no longer bundled.** It now lives in its own repo and is downloaded from a GitHub Release for the user's platform (with a `PATH` fallback), per the guideline that language/grammar extensions must not ship the server.
- **Submodule uses an HTTPS URL** (not SSH).
- **Accepted license** (MIT) at the repository root.
- **Only required resources are included** — the LSP source and local test files were removed from the extension repo.
- **Fixed the language config** so the language actually registers and highlights (the previous `config.toml` used an invalid schema).

### Compliance checklist

- [x] Submodule added under `extensions/pine-script` via **HTTPS**
- [x] Submodule commit is on a branch (`main`), repo is public
- [x] `extensions.toml` version (`0.1.0`) matches `extension.toml`
- [x] Ran `pnpm sort-extensions`
- [x] ID/name contain no `zed`/`extension`; `pine-script` describes the language
- [x] MIT license at repo root
- [x] Tested locally as a dev extension (highlighting + LSP verified)
