### PR TITLE
Add Modern SCSS Modules extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2878,6 +2878,10 @@
 	path = extensions/modern-icons
 	url = https://github.com/BadRat-in/zed-modern-icons.git
 
+[submodule "extensions/modern-scss-modules"]
+	path = extensions/modern-scss-modules
+	url = https://github.com/emilgerz/zed-modern-scss-modules.git
+
 [submodule "extensions/modern-vesper"]
 	path = extensions/modern-vesper
 	url = https://github.com/caiolandgraf/modern-vesper-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2930,6 +2930,10 @@ version = "0.0.1"
 submodule = "extensions/modern-icons"
 version = "0.7.2"
 
+[modern-scss-modules]
+submodule = "extensions/modern-scss-modules"
+version = "0.1.0"
+
 [modern-vesper]
 submodule = "extensions/modern-vesper"
 version = "1.0.3"


### PR DESCRIPTION
Adds Modern SCSS Modules, a focused Zed extension that provides go-to-definition support from React CSS module usages like `styles.root` to matching selectors in `.module.scss`, `.module.sass`, and `.module.css` files.

The extension has been tested locally as a dev extension.