### PR TITLE
Add plyn extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3550,6 +3550,10 @@
 	path = extensions/playdate
 	url = https://github.com/notpeter/playdate-zed-extension.git
 
+[submodule "extensions/plyn"]
+	path = extensions/plyn
+	url = https://github.com/plainlang/plyn.git
+
 [submodule "extensions/po"]
 	path = extensions/po
 	url = https://git.disroot.org/gemmaro/zed-po.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3607,6 +3607,11 @@ version = "0.0.1"
 submodule = "extensions/playdate"
 version = "0.1.2"
 
+[plyn]
+submodule = "extensions/plyn"
+path = "zed"
+version = "0.0.1"
+
 [po]
 submodule = "extensions/po"
 version = "0.1.0"


### PR DESCRIPTION
Adds **plyn**, language support for the `***plain` spec-driven language by *codeplain.

- Extension id: `plyn`, version `0.0.1`
- Source: https://github.com/plainlang/plyn (extension lives in the `zed/` subdirectory, referenced via the `path` field)
- Tree-sitter grammar: https://github.com/plainlang/tree-sitter-plain
- Provides a tree-sitter grammar, an icon theme for `.plain` files, and a language server (`plain-language-server`) launched via the Rust extension shim.
- MIT licensed (`zed/LICENSE`).
- Tested locally as a dev extension.