### PR TITLE
Add Thrift LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4558,6 +4558,10 @@
 	path = extensions/thrift
 	url = https://github.com/likaihua/zed-thrift.git
 
+[submodule "extensions/thrift-lsp"]
+	path = extensions/thrift-lsp
+	url = https://github.com/musicq/zed-thrift-lsp.git
+
 [submodule "extensions/tiniri"]
 	path = extensions/tiniri
 	url = https://github.com/vladstudio/tiniri-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4639,6 +4639,10 @@ version = "0.1.0"
 submodule = "extensions/thrift"
 version = "0.0.1"
 
+[thrift-lsp]
+submodule = "extensions/thrift-lsp"
+version = "0.0.1"
+
 [tiniri]
 submodule = "extensions/tiniri"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

A Zed extension for better Apache Thrift language support.

- Tree-sitter based syntax highlighting for `.thrift` files
- Bracket matching, indentation, outline, and text object queries
- LSP integration for diagnostics, completion, hover, formatting, references, rename, and go-to-definition
