### PR TITLE
Add carbon-candy-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5253,3 +5253,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/carbon-candy-theme"]
+	path = extensions/carbon-candy-theme
+	url = https://github.com/viral-team/carbon-candy-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -586,6 +586,10 @@
 	path = extensions/capnp
 	url = https://github.com/cmackenzie1/zed-capnp.git
 
+[submodule "extensions/carbon-candy-theme"]
+	path = extensions/carbon-candy-theme
+	url = https://github.com/viral-team/carbon-candy-zed-theme.git
+
 [submodule "extensions/carbonember"]
 	path = extensions/carbonember
 	url = https://github.com/HurrellT/CarbonEmber
@@ -5253,6 +5257,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/carbon-candy-theme"]
-	path = extensions/carbon-candy-theme
-	url = https://github.com/viral-team/carbon-candy-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -596,6 +596,10 @@ version = "0.0.1"
 submodule = "extensions/capnp"
 version = "0.0.1"
 
+[carbon-candy-theme]
+submodule = "extensions/carbon-candy-theme"
+version = "0.1.0"
+
 [carbonember]
 submodule = "extensions/carbonember"
 version = "1.1.1"
@@ -5337,7 +5341,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[carbon-candy-theme]
-submodule = "extensions/carbon-candy-theme"
-version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5337,3 +5337,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[carbon-candy-theme]
+submodule = "extensions/carbon-candy-theme"
+version = "0.1.0"


### PR DESCRIPTION
- [ x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

**Summary**
This PR adds a new Zed theme extension package for the Carbon Candy theme family. The extension is packaged as a standalone repository and registered in extensions.toml as a new submodule.

**What changed**
Added extensions/carbon-candy-theme as a Git submodule
Registered the new extension in extensions.toml:
[carbon-candy-theme]
submodule = "extensions/carbon-candy-theme"
version = "0.1.0"
Included the theme repository contents in the submodule:
extension.toml
README.md
LICENSE
assets/preview.svg
themes/*.json
Why
Carbon Candy is an existing VS Code theme family, and this PR brings the same palette collection to Zed as a properly packaged theme extension ready for marketplace distribution.

**Testing**
Verified the local extension repository layout
Confirmed the new branch pushed successfully to the fork
Confirmed the new submodule and manifest entry were committed
