### PR TITLE
Update rhai to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3968,7 +3968,7 @@ version = "0.1.0"
 
 [rhai]
 submodule = "extensions/rhai"
-version = "0.0.1"
+version = "0.0.2"
 
 [rich-vesper]
 submodule = "extensions/rich-vesper"


### PR DESCRIPTION
Updates the rhai extension, fixing some parser bugs and query semantics.

Follow up for #6766 , in which I forgot to bump the version in extensions.toml

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
