### PR TITLE
Add ansible-vault-inline extension 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -146,6 +146,10 @@
 	path = extensions/ansible
 	url = https://github.com/kartikvashistha/zed-ansible
 
+[submodule "extensions/ansible-vault-inline"]
+	path = extensions/ansible-vault-inline
+	url = https://github.com/dimao/ansible-vault-zed.git
+
 [submodule "extensions/anthracite-theme"]
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -150,6 +150,11 @@ version = "21.1.0"
 submodule = "extensions/ansible"
 version = "1.0.0"
 
+[ansible-vault-inline]
+submodule = "extensions/ansible-vault-inline"
+path = "zed-ansible-vault"
+version = "0.5.0"
+
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"


### PR DESCRIPTION
Inline `ansible-vault` encrypt/decrypt for YAML/Ansible files, similar to the
VSCode [ansible-vault-inline](https://marketplace.visualstudio.com/items?itemName=wolfmah.ansible-vault-inline) extension:

   - Code actions: **Encrypt/Decrypt with Ansible Vault** on the value under the cursor
   - Hover preview of decrypted values (can be disabled via settings)
   - Vault password resolution like ansible itself: `ansible.cfg` (`vault_password_file`,
     `vault_identity_list`), `ANSIBLE_VAULT_PASSWORD_FILE`, or LSP initialization options
   - Language server: [`ansible-vault-lsp`](https://github.com/dimao/ansible-vault-zed)
     (same repo, `path = "zed-ansible-vault"`) — **not** shipped in the extension; resolved
     from settings/PATH or auto-downloaded from GitHub releases (prebuilt for
     linux/macos x86_64+aarch64, windows x86_64)
   - Optionally shells out to the user's own `ansible-vault` executable instead of the
     built-in crypto (`ansibleVaultPath` setting)