### PR TITLE
Add VS Code 2026 theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4934,6 +4934,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vs-code-2026-theme"]
+	path = extensions/vs-code-2026-theme
+	url = https://github.com/mustafayurdakul/VS-Code-2026-Theme-for-Zed.git
+
 [submodule "extensions/vscode-classic-theme"]
 	path = extensions/vscode-classic-theme
 	url = https://github.com/CharlesSBL/-vscode_classic_theme.zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -5020,6 +5020,10 @@ version = "0.0.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vs-code-2026-theme]
+submodule = "extensions/vs-code-2026-theme"
+version = "0.2.0"
+
 [vscode-classic-theme]
 submodule = "extensions/vscode-classic-theme"
 version = "0.0.1"


### PR DESCRIPTION
  - [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant
  guidance for adding or updating my extension.

Adds the [VS Code 2026 theme](https://github.com/mustafayurdakul/VS-Code-2026-Theme-for-Zed) a port of the VS Code 2026 light and dark themes for Zed.

  - Light and dark variants included
  - Tested locally as a dev extension
  - MIT licensed