### PR TITLE
Add Appwrite MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -174,6 +174,10 @@
 	path = extensions/applescript
 	url = https://github.com/HelgeSverre/zed-applescript.git
 
+[submodule "extensions/appwrite-mcp"]
+	path = extensions/appwrite-mcp
+	url = https://github.com/appwrite/zed-extension.git
+
 [submodule "extensions/aptos-move"]
 	path = extensions/aptos-move
 	url = https://github.com/0xbe1/aptos-move-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -179,6 +179,10 @@ version = "0.0.1"
 submodule = "extensions/applescript"
 version = "1.9.1"
 
+[appwrite-mcp]
+submodule = "extensions/appwrite-mcp"
+version = "0.0.1"
+
 [aptos-move]
 submodule = "extensions/aptos-move"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

Adds the official Appwrite MCP extension for Zed.

- **Extension ID:** `appwrite-mcp`
- **Repository:** https://github.com/appwrite/zed-extension
- **Version:** `0.0.1`
- **License:** MIT

The extension installs the pinned `mcp-remote` package through Zed's npm APIs and connects to Appwrite's hosted MCP server at `https://mcp.appwrite.io/`. Authentication uses Appwrite's browser-based OAuth flow, so users do not need to enter API keys or other secrets.

## Validation

- Installed and tested locally as a Zed dev extension.
- Completed browser-based Appwrite OAuth.
- Verified `appwrite_get_context`, a read operation, and a confirmed write operation.
- Ran `cargo fmt --check` and `cargo check --target wasm32-wasip1`.
- Ran `pnpm sort-extensions`, `pnpm build`, and `pnpm test` (111 tests passed).

## Screenshots

### Appwrite MCP connection

![Appwrite MCP successfully running in Zed](https://raw.githubusercontent.com/appwrite/zed-extension/0.0.1/docs/appwrite-mcp-working.png)

### Confirmed write operation

![Appwrite MCP successfully completing a write operation in Zed](https://raw.githubusercontent.com/appwrite/zed-extension/0.0.1/docs/appwrite-mcp-write.png)
