### PR TITLE
Update vscode-classic-themes to v0.4.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4967,7 +4967,7 @@ version = "0.0.1"
 
 [vscode-classic-themes]
 submodule = "extensions/vscode-classic-themes"
-version = "0.4.0"
+version = "0.4.1"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"


### PR DESCRIPTION
Updates the **VS Code Classics** theme extension to v0.4.1.

> Supersedes #6675, which was closed for a CLA identity issue. The commit author has been corrected to an email that resolves to my GitHub account, so the CLA check should now pass.

Changes since 0.4.0:
- Fix swapped `variable` / `variable.parameter` highlighting in Dark 2026 and Light 2026 (alanisme/vscode-themes-for-zed#1)
- Add `property.json_key` color for themes whose source distinguishes JSON keys
- Refresh theme source to VS Code 1.126.0

Source: https://github.com/alanisme/vscode-themes-for-zed
