### PR TITLE
Add Carve extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -606,6 +606,10 @@
 	path = extensions/cargo-tom
 	url = https://github.com/frederik-uni/zed-cargotom.git
 
+[submodule "extensions/carve"]
+	path = extensions/carve
+	url = https://github.com/markup-carve/zed-carve.git
+
 [submodule "extensions/cassette-futurism-theme"]
 	path = extensions/cassette-futurism-theme
 	url = https://github.com/taotao7/cassette-futurism-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -616,6 +616,10 @@ version = "0.2.0"
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
 
+[carve]
+submodule = "extensions/carve"
+version = "0.1.0"
+
 [cassette-futurism-theme]
 submodule = "extensions/cassette-futurism-theme"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [Carve](https://markup-carve.github.io/carve/) language support via [markup-carve/zed-carve](https://github.com/markup-carve/zed-carve): syntax highlighting, code-block injections, bracket behavior, and outline support for .crv files, using the tree-sitter-carve grammar.