### PR TITLE
Add byteask extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git
 
+[submodule "extensions/byteask"]
+	path = extensions/byteask
+	url = https://github.com/ByteAsk/byteask-extensions.git
+
 [submodule "extensions/c3"]
 	path = extensions/c3
 	url = https://github.com/AineeJames/c3-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -568,6 +568,11 @@ version = "0.1.0"
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"
 
+[byteask]
+submodule = "extensions/byteask"
+version = "0.1.0"
+path = "zed"
+
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Drives the [ByteAsk](https://byteask.ai) C/C++ agentic coding harness from Zed:

- `/byteask-exec <prompt>` and `/byteask-review` slash commands (shell out to the `byteask` CLI, insert the output)
- A context-server integration wrapping `byteask app-server` (JSON-RPC over stdio), so Zed's own Agent Panel drives the streaming/approval UX rather than this extension building any UI itself

Source lives at [ByteAsk/byteask-extensions](https://github.com/ByteAsk/byteask-extensions), submoduled here at `extensions/byteask` with `path = "zed"` since it's one of several editor connectors in that monorepo, each independently versioned/tagged.

## Verification

- ✅ Compiles clean against `wasm32-wasip2`
- ✅ Passes `cargo clippy --target wasm32-wasip2 -- -D warnings` with zero warnings
- ✅ Every API call (`process::Command`, `context_server_command`, `Project`, `Worktree`) was checked against the actual `zed_extension_api` WIT interface bundled with the crate, not just the docs site (which lagged behind the real API in a couple of places — see `src/lib.rs`'s doc comments for the two gaps found this way: `Command` has no working-directory control, and `context_server_command`'s `Project` only exposes `worktree_ids()`)
- ⚠️ **Not yet verified**: a live "Install Dev Extension" pass inside a real Zed window, clicking through `/byteask-exec` and the context server in the Agent Panel. I don't currently have a machine set up to do this pass and wanted to open this PR for visibility/feedback in the meantime — happy to hold if a confirmed local test is a hard requirement before review, just let me know.

## Requirements

The `byteask` CLI must be on `PATH` (`pip install --upgrade byteask`). Documented in the submodule's own `zed/README.md`.

- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.