### PR TITLE
Add Passione Dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3442,6 +3442,10 @@
 	path = extensions/pascal
 	url = https://github.com/ChemisTechlabs/zed-pascal.git
 
+[submodule "extensions/passion-dark-theme"]
+	path = extensions/passion-dark-theme
+	url = https://github.com/Pers1x/Passione-dark.git
+
 [submodule "extensions/path-of-exile"]
 	path = extensions/path-of-exile
 	url = https://github.com/egibs/poe.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3498,6 +3498,10 @@ version = "1.0.2"
 submodule = "extensions/pascal"
 version = "0.1.0"
 
+[passion-dark-theme]
+submodule = "extensions/passion-dark-theme"
+version = "1.1.2"
+
 [path-of-exile]
 submodule = "extensions/path-of-exile"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds Passione Dark, a dark theme for Zed with balanced contrast, warm syntax highlighting, and comfortable long coding sessions.

## Repository

https://github.com/Pers1x/Passione-dark

## Checklist

- [x] Tested locally
- [x] Public repository
- [x] MIT license included
- [x] Version matches extension.toml