### PR TITLE
Add react-compiler-marker language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3814,6 +3814,10 @@
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
 
+[submodule "extensions/react-compiler-marker"]
+	path = extensions/react-compiler-marker
+	url = https://github.com/isaachinman/zed-react-compiler-marker.git
+
 [submodule "extensions/react-component-lens-lsp"]
 	path = extensions/react-component-lens-lsp
 	url = https://github.com/dev-five-git/react-component-lens.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3880,6 +3880,10 @@ version = "0.1.1"
 submodule = "extensions/rcl"
 version = "0.12.0"
 
+[react-compiler-marker]
+submodule = "extensions/react-compiler-marker"
+version = "0.1.0"
+
 [react-component-lens-lsp]
 submodule = "extensions/react-component-lens-lsp"
 path = "packages/zed"


### PR DESCRIPTION
Adds [react-compiler-marker](https://github.com/isaachinman/zed-react-compiler-marker) — inlay-hint markers showing which React components the React Compiler successfully memoizes (✨) and which have issues preventing optimization (🚫), with tooltips explaining why.

- LSP-based: launches the MIT-licensed [React Compiler Marker language server](https://github.com/blazejkustra/react-compiler-marker) (downloaded from a GitHub release at first launch, not bundled) via Zed's Node runtime, wrapped in a small shim that adapts it to Zed (monorepo plugin auto-discovery, inlay-hint refresh on open, per-chunk request handling).
- Works on JavaScript, TypeScript, JSX, and TSX buffers; requires `babel-plugin-react-compiler` in the project (auto-discovered anywhere in the workspace, with a bundled-plugin fallback).
- MIT licensed, with credit to the upstream project by @blazejkustra.
- Tested locally as a dev extension on macOS (Zed stable).