### PR TITLE
Add SigNoz MCP Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2762,6 +2762,10 @@
 	path = extensions/mcp-server-shortcut
 	url = https://github.com/useshortcut/zed-extension-mcp-server-shortcut.git
 
+[submodule "extensions/mcp-server-signoz"]
+	path = extensions/mcp-server-signoz
+	url = https://github.com/SigNoz/zed-signoz-extension.git
+
 [submodule "extensions/mcp-server-slack"]
 	path = extensions/mcp-server-slack
 	url = https://github.com/semioz/zed-slack-mcp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2812,6 +2812,10 @@ version = "0.1.0"
 submodule = "extensions/mcp-server-shortcut"
 version = "0.0.1"
 
+[mcp-server-signoz]
+submodule = "extensions/mcp-server-signoz"
+version = "0.0.1"
+
 [mcp-server-slack]
 submodule = "extensions/mcp-server-slack"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds the **SigNoz MCP Server** extension.

It provides a Model Context Protocol server for SigNoz observability (metrics, logs, traces, alerts, dashboards), exposed as a context server in Zed.

- Repository: https://github.com/SigNoz/zed-signoz-extension
- Extension ID: `mcp-server-signoz`
- Version: `0.0.1`
- License: MIT

I have tested the extension locally as a dev extension.