### PR TITLE
Add Qwik Language Extension: syntax highlighting, snippets, and Qwik City <Link> route completion

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5253,3 +5253,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/qwik"]
+	path = extensions/qwik
+	url = https://github.com/frypan05/qwik.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3782,6 +3782,10 @@
 	path = extensions/quill
 	url = https://github.com/CraftQuill/zed-theme-quill.git
 
+[submodule "extensions/qwik"]
+	path = extensions/qwik
+	url = https://github.com/frypan05/qwik.git
+
 [submodule "extensions/r"]
 	path = extensions/r
 	url = https://github.com/ocsmit/zed-r.git
@@ -5253,6 +5257,4 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/qwik"]
-	path = extensions/qwik
-	url = https://github.com/frypan05/qwik.git
+

--- a/extensions.toml
+++ b/extensions.toml
@@ -3848,6 +3848,10 @@ version = "0.8.0"
 submodule = "extensions/quill"
 version = "0.2.2"
 
+[qwik]
+submodule = "extensions/qwik"
+version = "0.0.1"
+
 [r]
 submodule = "extensions/r"
 version = "0.2.5"


### PR DESCRIPTION
Closes #1424

## Summary

Adds a new `qwik` extension providing basic Qwik support, as requested in #1424:

- Syntax highlighting for `.tsx`/`.jsx` Qwik files (via the existing TSX grammar)
- Snippets for common Qwik primitives (`component$`, `useSignal`, `routeLoader$`, `routeAction$`, `Link`, `createContextId`, and others — see full list in the completion popup)
- Autocomplete for Qwik City `<Link href="">` values, powered by a small companion language server ([qwik-route-ls](https://github.com/frypan05/qwik-route-ls)) that scans a project's `src/routes` directory and suggests real routes as you type, following Qwik City's file-based routing conventions (route groups, dynamic segments, catch-alls)

## How it works

- The extension declares a language server (`qwik-route-ls`) for TSX/JSX files.
- On startup, the server walks `src/routes`, builds a route index, and keeps it live via a filesystem watcher.
- When editing inside a `<Link href="...">` value, it returns the matching routes as completion items, replacing the typed prefix.
- The server binary is fetched from `qwik-route-ls` GitHub releases (prebuilt for macOS/Linux/Windows, both x86_64 and aarch64 where applicable), same pattern as other Zed language-server extensions.

## Demo

https://github.com/user-attachments/assets/a7466384-56c4-4649-b068-29c3f33d2721

Shows:
1. Snippet completion (`qwik-` triggering the snippet list)
2. Typing `<Link href="` and getting live route suggestions pulled from `src/routes`
3. Filtering as you keep typing (e.g. `/dash` narrowing to `/dashboard/`, `/dashboard/analytics/`, etc.)

## Testing

Tested locally as a dev extension in Zed on Windows against a Qwik City project with nested routes, route groups `(group)`, dynamic segments `[slug]`, and API routes.