### PR TITLE
Add Erlang OTP LS extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1326,6 +1326,10 @@
 	path = extensions/erlang
 	url = https://github.com/zed-extensions/erlang.git
 
+[submodule "extensions/erlang-otp-ls"]
+	path = extensions/erlang-otp-ls
+	url = https://github.com/ouweibiao/zed-erlang-otp-ls.git
+
 [submodule "extensions/esmerald-theme"]
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1349,6 +1349,10 @@ version = "0.1.0"
 submodule = "extensions/erlang"
 version = "0.2.1"
 
+[erlang-otp-ls]
+submodule = "extensions/erlang-otp-ls"
+version = "0.1.0"
+
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
 version = "0.1.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This adds `erlang-otp-ls`, a small Zed extension that lets users run Erlang LS with the OTP/runtime selected by their project.

Why a separate extension:
- The existing Erlang extension provides general Erlang support.
- This extension is focused on review workflows where the project is pinned to a specific OTP release, especially Windows projects that need to launch an OTP-compatible `erlang_ls` through `escript.exe`.
- It only declares a configurable language server command and does not try to replace Erlang grammar/highlighting support.

Local validation performed on the extension repository:
- `powershell -ExecutionPolicy Bypass -File scripts/Test-ErlangOtpLs.ps1`
- `node scripts/Test-ErlangLsDefinition.mjs` with an OTP 23 `escript.exe` + `erlang_ls 0.48.1` command

Registry validation performed here:
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm sort-extensions`
- `corepack pnpm build`
- `corepack pnpm test`
- `git diff --check`