### PR TITLE
Add Intra-mart Debug extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2018,6 +2018,10 @@
 	path = extensions/idris2
 	url = https://github.com/dylanbraithwaite/zed-idris2-lsp
 
+[submodule "extensions/imart-debug"]
+	path = extensions/imart-debug
+	url = https://github.com/nisama-6/zed-imart-debug.git
+
 [submodule "extensions/immigrant"]
 	path = extensions/immigrant
 	url = https://github.com/deltarocks/zed-immigrant.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2060,6 +2060,11 @@ version = "1.2.0"
 submodule = "extensions/idris2"
 version = "0.0.1"
 
+[imart-debug]
+submodule = "extensions/imart-debug"
+path = "crates/zed-imart-debug"
+version = "0.1.0"
+
 [immigrant]
 submodule = "extensions/immigrant"
 version = "0.1.2"


### PR DESCRIPTION
Adds Intra-mart Debug, a Zed debug extension for intra-mart JSSP JavaScript applications.

The extension provides a Rust-based Debug Adapter Protocol implementation with breakpoints, conditional breakpoints, call stacks, variables, stepping, evaluation, and exception handling. The native adapter is downloaded from versioned GitHub Release assets for macOS, Linux, and Windows.

Validation:
- Tested locally as a Zed dev extension against an intra-mart environment running on Resin 4.0.66
- pnpm build
- pnpm test (111 tests passed)
- pnpm sort-extensions
- Extension Rust tests, Clippy, and WASM build pass in the extension repository

- [x] I have read CONTRIBUTING.md and followed the relevant guidance for adding my extension.