### PR TITLE
Update csound to v1.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -896,7 +896,7 @@ version = "0.1.0"
 
 [csound]
 submodule = "extensions/csound"
-version = "1.2.4"
+version = "1.3.0"
 
 [cspell]
 submodule = "extensions/cspell"


### PR DESCRIPTION
Update csound-zed to 1.3.0

- resolve plugin opcodes from risset index
- fix typed opcode name
- others minor bug fixes

- [ x ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
