### PR TITLE
Add Kubernetes MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2686,6 +2686,10 @@
 	path = extensions/mcp-server-grafana
 	url = https://github.com/sd2k/zed-mcp-grafana.git
 
+[submodule "extensions/mcp-server-kubernetes"]
+	path = extensions/mcp-server-kubernetes
+	url = https://github.com/ferra-io/zed-mcp-server-kubernetes.git
+
 [submodule "extensions/mcp-server-markitdown"]
 	path = extensions/mcp-server-markitdown
 	url = https://github.com/G36maid/zed-mcp-server-markitdown

--- a/extensions.toml
+++ b/extensions.toml
@@ -2736,6 +2736,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-grafana"
 version = "0.1.2"
 
+[mcp-server-kubernetes]
+submodule = "extensions/mcp-server-kubernetes"
+version = "0.1.0"
+
 [mcp-server-markitdown]
 submodule = "extensions/mcp-server-markitdown"
 version = "0.0.1"


### PR DESCRIPTION
Retry of #5795.

This adds our [Kubernetes MCP server extension](https://github.com/ferra-io/zed-mcp-server-kubernetes) that wraps [kubernetes-mcp-server](https://github.com/containers/kubernetes-mcp-server), includes proper config docs and has been used by us daily for the past couple months.