### PR TITLE
Update ssh-config to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4365,7 +4365,7 @@ version = "0.0.4"
 
 [ssh-config]
 submodule = "extensions/ssh-config"
-version = "0.2.0"
+version = "0.3.0"
 
 [stan]
 submodule = "extensions/stan"


### PR DESCRIPTION
Updates ssh-config extension to v0.3.0.

It now uses the latest [tree-sitter-ssh-config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config), which adds [highlighting support for new keywords](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config/pull/15).

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
