### PR TITLE
Add pkl-lang extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3562,6 +3562,10 @@
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git
 
+[submodule "extensions/pkl-lang"]
+	path = extensions/pkl-lang
+	url = https://github.com/danteay/pkl-zed.git
+
 [submodule "extensions/plaintasks"]
 	path = extensions/plaintasks
 	url = https://github.com/cseelus/plaintasks-zed.git
@@ -5233,6 +5237,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/pkl-lang"]
-	path = extensions/pkl-lang
-	url = https://github.com/danteay/pkl-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5233,3 +5233,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/pkl-lang"]
+	path = extensions/pkl-lang
+	url = https://github.com/danteay/pkl-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3621,6 +3621,10 @@ version = "0.0.1"
 submodule = "extensions/pkl"
 version = "0.3.0"
 
+[pkl-lang]
+submodule = "extensions/pkl-lang"
+version = "0.1.0"
+
 [plaintasks]
 submodule = "extensions/plaintasks"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [pkl-lang](https://github.com/danteay/pkl-zed), a language extension for [Pkl](https://pkl-lang.org) (Apple's configuration language).

**Relation to the existing `pkl` extension:** I'm aware of the guidance about overlapping extensions. This one was built independently against the current Apple tooling and goes meaningfully beyond the existing `pkl` extension in scope:

- Code snippets (18 templates for modules, classes, generators, `pkl:test` scaffolds)
- Live evaluation: gutter runnables bound to `pkl eval` (pcf/JSON/YAML) and `pkl test` task templates
- Fuller query set: outline, indents, textobjects (Vim), overrides, regex injection in `Regex("...")`, rainbow-bracket support including `<>` type arguments
- Layered pkl-lsp resolution: Zed `lsp.pkl-lsp.binary` settings → `pkl-lsp` on PATH → auto-downloaded jar from GitHub releases launched via `JAVA_HOME`/PATH Java (23+), with workspace-configuration passthrough and automatic `pkl` CLI detection for project sync

Tested locally as a dev extension on macOS (Zed stable): highlighting, brace matching, snippets, eval tasks, and pkl-lsp hover/go-to-definition/diagnostics all verified against real Pkl projects. The repo is Apache-2.0 licensed and ships no language-server binaries.