### PR TITLE
Update pgfmt-lsp to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3549,7 +3549,7 @@ version = "0.1.1"
 [pgfmt-lsp]
 submodule = "extensions/pgfmt-lsp"
 path = "zed-pgfmt"
-version = "0.3.3"
+version = "0.4.0"
 
 [phasmid-theme]
 submodule = "extensions/phasmid-theme"


### PR DESCRIPTION
Bumps pgfmt-lsp to v0.4.0. Release: https://github.com/middle-management/pgfmt/releases/tag/v0.4.0