### PR TITLE
Add Sema

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4026,6 +4026,10 @@
 	path = extensions/selene-abyss-theme
 	url = https://github.com/envoidia/zed-selene-abyss.git
 
+[submodule "extensions/sema"]
+	path = extensions/sema
+	url = https://github.com/sema-lisp/zed-sema.git
+
 [submodule "extensions/semgrep"]
 	path = extensions/semgrep
 	url = https://github.com/zeelsheladiya/zed-semgrep.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4096,6 +4096,10 @@ version = "0.2.0"
 submodule = "extensions/selene-abyss-theme"
 version = "0.0.3"
 
+[sema]
+submodule = "extensions/sema"
+version = "0.3.0"
+
 [semgrep]
 submodule = "extensions/semgrep"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I've read CONTRIBUTING.md and followed the relevant guidance for adding or updating my extension.

Adds **Sema** — language support for [Sema](https://sema-lang.com), a Lisp dialect with first-class LLM primitives.

Provides the tree-sitter grammar and syntax queries (highlighting, outline, brackets, indents, text objects, injections, secret redaction), and registers the `sema` CLI as:

- **Language server** — `sema lsp`
- **Debug adapter (DAP)** — `sema dap`
- **MCP context server** — `sema mcp`

None of these binaries are bundled with the extension; they resolve from the user's `PATH` (installed via `cargo install sema-lang`), per the publishing prerequisites. Tested locally as a dev extension.

Repository: https://github.com/sema-lisp/zed-sema
