### PR TITLE
Add magequery language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2498,6 +2498,9 @@
 	path = extensions/magento2-snippets
 	url = https://github.com/mage-os-lab/zed-magento2-snippets
 
+[submodule "extensions/magequery"]
+	path = extensions/magequery
+	url = https://github.com/cresset-tools/magequery.git
 [submodule "extensions/maho-lsp"]
 	path = extensions/maho-lsp
 	url = https://github.com/MahoCommerce/zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2501,6 +2501,7 @@
 [submodule "extensions/magequery"]
 	path = extensions/magequery
 	url = https://github.com/cresset-tools/magequery.git
+
 [submodule "extensions/maho-lsp"]
 	path = extensions/maho-lsp
 	url = https://github.com/MahoCommerce/zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2498,8 +2498,8 @@
 	path = extensions/magento2-snippets
 	url = https://github.com/mage-os-lab/zed-magento2-snippets
 
-[submodule "extensions/magequery"]
-	path = extensions/magequery
+[submodule "extensions/magequery-lsp"]
+	path = extensions/magequery-lsp
 	url = https://github.com/cresset-tools/magequery.git
 
 [submodule "extensions/maho-lsp"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2547,6 +2547,11 @@ version = "0.4.0"
 submodule = "extensions/magento2-snippets"
 version = "0.1.0"
 
+[magequery]
+submodule = "extensions/magequery"
+path = "editors/zed"
+version = "0.1.0"
+
 [maho-lsp]
 submodule = "extensions/maho-lsp"
 version = "0.10.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2547,8 +2547,8 @@ version = "0.4.0"
 submodule = "extensions/magento2-snippets"
 version = "0.1.0"
 
-[magequery]
-submodule = "extensions/magequery"
+[magequery-lsp]
+submodule = "extensions/magequery-lsp"
 path = "editors/zed"
 version = "0.1.0"
 


### PR DESCRIPTION
Adds [magequery](https://github.com/cresset-tools/magequery), a language server for Magento 2 codebases. It attaches to the PHP and XML languages, next to their primary servers.

The extension is a launcher: it uses `magequery` from PATH when present, otherwise it downloads a prebuilt binary from the project's GitHub releases. The extension code (`editors/zed` in the repository) is MIT-licensed; the downloaded binary is EUPL-1.2.
