### PR TITLE
Add ldap extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2346,6 +2346,10 @@
 	path = extensions/lazyvim-theme
 	url = https://github.com/BadRat-in/zed-lazyvim-theme.git
 
+[submodule "extensions/ldap"]
+	path = extensions/ldap
+	url = https://github.com/kjanat/zed-ldap.git
+
 [submodule "extensions/lean4"]
 	path = extensions/lean4
 	url = https://github.com/blackbird314/zed-lean4.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2391,6 +2391,10 @@ version = "0.1.0"
 submodule = "extensions/lazyvim-theme"
 version = "0.1.0"
 
+[ldap]
+submodule = "extensions/ldap"
+version = "1.0.0"
+
 [lean4]
 submodule = "extensions/lean4"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the [ldap](https://github.com/kjanat/zed-ldap) extension: language support for LDAP Schema (RFC 4512) and LDIF (RFC 2849) files.

| Language | Extensions | Grammar |
| --- | --- | --- |
| LDAP Schema | `.schema`, `.ldapschema` | [tree-sitter-ldap-schema](https://github.com/kjanat/tree-sitter-ldap-schema) |
| LDIF | `.ldif` | [tree-sitter-ldif](https://github.com/kjanat/tree-sitter-ldif) |

Features:

- Syntax highlighting for both languages
- Symbol outline for schema definitions and LDIF entries/change records
- Bracket matching, auto-close, and indentation
- Vim mode textobjects (`ac` for schema definitions and LDIF entries, `ic`/`af` for schema definition bodies)
- LDIF-to-LDAP-Schema injections for OpenLDAP OLC attributes

Supersedes #5276, which had green CI but was closed as a stale draft. Packaging verified locally with the same `zed-extension` CLI build that CI uses (grammars compile, both languages and all queries load).