### PR TITLE
Add Gitlab Web IDE theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1662,6 +1662,10 @@
 	path = extensions/gitlab-ci-ls
 	url = https://github.com/tzabbi/zed-gitlab-ci-ls.git
 
+[submodule "extensions/gitlab-web-ide-theme"]
+	path = extensions/gitlab-web-ide-theme
+	url = https://github.com/karnauhmax/zed-gitlab-web-ide-theme.git
+
 [submodule "extensions/glazier"]
 	path = extensions/glazier
 	url = https://github.com/airgap/glazier.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1717,7 +1717,7 @@
 [submodule "extensions/gitlab-web-ide-theme"]
 	path = extensions/gitlab-web-ide-theme
 	url = https://github.com/karnauhmax/zed-gitlab-web-ide-theme.git
-  
+
 [submodule "extensions/glass-theme"]
 	path = extensions/glass-theme
 	url = https://github.com/b4bury/zed-glass.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1691,6 +1691,10 @@ version = "2025.08.0"
 submodule = "extensions/gitlab-ci-ls"
 version = "1.0.1"
 
+[gitlab-web-ide-theme]
+submodule = "extensions/gitlab-web-ide-theme"
+version = "0.1.0"
+
 [glazier]
 submodule = "extensions/glazier"
 version = "0.0.2"


### PR DESCRIPTION
## Description

Adds "Gitlab Web IDE Theme" — a port of GitLab's Web IDE / VS Code theme
(https://gitlab.com/gitlab-org/gitlab-web-ide/-/tree/main/packages/vscode-extension-gitlab-vscode-theme)
to Zed's theme format. Includes all three upstream variants: Dark, Dark
Midnight, and Light.

- Repository: https://github.com/karnauhmax/zed-gitlab-web-ide-theme
- Extension id: `gitlab-web-ide-theme`
- License: MIT (own LICENSE + attribution to GitLab B.V.'s MIT-licensed source)

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.