### PR TITLE
Update dependi to v1.9.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1079,7 +1079,7 @@ version = "0.1.1"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.9.0"
+version = "1.9.1"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
## Summary

• Update dependi extension to v1.9.1
• Point the dependi submodule at the v1.9.1 release commit

## Type

chore

## Validation

• pnpm package-extensions dependi
• pnpm sort-extensions
• pnpm build
• pnpm test
• RUSTUP_TOOLCHAIN=1.90 cargo build --release --target wasm32-wasip2
