### PR TITLE
Update phosphor-icons-theme to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3561,7 +3561,7 @@ version = "0.0.1"
 
 [phosphor-icons-theme]
 submodule = "extensions/phosphor-icons-theme"
-version = "0.0.2"
+version = "0.1.0"
 
 [phosphor-theme]
 submodule = "extensions/phosphor-theme"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for updating my extension.

Updates **phosphor-icons-theme** from 0.0.2 → 0.1.0.

- Wires up file-type icons that shipped but were unreachable (rust, python, js/ts, go, ruby, c/cpp, css, html, image, audio, video, …)
- Adds new icons: shell, text, pdf, zip, lock, font, xml, env, code, word, excel, powerpoint, ini, database, and tree chevrons
- Upgrades the icon-theme schema to v0.3.0 (adds `chevron_icons`)