### PR TITLE
Update dependi to v1.10.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1095,7 +1095,7 @@ version = "0.1.2"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.9.1"
+version = "1.10.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
## Summary

• Update dependi extension to v1.10.0
• Point the dependi submodule at the v1.10.0 release commit

## Type

chore

## Validation

• pnpm package-extensions dependi
• pnpm sort-extensions
• pnpm build
• pnpm test
• RUSTUP_TOOLCHAIN=1.90 cargo build --locked --release --target wasm32-wasip2
