### PR TITLE
Add Elasticsearch extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1234,6 +1234,10 @@
 	path = extensions/ejs
 	url = https://github.com/dangh/zed-ejs.git
 
+[submodule "extensions/elasticsearch"]
+	path = extensions/elasticsearch
+	url = https://github.com/foulkelore/zed-elasticsearch.git
+
 [submodule "extensions/elderberry"]
 	path = extensions/elderberry
 	url = https://github.com/IronGeek/zed-theme-elderberry.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1256,6 +1256,10 @@ version = "0.2.0"
 submodule = "extensions/ejs"
 version = "0.0.1"
 
+[elasticsearch]
+submodule = "extensions/elasticsearch"
+version = "0.1.0"
+
 [elderberry]
 submodule = "extensions/elderberry"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds the **Elasticsearch** extension.

- **id:** `elasticsearch`
- **version:** `0.1.0`
- **repository:** https://github.com/foulkelore/zed-elasticsearch
- **submodule pinned to tag:** `v0.1.0`

## What it does

Language support for Elasticsearch Console / Dev Tools files (the `.es` format) — the same request format used in Kibana Dev Tools:

- **Syntax highlighting** for HTTP methods, request paths/query params, `#` and `//` comments, and JSON request bodies (keys, strings, numbers, booleans, null, brackets), via a dedicated tree-sitter grammar.
- **Inline diagnostics** from a bundled language server: invalid HTTP method, missing request path, malformed JSON, duplicate object keys, and per-line NDJSON validation for `_bulk`/`_msearch` bodies. Pure editor-side analysis — it never contacts a cluster.

The language server is downloaded automatically per-platform on first use (prebuilt binaries from the extension repo's releases), so there is no setup step for users.

## Notes

- The extension is unofficial and not affiliated with or endorsed by Elastic N.V.; "Elasticsearch" and "Kibana" are trademarks of Elastic N.V., referenced only to describe the supported file format. This is documented in the README and manifest.
- License: Apache-2.0.