### PR TITLE
Add CodeGraph MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -778,6 +778,10 @@
 	path = extensions/codebook
 	url = https://github.com/blopker/codebook-zed.git
 
+[submodule "extensions/codegraph"]
+	path = extensions/codegraph
+	url = https://github.com/sunerpy/codegraph-rust.git
+
 [submodule "extensions/codely-theme"]
 	path = extensions/codely-theme
 	url = https://github.com/GOI17/codely-theme-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -778,8 +778,8 @@
 	path = extensions/codebook
 	url = https://github.com/blopker/codebook-zed.git
 
-[submodule "extensions/codegraph"]
-	path = extensions/codegraph
+[submodule "extensions/codegraph-mcp"]
+	path = extensions/codegraph-mcp
 	url = https://github.com/sunerpy/codegraph-rust.git
 
 [submodule "extensions/codely-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -791,6 +791,11 @@ version = "0.0.5"
 submodule = "extensions/codebook"
 version = "0.2.14"
 
+[codegraph]
+submodule = "extensions/codegraph"
+path = "editors/zed"
+version = "0.1.0"
+
 [codely-theme]
 submodule = "extensions/codely-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -791,10 +791,10 @@ version = "0.0.5"
 submodule = "extensions/codebook"
 version = "0.2.14"
 
-[codegraph]
-submodule = "extensions/codegraph"
+[codegraph-mcp]
+submodule = "extensions/codegraph-mcp"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.2.1"
 
 [codely-theme]
 submodule = "extensions/codely-theme"


### PR DESCRIPTION
Adds the **CodeGraph** extension, which provides [CodeGraph](https://github.com/sunerpy/codegraph-rust) as an MCP context server inside Zed.

CodeGraph is a deterministic tree-sitter + SQLite/FTS5 **code knowledge graph**. It parses a codebase, extracts symbols and their call/dependency relationships, and answers structural questions ("who calls X", "what breaks if I change X", "where is X defined", "how does this area work") in one query instead of dozens of grep + file reads. There is no AI/LLM/vector store inside the binary — output is fully deterministic.

The extension registers a `codegraph` context server. On launch it resolves the latest GitHub release of `sunerpy/codegraph-rust`, downloads the platform binary, and caches it under a version-stamped path (auto-updates on new releases); a user-provided `context_servers.codegraph.command` in Zed settings overrides the download.

- **Repository:** https://github.com/sunerpy/codegraph-rust
- **Extension path:** `editors/zed` (monorepo subdirectory; submodule pinned to tag `v0.25.1`)
- **License:** MIT (`editors/zed/LICENSE`)

### Checklist
- [x] Read the Extension Publishing Prerequisites and Publishing guide.
- [x] Tested locally as a dev extension before submitting.
- [x] The extension repository includes an accepted license (MIT).
- [x] No existing extension provides this functionality (searched `extensions.toml` — no `codegraph`/`code-graph` entry).
- [x] Added the submodule and an `extensions.toml` entry in alphabetical order.