### PR TITLE
Add RuneScape Icon Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3982,6 +3982,10 @@
 	path = extensions/rumdl
 	url = https://github.com/inflation/zed-rumdl.git
 
+[submodule "extensions/runescape-icon-theme"]
+	path = extensions/runescape-icon-theme
+	url = https://github.com/runescape-themes/zed-icons.git
+
 [submodule "extensions/rust-and-brown"]
 	path = extensions/rust-and-brown
 	url = https://github.com/LukianovII/rust-and-brown-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4052,6 +4052,10 @@ version = "0.16.14"
 submodule = "extensions/rumdl"
 version = "0.0.1"
 
+[runescape-icon-theme]
+submodule = "extensions/runescape-icon-theme"
+version = "1.0.0"
+
 [rust-and-brown]
 submodule = "extensions/rust-and-brown"
 version = "1.0.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds an icon theme based on various icons from the hit MMO -- Old School RuneScape. The theme supports more than a dozen language and various toolset files/extensions. I ported this theme to Zed from VS Code and look forward to supporting it well into the future.

Repo: https://github.com/runescape-themes/zed-icons
Existing VS Code extension: https://marketplace.visualstudio.com/items?itemName=392781.runescape-icon-theme