### PR TITLE
Add Laravel Assist extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2318,6 +2318,10 @@
 	path = extensions/laravel
 	url = https://github.com/mike-bronner/zed-laravel.git
 
+[submodule "extensions/laravel-assist"]
+	path = extensions/laravel-assist
+	url = https://github.com/eyedroot/zed-laravel-assist.git
+
 [submodule "extensions/latex"]
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2362,6 +2362,10 @@ version = "1.0.3"
 submodule = "extensions/laravel"
 version = "0.5.0"
 
+[laravel-assist]
+submodule = "extensions/laravel-assist"
+version = "0.0.1"
+
 [latex]
 submodule = "extensions/latex"
 version = "0.2.3"


### PR DESCRIPTION
## Summary
- Add Laravel Assist as a Zed extension registry submodule
- Register version 0.0.1 in extensions.toml
- Laravel Assist complements existing PHP/Laravel language support with Laravel-specific IDE intelligence

## Notes
- The extension does not commit extension.wasm
- The language server is downloaded at runtime through zed_extension_api::download_file from a versioned GitHub-hosted server asset
- The source repository is public and includes a root LICENSE file

## Verification
- npm test in the extension repository language server: 171 tests passed
- cargo check in the extension repository passed
- cargo build --release --target wasm32-wasip2 in the extension repository passed
- pnpm sort-extensions passed
- pnpm build passed