### PR TITLE
Add Leo-Solarized theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2318,6 +2318,10 @@
 	path = extensions/legendary-dark-theme
 	url = https://github.com/Llewellyn500/Legendary-Dark.git
 
+[submodule "extensions/leo-solarized-theme"]
+	path = extensions/leo-solarized-theme
+	url = https://github.com/HernandoR/Solarized.zed.git
+
 [submodule "extensions/leptos"]
 	path = extensions/leptos
 	url = https://github.com/zed-extensions/leptos.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2365,7 +2365,7 @@ version = "5.0.1"
 
 [leo-solarized-theme]
 submodule = "extensions/leo-solarized-theme"
-version = "0.10.0"
+version = "0.11.0"
 
 [leptos]
 submodule = "extensions/leptos"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2363,6 +2363,10 @@ submodule = "extensions/legendary-dark-theme"
 path = "zed"
 version = "5.0.1"
 
+[leo-solarized-theme]
+submodule = "extensions/leo-solarized-theme"
+version = "0.10.0"
+
 [leptos]
 submodule = "extensions/leptos"
 version = "0.1.1"


### PR DESCRIPTION
Adds **Leo-Solarized**, a Solarized theme extension for Zed.

- Repository: https://github.com/HernandoR/Solarized.zed
- Extension id: `leo-solarized-theme`
- Provides two theme variants: **Solarized Dark** and **Solarized Light**

A fork of [harmtemolder/Solarized.zed](https://github.com/harmtemolder/Solarized.zed) that refines the color system: UI surface shades are computed from a CIELAB lightness ladder and the semantic/token setup is expanded to follow the LSP more closely.

Licensed under MIT (`LICENSE` at the repo root). Tested locally as a dev extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)