### PR TITLE
Updates arkts to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -217,7 +217,7 @@ version = "0.0.1"
 
 [arkts]
 submodule = "extensions/arkts"
-version = "0.2.0"
+version = "0.3.0"
 
 [ars-goetia-theme]
 submodule = "extensions/ars-goetia-theme"


### PR DESCRIPTION
This pull request updates the arkts extension to 0.3.0.

Changes in this release:

- Fixed "go to definition", hover and document highlight silently returning no results in Zed: the extension now maps "ArkTS Language" to the LSP languageId `ets` via `language_ids`, which the ArkTS language server requires to process documents.
- The language server now starts out of the box without manually configured `initialization_options`: the wrapper auto-detects the bundled TypeScript SDK and provides a placeholder OHOS SDK skeleton (compatible with @arkts/language-server v1.2 and the stricter v1.3 validation). ArkUI typings still require configuring a real OHOS SDK path.
- The wrapper npm package is now pinned to a major version matching the extension, with major-aware update checks to avoid reinstalling on every startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)