### PR TITLE
Update cem to v0.11.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -647,7 +647,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.10.5"
+version = "0.11.0"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
Updates cem extension to [version 0.11.0](https://github.com/bennypowers/cem/releases/tag/v0.11.0).