### PR TITLE
Add Rust Workflow snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3997,7 +3997,6 @@
 [submodule "extensions/rust-workflow-snippets"]
 	path = extensions/rust-workflow-snippets
 	url = https://github.com/Teamofeyy/rust-snippets.git
-	branch = main
 
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -3994,6 +3994,11 @@
 	path = extensions/rust-snippets
 	url = https://github.com/bobbymannino/rust-snippets-for-zed.git
 
+[submodule "extensions/rust-workflow-snippets"]
+	path = extensions/rust-workflow-snippets
+	url = https://github.com/Teamofeyy/rust-snippets.git
+	branch = main
+
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4064,6 +4064,10 @@ version = "1.0.3"
 submodule = "extensions/rust-snippets"
 version = "0.0.4"
 
+[rust-workflow-snippets]
+submodule = "extensions/rust-workflow-snippets"
+version = "0.1.0"
+
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
 version = "2.0.0"


### PR DESCRIPTION
## Extension

Adds Rust Workflow Snippets, a snippets-only extension providing practical
Rust templates for Tokio, tracing, serde, thiserror, testing, error handling,
and common production workflows.

Repository:
https://github.com/Teamofeyy/rust-snippets

## Difference from the existing Rust Snippets extension

This extension intentionally excludes basic syntax snippets already covered
by rust-analyzer completion and postfix completion.

It focuses on higher-level workflows:

- Tokio tasks, channels, timeouts, intervals, and graceful shutdown
- Structured tracing
- Serde models and attributes
- thiserror error definitions
- Result-based functions and async tests
- Common trait implementations
- Clap and Cargo feature patterns

## Attribution

The project is based on the MIT-licensed Rust Snippets extension originally
created by Bobby Mannino. The original copyright notice and MIT license
are retained.

## Testing

- Installed successfully using `zed: install dev extension`
- Tested in Rust files
- Verified snippet placeholders and tab stops
- Validated `snippets/rust.json` with `jq`