### PR TITLE
Add Zen Dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5206,6 +5206,10 @@
 	path = extensions/zen-abyssal
 	url = https://github.com/KevInCompile/ZenAbyssal.git
 
+[submodule "extensions/zen-dark"]
+	path = extensions/zen-dark
+	url = https://github.com/ZacZhangzhuo/zen-dark-zed.git
+
 [submodule "extensions/zenburn-transparent-theme"]
 	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3035,6 +3035,10 @@ version = "0.0.1"
 submodule = "extensions/muted"
 version = "0.0.1"
 
+[my-extension]
+submodule = "extensions/zen-dark"
+version = "1.0.0"
+
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Zen Dark theme, a minimal dark theme for Zed that is easy on the eyes. 

Source repository: https://github.com/ZacZhangzhuo/zen-dark-zed
Extension ID: `zen-dark-theme`
Version: `1.0.0`

Local checks performed:
- Compared style keys against `https://zed.dev/schema/themes/v0.2.0.json` for unsupported keys
- Applied and tested the theme json 