### PR TITLE
Add alpinejs-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5253,3 +5253,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/alpinejs-lsp"]
+	path = extensions/alpinejs-lsp
+	url = https://github.com/povly/zed-alpinejs-lsp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -118,6 +118,10 @@
 	path = extensions/alpental-theme
 	url = https://github.com/ascarter/zed-alpental-theme.git
 
+[submodule "extensions/alpinejs-lsp"]
+	path = extensions/alpinejs-lsp
+	url = https://github.com/povly/zed-alpinejs-lsp.git
+
 [submodule "extensions/alpinejs-snippets"]
 	path = extensions/alpinejs-snippets
 	url = https://github.com/A909M/zed-alpinejs-snippets
@@ -5253,6 +5257,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/alpinejs-lsp"]
-	path = extensions/alpinejs-lsp
-	url = https://github.com/povly/zed-alpinejs-lsp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -122,6 +122,10 @@ version = "2.0.2"
 submodule = "extensions/alpental-theme"
 version = "0.0.9"
 
+[alpinejs-lsp]
+submodule = "extensions/alpinejs-lsp"
+version = "0.1.0"
+
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -124,7 +124,7 @@ version = "0.0.9"
 
 [alpinejs-lsp]
 submodule = "extensions/alpinejs-lsp"
-version = "0.1.0"
+version = "0.2.0"
 
 [alpinejs-snippets]
 submodule = "extensions/alpinejs-snippets"


### PR DESCRIPTION
## Alpine.js LSP

Alpine.js language server for Zed — hover documentation, go-to-definition, completions, diagnostics, and code actions for Alpine directives across HTML and Blade files.

### Features

**LSP Intelligence:**
- Hover docs for directives (`x-data`, `x-show`, `x-on`, `x-model`, `x-transition`, etc.), modifiers (`.prevent`, `.stop`, `.debounce`), magic properties (`$el`, `$refs`, `$store`), and global APIs (`Alpine.data`, `Alpine.store`, etc.)
- Go-to-definition for `Alpine.data()` registrations (cross-file), `$store.*` references, and inline x-data scope members
- Completions for magic properties, scope members, `$store.*` chains, `Alpine.*` global APIs, and directive modifiers
- Document Symbols — x-data scope outline with methods/properties
- Document Links — clickable `x-data="name"` → registration, `$store.ui` → `Alpine.store('ui')`
- References — find all usages of `Alpine.data()`, `Alpine.store()`, `x-data="name"`
- Rename — rename components and stores with automatic update of all references

**Diagnostics (6 rules):**
- `x-if`/`x-for` outside `<template>` (Error)
- Duplicate `x-data` on element (Error)
- Unregistered `x-data="name"` component (Warning)
- Unknown `$store.name` (Warning)
- Unknown magic property (Warning)
- Undefined method with "did you mean?" fuzzy hint (Warning)

**Code Actions (4 actions):**
- Extract inline `x-data="{...}"` to `Alpine.data()` registration
- Wrap element in `<template>` (for x-if/x-for)
- Remove duplicate `x-data`
- Register missing `Alpine.data()` component

**Syntax (tree-sitter):**
- Alpine directives (`x-*`, `:`, `@`) highlighted as keywords
- JavaScript injection inside Alpine attribute values

**Workspace Indexer:**
- Scans all HTML/Blade/PHP files for `Alpine.data()`, `Alpine.store()`, `Alpine.magic()` registrations
- Cross-file symbol resolution and go-to-definition
- Supports inline `x-data="{ ... }"` and registered components

### Supported Languages

| Language | LSP | Tree-sitter |
|----------|:---:|:---:|
| HTML (.html) | ✅ | ✅ |
| Blade (.blade.php) | ✅ | ✅ (via Blade extension) |
| PHP (.php) | ✅ | — |

### Data Coverage

18 directives, 29 modifiers, 10 magic properties, 9 global APIs — all with hover documentation and completions.

### Tests

253 unit tests covering extractor, xdata parser, workspace indexer, LSP handlers, diagnostics, code actions, and tree-sitter files.

---

- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.