### PR TITLE
Add lndpnr-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2422,6 +2422,10 @@
 	path = extensions/llvm-ir
 	url = https://github.com/kdkasad/zed-llvm-ir-extension
 
+[submodule "extensions/lndpnr-theme"]
+	path = extensions/lndpnr-theme
+	url = https://github.com/leaandropinheiro/lndpnr.git
+
 [submodule "extensions/log"]
 	path = extensions/log
 	url = https://github.com/nervenes/zed-log.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2470,6 +2470,10 @@ version = "0.0.4"
 submodule = "extensions/llvm-ir"
 version = "0.1.1"
 
+[lndpnr-theme]
+submodule = "extensions/lndpnr-theme"
+version = "0.0.1"
+
 [log]
 submodule = "extensions/log"
 version = "0.0.7"


### PR DESCRIPTION
#### Description

This PR adds the **lndpnr** theme extension to the Zed extension registry.

- **Extension ID:** `lndpnr-theme`
- **Repository:** https://github.com/leaandropinheiro/lndpnr
- **Version:** `0.0.1`
- **License:** MIT

`lndpnr` is a dark theme for the Zed editor.

The extension was tested locally as a **dev extension** before submission (Install Dev Extension → Theme Selector → `lndpnr`).

#### Assets

Screenshot:

![lndpnr theme preview](https://github.com/user-attachments/assets/368e13a5-43b3-4062-9d0b-37f3b61af67e)

#### Checklist

- [x] Followed the [extension publishing guidelines](https://zed.dev/docs/extensions/developing-extensions#publishing-your-extension)
- [x] Extension ID is unique and suffixed with `-theme`
- [x] Extension repository includes an accepted license (`LICENSE` / MIT)
- [x] Added as a Git submodule under `extensions/lndpnr-theme` (HTTPS)
- [x] Entry added to `extensions.toml`
- [x] Ran `pnpm sort-extensions`
- [x] Tested locally as a dev extension before opening this PR