### PR TITLE
Add Deep Slate theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/deep-slate-theme"]
+	path = extensions/deep-slate-theme
+	url = https://github.com/Roter-S/deep-slate-theme.git
+	branch = zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1049,7 +1049,6 @@
 [submodule "extensions/deep-slate-theme"]
 	path = extensions/deep-slate-theme
 	url = https://github.com/Roter-S/deep-slate-theme.git
-	branch = zed
 
 [submodule "extensions/defold"]
 	path = extensions/defold

--- a/.gitmodules
+++ b/.gitmodules
@@ -1046,6 +1046,11 @@
 	path = extensions/deep-ocean-theme
 	url = https://github.com/axatbhardwaj/deep-ocean-theme.git
 
+[submodule "extensions/deep-slate-theme"]
+	path = extensions/deep-slate-theme
+	url = https://github.com/Roter-S/deep-slate-theme.git
+	branch = zed
+
 [submodule "extensions/defold"]
 	path = extensions/defold
 	url = https://github.com/whiterabbit1983/zed-defold
@@ -5197,7 +5202,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/deep-slate-theme"]
-	path = extensions/deep-slate-theme
-	url = https://github.com/Roter-S/deep-slate-theme.git
-	branch = zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1064,6 +1064,10 @@ version = "1.0.0"
 submodule = "extensions/deep-ocean-theme"
 version = "0.1.0"
 
+[deep-slate-theme]
+submodule = "extensions/deep-slate-theme"
+version = "0.0.1"
+
 [defold]
 submodule = "extensions/defold"
 version = "0.1.4"


### PR DESCRIPTION
Resubmitting the Deep Slate theme. 

In my previous PR I missed the guideline regarding the `-theme` suffix for the extension ID. I have now updated the `extension.toml` in the submodule to use `deep-slate-theme`, added the MIT License to the root of the theme repository, and sorted the `extensions.toml` file.

Ready for review! Thank you.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
