### PR TITLE
Add Pyfun language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3714,6 +3714,10 @@
 	path = extensions/pycharm-modern-themes
 	url = https://github.com/injirez/zed-pycharm-modern-themes
 
+[submodule "extensions/pyfun"]
+	path = extensions/pyfun
+	url = https://github.com/simontreanor/Pyfun.git
+
 [submodule "extensions/pylsp"]
 	path = extensions/pylsp
 	url = https://github.com/rgbkrk/python-lsp-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3779,6 +3779,11 @@ version = "0.1.1"
 submodule = "extensions/pycharm-modern-themes"
 version = "0.0.1"
 
+[pyfun]
+submodule = "extensions/pyfun"
+path = "editors/zed"
+version = "0.1.0"
+
 [pylsp]
 submodule = "extensions/pylsp"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3782,7 +3782,7 @@ version = "0.0.1"
 [pyfun]
 submodule = "extensions/pyfun"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.2.0"
 
 [pylsp]
 submodule = "extensions/pylsp"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds language support for [Pyfun](https://github.com/simontreanor/Pyfun), an F#-inspired, functional-first language that compiles to readable Python (Apache-2.0).

The extension lives in the `editors/zed` subdirectory of the main Pyfun repo (`path = "editors/zed"`, with an Apache-2.0 LICENSE at that path). It provides Tree-sitter syntax highlighting (grammar pinned via `[grammars.pyfun]`) plus a language-server shim that locates the `pyfun` binary (`pyfun lsp`) on the user's PATH — the language server is not shipped with the extension. Tested locally as a dev extension.

Ran `sort-extensions` to keep `extensions.toml` and `.gitmodules` sorted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)