### PR TITLE
Add pkl-icons extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3566,6 +3566,10 @@
 	path = extensions/pkl
 	url = https://github.com/Moshyfawn/pkl-zed.git
 
+[submodule "extensions/pkl-icons"]
+	path = extensions/pkl-icons
+	url = https://github.com/danteay/pkl-zed-icons.git
+
 [submodule "extensions/plaintasks"]
 	path = extensions/plaintasks
 	url = https://github.com/cseelus/plaintasks-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3627,7 +3627,7 @@ version = "0.3.0"
 
 [pkl-icons]
 submodule = "extensions/pkl-icons"
-version = "0.1.0"
+version = "0.2.0"
 
 [plaintasks]
 submodule = "extensions/plaintasks"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3625,6 +3625,10 @@ version = "0.0.1"
 submodule = "extensions/pkl"
 version = "0.3.0"
 
+[pkl-icons]
+submodule = "extensions/pkl-icons"
+version = "0.1.0"
+
 [plaintasks]
 submodule = "extensions/plaintasks"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [pkl-icons](https://github.com/danteay/pkl-zed-icons) (v0.2.0), an icon theme that combines the [Material Icon Theme](https://github.com/material-extensions/vscode-material-icon-theme) file and folder icons with the official [Pkl](https://pkl-lang.org) logo on Pkl files (`*.pkl`, `*.pcf`, `PklProject`, `PklProject.deps.json`).

It ships two themes, **Pkl Icons** (dark) and **Pkl Icons Light**, covering ~1,400 file suffixes, ~4,600 well-known file names, and per-name folder icons. The theme JSON and SVGs are generated from the [`material-icon-theme`](https://www.npmjs.com/package/material-icon-theme) npm package (v5.36.1) by a script in the repo, so it can be kept in sync with upstream.

It complements the `pkl-lang` language extension (#6720) and is published as a separate extension per the guideline that icon themes must not ship inside extensions providing other features.

Licensing: the Material icons and mappings are MIT-licensed ([material-extensions/vscode-material-icon-theme](https://github.com/material-extensions/vscode-material-icon-theme)), with the license vendored in `licenses/` and attribution in the README. The Pkl logo is from [apple/pkl-vscode](https://github.com/apple/pkl-vscode) (`img/icon.svg`, Apache-2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)