### PR TITLE
Add the MPLAB Core Debugger extension. Enabled DAP access to the MPLA…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2918,6 +2918,10 @@
 	path = extensions/move-aptos
 	url = https://github.com/caoyang2002/zed-move-aptos.git
 
+[submodule "extensions/mplab-core-debugger"]
+	path = extensions/mplab-core-debugger
+	url = https://github.com/xoriath/mplab-core-da-zed.git
+
 [submodule "extensions/mpls"]
 	path = extensions/mpls
 	url = https://github.com/pnyda/zed-mpls.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2969,6 +2969,10 @@ version = "0.0.4"
 submodule = "extensions/move-aptos"
 version = "0.0.2"
 
+[mplab-core-debugger]
+submodule = "extensions/mplab-core-debugger"
+version = "0.1.0"
+
 [mpls]
 submodule = "extensions/mpls"
 version = "0.2.0"


### PR DESCRIPTION
…B Debugger Backend used in the MPLAB VSCode Extensions to enable debugging of all Microchip supported embedded devices

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
