### PR TITLE
Update cem to v0.11.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -647,7 +647,7 @@ version = "0.0.1"
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"
-version = "0.10.5"
+version = "0.11.0"
 
 [cfengine]
 submodule = "extensions/cfengine"


### PR DESCRIPTION
Updates the cem submodule to v0.11.0, which includes a fix for the
`zed_extension_api` 0.7.0 breaking change (`Project::worktrees()` removed,
replaced by `worktree_ids()`).

Supersedes #6676 which failed CI due to this API change.