### PR TITLE
Add zed-linear theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2376,7 +2376,7 @@
 
 [submodule "extensions/linear"]
 	path = extensions/linear
-	url = https://github.com/adriandlam/linear.git
+	url = https://github.com/adriandlam/zed-linear.git
 
 [submodule "extensions/linkerscript"]
 	path = extensions/linkerscript

--- a/.gitmodules
+++ b/.gitmodules
@@ -2374,6 +2374,10 @@
 	path = extensions/lilypond
 	url = https://github.com/nwhetsell/lilypond-zed-extension
 
+[submodule "extensions/linear"]
+	path = extensions/linear
+	url = https://github.com/adriandlam/linear.git
+
 [submodule "extensions/linkerscript"]
 	path = extensions/linkerscript
 	url = https://github.com/notpeter/linkerscript-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2419,6 +2419,10 @@ version = "0.0.1"
 submodule = "extensions/lilypond"
 version = "0.0.9"
 
+[linear]
+submodule = "extensions/linear"
+version = "0.0.1"
+
 [linkerscript]
 submodule = "extensions/linkerscript"
 version = "0.1.0"


### PR DESCRIPTION
Adds Linear, a light and dark Zed theme ported from the Codex Linear code theme.

The extension is published at https://github.com/adriandlam/zed-linear and registered as the `linear` submodule.
The source repo includes a tag-triggered workflow for future marketplace updates.

Checks:
- Parsed `themes/linear.json` with Node JSON.parse
- Confirmed both `Linear Dark` and `Linear Light` are present
