### PR TITLE
Add test-coverage-highlight language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4518,6 +4518,10 @@
 	path = extensions/terrible-theme
 	url = https://github.com/nooooaaaaah/terrible-zed.git
 
+[submodule "extensions/test-coverage-highlight"]
+	path = extensions/test-coverage-highlight
+	url = https://github.com/hyyan/zed-test-coverage-highlight.git
+
 [submodule "extensions/tex-japanese-formatter"]
 	path = extensions/tex-japanese-formatter
 	url = https://github.com/keufcp/tex-japanese-formatter-for-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -4518,8 +4518,8 @@
 	path = extensions/terrible-theme
 	url = https://github.com/nooooaaaaah/terrible-zed.git
 
-[submodule "extensions/test-coverage-highlight"]
-	path = extensions/test-coverage-highlight
+[submodule "extensions/test-coverage-highlight-lsp"]
+	path = extensions/test-coverage-highlight-lsp
 	url = https://github.com/hyyan/zed-test-coverage-highlight.git
 
 [submodule "extensions/tex-japanese-formatter"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4599,6 +4599,11 @@ version = "1.0.0"
 submodule = "extensions/terrible-theme"
 version = "0.0.3"
 
+[test-coverage-highlight]
+submodule = "extensions/test-coverage-highlight"
+path = "editors/zed"
+version = "0.1.0"
+
 [tex-japanese-formatter]
 submodule = "extensions/tex-japanese-formatter"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4599,8 +4599,8 @@ version = "1.0.0"
 submodule = "extensions/terrible-theme"
 version = "0.0.3"
 
-[test-coverage-highlight]
-submodule = "extensions/test-coverage-highlight"
+[test-coverage-highlight-lsp]
+submodule = "extensions/test-coverage-highlight-lsp"
 path = "editors/zed"
 version = "0.1.0"
 


### PR DESCRIPTION
Adds [Test Coverage Highlight](https://github.com/hyyan/zed-test-coverage-highlight), an extension that highlights test coverage directly in the editor: uncovered lines red, partially covered lines yellow, covered lines green (opt-in), plus the file coverage percentage as a code lens and hover.

It reads lcov, JaCoCo, Cobertura and Clover reports, auto-discovers them across multi-module projects, and merges them. Since extensions cannot draw gutters, it ships a small language server (`covhl`) that reports coverage via `textDocument/documentColor`, the extension downloads the prebuilt binary for the current platform from the repo's GitHub Releases (v0.1.0 is published for all five platform targets), preferring a `covhl` already on `PATH`.
