### PR TITLE
Add Modelica extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2874,6 +2874,10 @@
 	path = extensions/mnemonic
 	url = https://github.com/mnemonic-theme/zed
 
+[submodule "extensions/modelica"]
+	path = extensions/modelica
+	url = https://github.com/jbaayen/zed-modelica.git
+
 [submodule "extensions/modern-icons"]
 	path = extensions/modern-icons
 	url = https://github.com/BadRat-in/zed-modern-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2926,6 +2926,10 @@ version = "0.2.1"
 submodule = "extensions/mnemonic"
 version = "0.0.1"
 
+[modelica]
+submodule = "extensions/modelica"
+version = "0.1.0"
+
 [modern-icons]
 submodule = "extensions/modern-icons"
 version = "0.7.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Modelica language support, for the equation-based modelling language used in systems simulation ([Modelica Association](https://modelica.org)). There is currently no Modelica extension in the registry.

Repository: https://github.com/jbaayen/zed-modelica (MIT)

It wraps [OpenModelica's tree-sitter grammar](https://github.com/OpenModelica/tree-sitter-modelica), pinned to a fixed revision, and provides:

- **Highlighting** — built-in types (`Real`, `Integer`, ...) and built-in operators (`der`, `pre`, `noEvent`, `homotopy`, ...) are distinguished from user code; class names highlight as types, except `function` classes; description strings are treated as documentation and modifications (`R = 100`) as properties.
- **Outline** — classes and their components, so parameters are reachable from the symbol picker.
- **Indentation** — `equation`, `algorithm`, `public`, `protected` and `else`/`elseif` sit at the enclosing level, per Modelica Standard Library style.
- **Brackets**, and Vim **text objects**.

Testing: the grammar and queries were checked against the full Modelica Standard Library style corpus of a real project (110 `.mo` files — packages, connectors, partial models, external functions), all of which parse without error, and against a sample exercising every construct the queries cover (`test/Sample.mo` in the extension repo). Installed and exercised locally as a dev extension in Zed 1.10.3.
