### PR TITLE
Add regex-linter-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3774,6 +3774,10 @@
 	path = extensions/regedit
 	url = https://github.com/JasonGH17/regedit
 
+[submodule "extensions/regex-linter-lsp"]
+	path = extensions/regex-linter-lsp
+	url = https://github.com/GottemHams/zed-regex-linter-lsp.git
+
 [submodule "extensions/regex-theme"]
 	path = extensions/regex-theme
 	url = https://github.com/oxnan/RegEx-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3836,6 +3836,10 @@ version = "0.2.0"
 submodule = "extensions/regedit"
 version = "0.0.1"
 
+[regex-linter-lsp]
+submodule = "extensions/regex-linter-lsp"
+version = "1.0.0"
+
 [regex-theme]
 submodule = "extensions/regex-theme"
 version = "0.11.11"


### PR DESCRIPTION
- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This started as a simple "linter" for highlighting annotations like `TODO`, but I figured other people could come up with other regexable strings they want to see reported via LSP as well, so I turned it into a generic regex-based linter instead. The annotations are now simply built-in but disabled by default, so the extension is at least not without any real functions on its own.

Some screenshots:

<img width="400" height="199" alt="image" src="https://github.com/user-attachments/assets/809a5b37-f97c-4821-ae16-2ec7c9c8de47" />
 
<img width="400" height="397" alt="image" src="https://github.com/user-attachments/assets/917baaef-6a9d-4663-97f4-24e8c8d9219e" />

As you can see it's somewhat aware of block comments, but this doesn't span across multiple lines because it still only deals with individual lines. Nested comments can prevent correctly extracting the actual message part, since it only cares about the first comment on the line. This is just a general-purpose linter, anything that's truly aware of any language's syntax would need a separate, full-fledged LSP anyway. It does support parsing some "label delimiters" (`:` or any amount of `-`) so you can do things like `// TODO: foo` or `# FIXME -- bar` and it'll try to extract the actual message part from that.

For every given linter it'll only report 1 issue per severity level per line, so e.g. `// MY_ERROR1 MY_ERROR2 MY_INFO` will only trigger diagnostics for `MY_ERROR1` and `MY_INFO`.