### PR TITLE
Update cyan-light-theme to v0.7.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -954,7 +954,7 @@ version = "0.0.1"
 
 [cyan-light-theme]
 submodule = "extensions/cyan-light-theme"
-version = "0.7.1"
+version = "0.7.2"
 
 [cyberpunk-2077]
 submodule = "extensions/cyberpunk-2077"


### PR DESCRIPTION
## Summary
- Fix `element.disabled` color for light UI elements (settings toggles, buttons, icons)
- Changes disabled color from near-black `#3C3C3C` to light gray `#D0D8DC`
- Upstream change: https://github.com/bIaqat/cyan-light-theme-zed/pull/3
