### PR TITLE
Add inlang language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2094,6 +2094,10 @@
 	path = extensions/inko
 	url = https://github.com/inko-lang/zed.git
 
+[submodule "extensions/inlang-language-server"]
+	path = extensions/inlang-language-server
+	url = https://github.com/NEKOYASAN/inlang-zed
+
 [submodule "extensions/intellij-light-theme"]
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2136,6 +2136,10 @@ version = "0.0.2"
 submodule = "extensions/inko"
 version = "0.0.1"
 
+[inlang-language-server]
+submodule = "extensions/inlang-language-server"
+version = "0.0.1"
+
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"


### PR DESCRIPTION
Add Inlang language server support

This extension provides language-server support for Inlang and Paraglide message references, including inline hints, hovers, diagnostics, reference navigation, and code lenses.

This extension was developed inspired by [opral/sherlock](https://github.com/opral/sherlock), which is Inlang's VS Code extension. Since Sherlock does not support Zed, this extension was created to make similar inspections available in Zed.

inline hint & hovers
<img width="810" height="534" alt="image" src="https://github.com/user-attachments/assets/31755143-e4f8-44b3-ac57-d1334a29572f" />

diagnostics
<img width="786" height="213" alt="image" src="https://github.com/user-attachments/assets/bc8e61f1-33dc-4993-abe3-91f1186abc55" />

reference navigation
<img width="1479" height="741" alt="image" src="https://github.com/user-attachments/assets/c47ba7ba-5d40-418d-9503-776ac775b7c7" />


Code lens 
<img width="948" height="250" alt="image" src="https://github.com/user-attachments/assets/dde3bc5b-67d9-4582-ba23-deda5219a46c" />


<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
