### PR TITLE
Add custom-code-folding language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -934,6 +934,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/custom-code-folding-lsp"]
+	path = extensions/custom-code-folding-lsp
+	url = https://github.com/tomchor/zed-custom-code-folding.git
+
 [submodule "extensions/cutiepro-theme"]
 	path = extensions/cutiepro-theme
 	url = https://codeberg.org/wuemeli/cutiepro-zed
@@ -5253,6 +5257,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/custom-code-folding-lsp"]
-	path = extensions/custom-code-folding-lsp
-	url = https://github.com/tomchor/zed-custom-code-folding.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -934,6 +934,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/custom-code-folding"]
+	path = extensions/custom-code-folding
+	url = https://github.com/tomchor/zed-custom-code-folding.git
+
 [submodule "extensions/cyan-light-theme"]
 	path = extensions/cyan-light-theme
 	url = https://github.com/biaqat/cyan-light-theme-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -934,10 +934,6 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
-[submodule "extensions/custom-code-folding"]
-	path = extensions/custom-code-folding
-	url = https://github.com/tomchor/zed-custom-code-folding.git
-
 [submodule "extensions/cutiepro-theme"]
 	path = extensions/cutiepro-theme
 	url = https://codeberg.org/wuemeli/cutiepro-zed
@@ -5257,3 +5253,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/custom-code-folding-lsp"]
+	path = extensions/custom-code-folding-lsp
+	url = https://github.com/tomchor/zed-custom-code-folding.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -952,9 +952,9 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
-[custom-code-folding]
-submodule = "extensions/custom-code-folding"
-version = "0.1.1"
+[custom-code-folding-lsp]
+submodule = "extensions/custom-code-folding-lsp"
+version = "0.1.0"
 
 [cutiepro-theme]
 submodule = "extensions/cutiepro-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -952,6 +952,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[custom-code-folding]
+submodule = "extensions/custom-code-folding"
+version = "0.1.1"
+
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
 version = "0.7.1"


### PR DESCRIPTION
Adds a new extension: **custom-code-folding**.

## What it does

An LSP server implementing `textDocument/foldingRange` to provide configurable code folding via custom comment markers, e.g. `# +++ … # ---` and `#region … #endregion`, plus user-defined regex patterns through `initialization_options`. This addresses the request in zed-industries/zed#41167 (custom foldable regions, like VS Code's `#region`).

- Extension repo: https://github.com/tomchor/zed-custom-code-folding
- Registered for 40+ languages; nested regions supported.
- The language server binary is downloaded from GitHub Releases at runtime, not shipped inside the extension package.

## Attribution

Originally authored by @ali-ramadhan and first submitted in #5104, which was closed as stale with an invitation to resubmit. This PR revives that work: the server-binary download is repointed to a maintained fork and the version bumped to `0.1.1`. Ali is retained as the original author in `extension.toml` and credited in the README.

## Checklist

- [x] Tested locally as a dev extension — default and custom markers fold correctly
- [x] Added entry to `extensions.toml` at the sorted position (verified with `sort-extensions`)
- [x] Submodule pinned to tag `v0.1.1`
- [x] License: MIT (`LICENSE` present in the extension repo)
- [x] Extension ID (`custom-code-folding`) follows the naming rules (no `zed`/`extension`)
