### PR TITLE
Add kanata language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+
+[submodule "extensions/kanata"]
+	path = extensions/kanata
+	url = https://github.com/sinder38/kbd-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5278,3 +5278,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[kanata]
+submodule = "extensions/kanata"
+version = "0.0.1"


### PR DESCRIPTION
This is a language extension to work with `.kbd` files used by Kanata and Kmonad.
Currently it supports only kanata, but is still much better than nothing for Kmonad.


Here are some previews:
<img width="912" height="903" alt="image" src="https://github.com/user-attachments/assets/a75338b3-22e1-4f38-b9c9-f761c039e7fb" />

https://github.com/user-attachments/assets/b56b2dc0-fb17-4968-aa32-6867d62ba6b6

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
