### PR TITLE
Add MakeSenseTSX theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2510,6 +2510,10 @@
 	path = extensions/make
 	url = https://github.com/caius/zed-make.git
 
+[submodule "extensions/makesensetsx"]
+	path = extensions/makesensetsx
+	url = https://github.com/dutaahmad/makesensetsx-theme.git
+
 [submodule "extensions/mako"]
 	path = extensions/mako
 	url = https://github.com/ron0studios/mako-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2559,6 +2559,11 @@ version = "0.1.0"
 submodule = "extensions/make"
 version = "1.1.2"
 
+[makesensetsx]
+submodule = "extensions/makesensetsx"
+path = "zed"
+version = "0.0.1"
+
 [mako]
 submodule = "extensions/mako"
 version = "0.0.3"


### PR DESCRIPTION
✅️ I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **MakeSenseTSX** — a dark + light theme family for TSX-focused development, inspired by VSCode's Extension Marketplace version of GitHub Dark Theme and Developer's Theme.

- **MakeSenseTSX Dark** — dark appearance (`#0d1117` background)
- **LightSenseTSX Light** — light appearance (`#ffffff` background)

Both variants include full syntax highlighting, terminal ANSI colors, and semantic token colors. The extension lives in the `zed/` subdirectory of the submodule.

- `extensions.toml`: `[makesensetsx]` with `path = "zed"`, `version = "0.0.1"`
- License: MIT (`zed/LICENSE`)
- Repo: https://github.com/dutaahmad/makesensetsx-theme (public, `dev/zed-integration` branch)