### PR TITLE
Update sqlalchemy-lsp to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4286,7 +4286,7 @@ version = "1.1.7"
 [sqlalchemy-lsp]
 submodule = "extensions/sqlalchemy-lsp"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.1.1"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"


### PR DESCRIPTION
## Summary

- Updates `sqlalchemy-lsp` from `0.1.0` → `0.1.1`
- Fixes server ID: was registered as `sqlalchemy_lsp` (underscore), now correctly `sqlalchemy-lsp` (hyphen), matching the binary name and `lsp` config key in Zed settings