### PR TITLE
Add freshjuice-themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1554,6 +1554,10 @@
 	path = extensions/freezed-dart-flutter-snippets
 	url = https://github.com/OppositeDragon/freezed-snippets.git
 
+[submodule "extensions/freshjuice-themes"]
+	path = extensions/freshjuice-themes
+	url = https://github.com/freshjuice-dev/zed-themes.git
+
 [submodule "extensions/frieren-theme"]
 	path = extensions/frieren-theme
 	url = https://github.com/PR454D/frieren-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1581,6 +1581,10 @@ version = "0.1.0"
 submodule = "extensions/freezed-dart-flutter-snippets"
 version = "0.0.1"
 
+[freshjuice-themes]
+submodule = "extensions/freshjuice-themes"
+version = "0.1.0"
+
 [frieren-theme]
 submodule = "extensions/frieren-theme"
 version = "0.1.0"


### PR DESCRIPTION
FreshJuice Themes — a collection of 11 fruit-named dark themes for Zed (22 variants total including high-contrast versions).

- Extension ID: freshjuice-themes
- Version: 0.1.0
- License: MIT
- Repository: https://github.com/freshjuice-dev/zed-themes

Themes included: Cyber Banana, Neon Blackcurrant, Electric Lime, Blueberry Blast, Dragon Fruit, Blue Curaçao, Spicy Mango, Deep Space, Synthwave, Neon District, Tokyo Neo (each with a High Contrast variant).