### PR TITLE
Add divine-hc extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/divine-hc"]
+	path = extensions/divine-hc
+	url = https://github.com/Snowman-scott/divine-hc.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1119,6 +1119,10 @@ version = "0.1.0"
 submodule = "extensions/discord-presence"
 version = "0.2.4"
 
+[divine-hc]
+submodule = "extensions/divine-hc"
+version = "0.1.0"
+
 [django]
 submodule = "extensions/django"
 version = "0.2.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1121,7 +1121,7 @@ version = "0.2.4"
 
 [divine-hc]
 submodule = "extensions/divine-hc"
-version = "0.1.0"
+version = "0.1.1"
 
 [django]
 submodule = "extensions/django"


### PR DESCRIPTION
# Summary
Adds the divine-hc extension, A HolyC language extension

Adds holyc support to zed, Mainly syntax highlighting

Updated:
Added a grammar for HolyC
Fully tested and working as a dev extension

# Checklist
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

# Verified
- [x] Extension tested as a dev extension
- [x] Repository includes a GPL3 license 
- [x] Confirmed extension functionality, does not seem to duplicate any other extension
- [x] Registered via `extensions.toml` and verified with `pnpm sort-extensions`