### PR TITLE
Add VSCode 2026 theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4898,6 +4898,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vscode-2026-theme"]
+	path = extensions/vscode-2026-theme
+	url = https://github.com/shreyan-gupta/zed-vscode-2026-theme.git
+
 [submodule "extensions/vscode-classic-theme"]
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4982,6 +4982,10 @@ version = "0.0.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vscode-2026-theme]
+submodule = "extensions/vscode-2026-theme"
+version = "0.1.0"
+
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds **VSCode 2026**, a faithful port of VS Code's default Dark 2026 and Light 2026 themes. Ships both variants (VSCode 2026 Dark and VSCode 2026 Light) as one theme extension.

Repository: https://github.com/shreyan-gupta/zed-vscode-2026-theme

## Notes

- Theme-only extension — contains just the manifest, the theme file, README, screenshots, and an MIT license at the repository root.
- Extension id `vscode-2026-theme` (unique, `-theme` suffixed per the guidelines).
- Installed and tested locally as a dev extension in Zed against Rust, TypeScript, Python, JSON, and Markdown.

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
