### PR TITLE
Add drenv language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1170,6 +1170,10 @@
 	path = extensions/dream
 	url = https://github.com/arturonegrete-dev/Dream-zed
 
+[submodule "extensions/drenv"]
+	path = extensions/drenv
+	url = https://github.com/Nitemaeric/drenv.git
+
 [submodule "extensions/duckyscript"]
 	path = extensions/duckyscript
 	url = https://github.com/Lalolog/duckyscript-zed-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -1191,6 +1191,11 @@ version = "1.0.0"
 submodule = "extensions/dream"
 version = "1.0.0"
 
+[drenv]
+submodule = "extensions/drenv"
+path = "editors/zed"
+version = "0.1.0"
+
 [duckyscript]
 submodule = "extensions/duckyscript"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## drenv

DragonRuby language intelligence via the [drenv](https://github.com/Nitemaeric/drenv) language server — completions, hover docs, signature help, go-to-definition/references, and diagnostics for [DragonRuby GTK](https://dragonruby.org) projects. All intelligence is derived from the DragonRuby version the project uses; there is no bundled server.

The extension lives in `editors/zed/` within the drenv repository, so the entry uses the `path` field. The MIT `LICENSE` resides at that path.

**Does not bundle a language server:** the extension resolves `drenv` on the user's `PATH` via `worktree.which("drenv")` and runs `drenv lsp` (drenv 0.17.0+ ships the `lsp` subcommand). If `drenv` isn't found it returns a clear error and the server doesn't start. It registers for `Ruby` and `TOML`, and the server is dormant outside DragonRuby projects, so enabling it globally is safe.

**Tested locally:** built and run as a Zed dev extension against a real DragonRuby monorepo (completions, hover with version-matched engine docs, signature help, navigation across `mygame/` and vendored libraries, and diagnostics all verified), against the released `drenv 0.17.1` binary.