### PR TITLE
Update cloudformation-language-server to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -765,7 +765,7 @@ version = "0.2.2"
 
 [cloudformation-language-server]
 submodule = "extensions/cloudformation-language-server"
-version = "0.1.0"
+version = "1.0.0"
 
 [cobalt2]
 submodule = "extensions/cobalt2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Extension changes:

- Improved language server activation (https://github.com/Ben-Wormald/cloudformation-language-server-zed/pull/4)
- Incremented to version v1.0.0 now the language server has better JSON support