### PR TITLE
Add act101 MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,10 @@
 	path = extensions/abysswalker-theme
 	url = https://github.com/ModusTeam/abysswalker-zed.git
 
+[submodule "extensions/act101"]
+	path = extensions/act101
+	url = https://github.com/act101-ai/act101.git
+
 [submodule "extensions/actionscript"]
 	path = extensions/actionscript
 	url = https://github.com/pngdrift/zed-actionscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -22,6 +22,11 @@ version = "0.0.1"
 submodule = "extensions/abysswalker-theme"
 version = "0.1.0"
 
+[act101]
+submodule = "extensions/act101"
+path = "zed-extension"
+version = "2.0.1"
+
 [actionscript]
 submodule = "extensions/actionscript"
 version = "0.1.1"


### PR DESCRIPTION
Adds **act101**, an AST-aware code-transformation MCP server, as a Zed context server extension.

- Submodule: `act101-ai/act101` (`path = zed-extension`), pinned to the v2.0.1 release commit.
- The extension only registers act101 as a context server and launches the installed `act` binary — it does not download or cache a binary; `act` owns install, licensing, and auto-update.

I have signed the Zed CLA with this account.