### PR TITLE
Add typescript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4690,6 +4690,10 @@
 	path = extensions/ty
 	url = https://github.com/zed-extensions/ty.git
 
+[submodule "extensions/typescript"]
+	path = extensions/typescript
+	url = https://github.com/kjanat/zed-typescript.git
+
 [submodule "extensions/typescript-snippets"]
 	path = extensions/typescript-snippets
 	url = https://github.com/seekode/zed-ts-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -4777,7 +4777,7 @@ version = "0.0.3"
 
 [typescript]
 submodule = "extensions/typescript"
-version = "0.0.1"
+version = "0.0.2"
 
 [typescript-snippets]
 submodule = "extensions/typescript-snippets"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4775,6 +4775,10 @@ version = "0.3.0"
 submodule = "extensions/ty"
 version = "0.0.3"
 
+[typescript]
+submodule = "extensions/typescript"
+version = "0.0.1"
+
 [typescript-snippets]
 submodule = "extensions/typescript-snippets"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the [typescript](https://github.com/kjanat/zed-typescript) extension: runs the stable [TypeScript 7](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) native language server (`tsc --lsp --stdio` from the `typescript` npm package) for JavaScript, JSX, TypeScript, and TSX.

- Prefers the project's own TypeScript 7+ (`tsdk.path` setting or `package.json` dependency), falls back to a managed `npm install typescript`.
- Executes the platform-native server binary directly when resolvable; otherwise launches via the package's `bin/tsc` Node shim.
- Forwards `lsp.typescript.settings` to the server's `workspace/configuration` sections (`js/ts`, `typescript`, `javascript`, `editor`), with inlay hint/code lens defaults matching Zed's built-in vtsls adapter.

Note: distinct from the existing `tsgo` extension, which wraps the `@typescript/native-preview` package; this one targets the stable `typescript@7` release line and enforces >=7 (TypeScript 6 and older stay with Zed's built-in support).