### PR TITLE
Add Mindnight Prism theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/midnight-prism"]
+	path = extensions/midnight-prism
+	url = https://github.com/RahulKhanSuvo/midnight-prism.git


### PR DESCRIPTION
* [x] I've read `CONTRIBUTING.md` and followed the relevant guidance for adding or updating my extension.

This PR adds the Midnight Prism theme extension.

Repository:
https://github.com/RahulKhanSuvo/midnight-prism

Midnight Prism is a cyberpunk-inspired dark theme for Zed featuring neon syntax colors, deep backgrounds, Git integration colors, terminal ANSI colors, and multiplayer cursor support.

