### PR TITLE
Add blade-links extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -454,6 +454,10 @@
 	path = extensions/blade
 	url = https://github.com/bajrangCoder/zed-laravel-blade.git
 
+[submodule "extensions/blade-links"]
+	path = extensions/blade-links
+	url = https://github.com/gustavofrdev/zed-blade-links.git
+
 [submodule "extensions/blade-runner-2049"]
 	path = extensions/blade-runner-2049
 	url = https://github.com/Takk8IS/blade-runner-2049-theme-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -462,6 +462,10 @@ version = "0.1.1"
 submodule = "extensions/blade"
 version = "0.2.6"
 
+[blade-links]
+submodule = "extensions/blade-links"
+version = "0.1.0"
+
 [blade-runner-2049]
 submodule = "extensions/blade-runner-2049"
 version = "1.0.4"


### PR DESCRIPTION
Adds [blade-links](https://github.com/gustavofrdev/zed-blade-links), a language server for Laravel Blade views that provides:

- Go-to-definition for inline JS handlers (e.g. `onclick="f()"`) resolving to function declarations in `public/` JS files
- Clickable document links for `asset()`, `mix()`, `secure_asset()` and plain `src="assets/..."` paths

The server is a zero-dependency Node script embedded in the extension WASM and runs alongside existing PHP/Laravel language servers.