### PR TITLE
Update comment-block-snippets to v1.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -838,7 +838,7 @@ version = "0.6.6"
 
 [comment-block-snippets]
 submodule = "extensions/comment-block-snippets"
-version = "1.0.2"
+version = "1.0.4"
 
 [comphy-crisp-themes]
 submodule = "extensions/comphy-crisp-themes"


### PR DESCRIPTION
Release notes:

https://github.com/rami-shalhoub/comment-blocks-zed/releases/tag/v1.0.4