### PR TITLE
Add Vercel Ayu theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4846,6 +4846,10 @@
 	path = extensions/vento
 	url = https://github.com/dz4k/zed-vento
 
+[submodule "extensions/vercel-ayu-theme"]
+	path = extensions/vercel-ayu-theme
+	url = https://github.com/har4s/zed-vercel-ayu-theme.git
+
 [submodule "extensions/vercel-carbon-theme"]
 	path = extensions/vercel-carbon-theme
 	url = https://github.com/SwiftlyDaniel/zed-vercel-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4931,6 +4931,10 @@ version = "0.1.1"
 submodule = "extensions/vento"
 version = "1.0.0"
 
+[vercel-ayu-theme]
+submodule = "extensions/vercel-ayu-theme"
+version = "0.1.0"
+
 [vercel-carbon-theme]
 submodule = "extensions/vercel-carbon-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **Vercel Ayu Theme** extension — a Vercel-inspired Ayu theme featuring Dark, Mirage, and Light variants.

- Extension repo: https://github.com/har4s/zed-vercel-ayu-theme
- Added submodule entry in `.gitmodules`
- Added entry in `extensions.toml` (v0.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)