### PR TITLE
Update todo-highlight-language-server to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4662,7 +4662,7 @@ version = "0.0.2"
 
 [todo-highlight-language-server]
 submodule = "extensions/todo-highlight-language-server"
-version = "0.2.2"
+version = "0.3.0"
 path = "extension"
 
 [todotxt]


### PR DESCRIPTION
Bumps the TODO Highlight extension (`todo-highlight-language-server`) from v0.2.2 to v0.3.0.

Release: https://github.com/shionit/zed-todo-highlight/releases/tag/v0.3.0

Changes in this version:
- Keywords are now emitted as the standard `keyword` semantic token type (plus per-keyword modifiers such as `todo`, `fixme`), so highlighting works out of the box with only `"semantic_tokens": "combined"` — no custom `semantic_token_rules` block required anymore (shionit/zed-todo-highlight#25)
- Fixed a race that showed a false "keyword highlighting is not active" warning even when settings were correct, and added `window/logMessage` diagnostics (shionit/zed-todo-highlight#24)

- [x] `extensions.toml` version matches `extension.toml` in the submodule (0.3.0)
- [x] Submodule points at the tagged release commit on the default branch