### PR TITLE
Add browser-use extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -534,6 +534,10 @@
 	path = extensions/browser-tools-context-server
 	url = https://github.com/mirageN1349/browser-tools-context-server.git
 
+[submodule "extensions/browser-use"]
+	path = extensions/browser-use
+	url = https://github.com/browser-use/zed-browser-use-extension.git
+
 [submodule "extensions/bsl"]
 	path = extensions/bsl
 	url = https://github.com/dlyubanevich/zed-bsl-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -543,6 +543,10 @@ version = "0.0.1"
 submodule = "extensions/browser-tools-context-server"
 version = "0.1.0"
 
+[browser-use]
+submodule = "extensions/browser-use"
+version = "0.1.0"
+
 [bsl]
 submodule = "extensions/bsl"
 version = "0.0.2"


### PR DESCRIPTION
Adds the official [Browser Use](https://browser-use.com) extension: a context server that launches `browser-use --mcp` (Browser Use CLI 3.0), giving the Zed Agent a real browser — navigate, click, type, read page state, extract content, and take screenshots. Useful for testing the web apps the agent builds, debugging live DOM state, and reading JS-rendered pages.

Extension repo: https://github.com/browser-use/zed-browser-use-extension

Tested locally as a dev extension against a Zed build from main: the server launches, its tools appear in the Agent Panel, and the agent can drive the browser end to end. Requires the Browser Use CLI on PATH (`uv tool install browser-use`); install instructions are shown in the server's configuration view.