### PR TITLE
Update verilog to v0.0.18

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4941,7 +4941,7 @@ version = "1.1.0"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.17"
+version = "0.0.18"
 
 [version14-theme]
 submodule = "extensions/version14-theme"


### PR DESCRIPTION
- Adds the `svls` language server.
- Updates slang-server and verible

---

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
