### PR TITLE
Add Leo language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -114,6 +114,10 @@
 	path = extensions/alabaster-dark
 	url = https://github.com/findrakecil/alabaster-dark-zed-theme.git
 
+[submodule "extensions/aleo"]
+	path = extensions/aleo
+	url = https://github.com/MagicGordon/zed-aleo-extension.git
+
 [submodule "extensions/alpental-theme"]
 	path = extensions/alpental-theme
 	url = https://github.com/ascarter/zed-alpental-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -114,10 +114,6 @@
 	path = extensions/alabaster-dark
 	url = https://github.com/findrakecil/alabaster-dark-zed-theme.git
 
-[submodule "extensions/aleo"]
-	path = extensions/aleo
-	url = https://github.com/MagicGordon/zed-aleo-extension.git
-
 [submodule "extensions/alpental-theme"]
 	path = extensions/alpental-theme
 	url = https://github.com/ascarter/zed-alpental-theme.git
@@ -2365,6 +2361,10 @@
 [submodule "extensions/legendary-dark-theme"]
 	path = extensions/legendary-dark-theme
 	url = https://github.com/Llewellyn500/Legendary-Dark.git
+
+[submodule "extensions/leo"]
+	path = extensions/leo
+	url = https://github.com/MagicGordon/zed-leo-extension.git
 
 [submodule "extensions/leptos"]
 	path = extensions/leptos

--- a/extensions.toml
+++ b/extensions.toml
@@ -118,6 +118,10 @@ version = "0.0.5"
 submodule = "extensions/alabaster-dark"
 version = "2.0.2"
 
+[aleo]
+submodule = "extensions/aleo"
+version = "0.0.1"
+
 [alpental-theme]
 submodule = "extensions/alpental-theme"
 version = "0.0.9"

--- a/extensions.toml
+++ b/extensions.toml
@@ -118,10 +118,6 @@ version = "0.0.5"
 submodule = "extensions/alabaster-dark"
 version = "2.0.2"
 
-[aleo]
-submodule = "extensions/aleo"
-version = "0.0.1"
-
 [alpental-theme]
 submodule = "extensions/alpental-theme"
 version = "0.0.9"
@@ -2411,6 +2407,10 @@ version = "0.2.0"
 submodule = "extensions/legendary-dark-theme"
 path = "zed"
 version = "5.0.1"
+
+[leo]
+submodule = "extensions/leo"
+version = "0.0.1"
 
 [leptos]
 submodule = "extensions/leptos"


### PR DESCRIPTION
## Summary

Adds Aleo and Leo language support to Zed.

Aleo is the compiled instruction format produced by Leo, so this extension provides language support for both source and compiled project files.

## Features

- Syntax highlighting for Aleo and Leo
- Aleo and Leo document outlines
- Bracket matching, text objects, and Leo indentation
- Leo snippets
- Leo test runnables for functions annotated with `@test`
- `leo-lsp` integration through `PATH` or an explicitly configured binary path

## Tooling

The extension does not bundle or download Leo tooling. `leo`, `leo-fmt`, and `leo-lsp` are optional external tools documented in the extension README.

Leo test runnables use a matching Zed task template, also documented in the README.

## Validation

- Installed and tested locally as a Zed dev extension
- Tested Aleo and Leo syntax highlighting
- Tested Leo diagnostics and navigation with `leo-lsp` 4.2.0
- Tested Leo test runnables
- Passed `cargo check --target wasm32-wasip2`
- Passed the official `zed-extension` packaging process
- Passed the extensions repository build and all 111 tests

- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
