### PR TITLE
Update effect-language-server-tsgo to v0.0.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1258,7 +1258,7 @@ version = "1.0.0"
 
 [effect-language-service-tsgo]
 submodule = "extensions/effect-language-service-tsgo"
-version = "0.0.5"
+version = "0.0.6"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"


### PR DESCRIPTION
Updated extension to v0.0.6, changes include:

1. `src/tsgo.rs`: binary resolution
   - Stop hardcoding a single name.
   - Try candidates in order:
     - Unix: tsc, then tsgo
     - Windows: tsc.exe, then tsgo.exe
   - First existing path under `node_modules/@effect/tsgo-<os>-<arch>/lib/` wins.
   - Error message lists every path tried.
 
 2. README.md: docs
    - Document that the shipped executable is now tsc, with tsgo still accepted for older packages.
    - Local-binary example path updated to .../lib/tsc.
 3. Version bump to 0.0.6
    - extension.toml: 0.0.5 → 0.0.6
    - Cargo.toml: 0.0.1 → 0.0.6 (aligned with extension version)
    - Cargo.lock: package version updated to match

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
