### PR TITLE
Add Bundle Size extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git
 
+[submodule "extensions/bundle-size"]
+	path = extensions/bundle-size
+	url = https://github.com/shivraj-roy/zed-bundle-size.git
+
 [submodule "extensions/c3"]
 	path = extensions/c3
 	url = https://github.com/AineeJames/c3-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -568,6 +568,10 @@ version = "0.1.0"
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"
 
+[bundle-size]
+submodule = "extensions/bundle-size"
+version = "0.0.1"
+
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

Adds the **Bundle Size** extension, which shows the bundle size of each imported package inline in JavaScript and TypeScript files (via inlay hints backed by a bundled Node language server).

- Extension repository: https://github.com/shivraj-roy/zed-bundle-size
- License: MIT

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
- [x] Tested locally as a dev extension in Zed.
- [x] `extensions.toml` and `.gitmodules` updated and sorted via `pnpm sort-extensions`.
- [x] Extension crate builds cleanly for `wasm32-wasip2` (`cargo build --target wasm32-wasip2 --release`).