### PR TITLE
Add Pike language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3554,6 +3554,10 @@
 	path = extensions/pigs-in-space
 	url = https://github.com/kreek/pigs-in-space-zed.git
 
+[submodule "extensions/pike"]
+	path = extensions/pike
+	url = https://github.com/TheSmuks/zed-pike.git
+
 [submodule "extensions/pinata-theme"]
 	path = extensions/pinata-theme
 	url = https://github.com/stevedylandev/pinata-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3614,6 +3614,10 @@ version = "0.0.29"
 submodule = "extensions/pigs-in-space"
 version = "0.1.0"
 
+[pike]
+submodule = "extensions/pike"
+version = "0.1.0"
+
 [pinata-theme]
 submodule = "extensions/pinata-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds **Pike** language support (id: `pike`).

- **Repository:** https://github.com/TheSmuks/zed-pike (MIT licensed)
- **Version:** 0.1.0 (pinned submodule at tag `v0.1.0`)
- **Grammar:** [`TheSmuks/tree-sitter-pike`](https://github.com/TheSmuks/tree-sitter-pike) v1.3.1, pinned by SHA
- **Provides:** Tree-sitter syntax highlighting (highlights, brackets, indents, outline) for `.pike`, `.pmod`, `.cmod`; plus a language-server bridge (`pike-lsp`) that resolves from PATH or the extension GitHub releases.

Validation performed:
- `cargo build --release --target wasm32-wasip2` (the extension bridge) builds clean.
- Every `languages/pike/*.scm` query compiles against the pinned grammar, and the grammar parses the example fixtures.
- `tree-sitter` runtime matches Zed (0.26), grammar ABI 15.
