### PR TITLE
Add HC Monokai theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1874,6 +1874,10 @@
 	path = extensions/hbuilderx-push-light
 	url = https://github.com/yuanzhhh/hbuilderx-theme-zed.git
 
+[submodule "extensions/hc-monokai-theme"]
+	path = extensions/hc-monokai-theme
+	url = https://github.com/p404/zed-hc-monokai.git
+
 [submodule "extensions/helios-theme"]
 	path = extensions/helios-theme
 	url = https://github.com/heliosgraphics/helios-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1909,6 +1909,10 @@ version = "0.4.0"
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"
 
+[hc-monokai-theme]
+submodule = "extensions/hc-monokai-theme"
+version = "0.0.1"
+
 [helios-theme]
 submodule = "extensions/helios-theme"
 version = "0.0.8"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds HC Monokai, a high-contrast Monokai theme for Zed.

Source repository: https://github.com/p404/zed-hc-monokai
Extension ID: `hc-monokai-theme`
Version: `0.0.1`

Local checks performed:
- Installed the theme JSON into a temporary Zed themes directory with `make install`
- Validated the theme JSON with `jq empty`
- Compared style keys against `https://zed.dev/schema/themes/v0.2.0.json` for unsupported keys