### PR TITLE
ci: Pin pnpm version to v11.11.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
-          version: 11
-          standalone: true
+          version: 11.11.x
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11
+          standalone: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
           version: 11
+          standalone: true
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -21,8 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         with:
-          version: 11
-          standalone: true
+          version: 11.11.x
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 # We only use pnpm.
 bun.lockb
 package-lock.json
+.pnpm-store/
 yarn.lock
 
 # Zed extension CLI.


### PR DESCRIPTION
As of pnpm v11.12.0, the setup step broke - seemingly because of issues with `@pnpm/exe` starting with v11.12.0.

Hence, pinning pnpm to v11.11.x here until this is resolved.