### PR TITLE
Add vsc-material-icons icon theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4930,6 +4930,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vsc-material-icons"]
+	path = extensions/vsc-material-icons
+	url = https://github.com/danteay/zed-material-icons-theme.git
+
 [submodule "extensions/vscode-classic-theme"]
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -5016,6 +5016,10 @@ version = "0.0.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vsc-material-icons]
+submodule = "extensions/vsc-material-icons"
+version = "0.1.0"
+
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the **vsc-material-icons** icon theme extension.

It is a port of the VS Code [Material Icon Theme](https://github.com/material-extensions/vscode-material-icon-theme) file and folder icons to Zed. It ships two variants — `Material Icons` (dark) and `Material Icons Light` — and additionally overlays the official Pkl logo on Pkl files.

- Repository: https://github.com/danteay/zed-material-icons-theme
- Icons and mappings are from [material-extensions/vscode-material-icon-theme](https://github.com/material-extensions/vscode-material-icon-theme) (MIT), attributed in the repo.

I have tested my extension locally and it works as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)