### PR TITLE
Add suitecloud extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5253,3 +5253,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/suitecloud"]
+	path = extensions/suitecloud
+	url = https://github.com/alegerber/zed-suitecloud-plugin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4338,6 +4338,10 @@
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall
 
+[submodule "extensions/suitecloud"]
+	path = extensions/suitecloud
+	url = https://github.com/alegerber/zed-suitecloud-plugin.git
+
 [submodule "extensions/sumi-light"]
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
@@ -5253,6 +5257,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/suitecloud"]
-	path = extensions/suitecloud
-	url = https://github.com/alegerber/zed-suitecloud-plugin.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4413,6 +4413,10 @@ submodule = "extensions/subliminal-nightfall"
 path = "zed"
 version = "0.1.16"
 
+[suitecloud]
+submodule = "extensions/suitecloud"
+version = "0.1.0"
+
 [sumi-light]
 submodule = "extensions/sumi-light"
 version = "0.0.2"


### PR DESCRIPTION
Adds the **SuiteCloud** extension: NetSuite SuiteCloud/SDF support.

- **SDF XML** language: syntax highlighting and detection for SDF object files, `deploy.xml`, and `manifest.xml` (tree-sitter-xml grammar)
- **SuiteScript snippets** for JavaScript (JSDoc) and TypeScript — all 8 script types with correct `@NScriptType` headers
- **MCP context server** wrapping the `suitecloud` CLI ([suitecloud-mcp](https://www.npmjs.com/package/suitecloud-mcp) on npm): deploy, validate, import objects/files, project scaffolding

Repository: https://github.com/alegerber/zed-suitecloud-plugin (MIT). Not affiliated with Oracle/NetSuite; the description states this explicitly.