### PR TITLE
fix: remove unreachable dead code in `validateGitmodulesLocations`

### DIFF
--- a/src/lib/validation.js
+++ b/src/lib/validation.js
@@ -166,12 +166,6 @@ export function validateGitmodulesLocations(extensionsToml, gitmodules) {
         `Name and path do not match for submodule ${expectedSubmoduleName}. Please ensure that the submodule is named and located at "${expectedSubmoduleName}".`,
       );
     }
-
-    if (submoduleName !== expectedSubmoduleName) {
-      throw new Error(
-        `Extension with ID "${extensionId}" does not use the proper submodule. Please ensure that the submodule is named and located at "${expectedSubmoduleName}".`,
-      );
-    }
   }
 }
 


### PR DESCRIPTION
## Summary

Removes the duplicate `if` condition on lines 170–174 of `src/lib/validation.js` 
that made the third error block **dead code** — it could never be reached or executed.

Fixes #6810

## What Was Wrong

The function `validateGitmodulesLocations` had **two identical `if` conditions**:

```js
// Line 158 — FIRST check (reachable ✅)
if (submoduleName !== expectedSubmoduleName) {
  throw new Error(`Submodule name ${submoduleName} does not match expected name...`);
}

// Line 170 — THIRD check (❌ DEAD CODE — identical condition)
if (submoduleName !== expectedSubmoduleName) {
  throw new Error(`Extension with ID "${extensionId}" does not use the proper submodule...`);
}
