### PR TITLE
Update vibescript to v0.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4978,7 +4978,7 @@ version = "1.0.0"
 
 [vibescript]
 submodule = "extensions/vibescript"
-version = "0.0.1"
+version = "0.0.4"
 
 [vibrant-abyss]
 submodule = "extensions/vibrant-abyss"


### PR DESCRIPTION
Updates the Vibescript extension from 0.0.1 to 0.0.4: syncs the tree-sitter grammar to VibeScript 1.0.0-rc5 syntax (string interpolation, enums, setter/operator method names, shape literals, statement-modifier command calls, and more) plus refreshed highlight/outline/indent queries.

Extension repo: https://github.com/mgomes/zed-vibescript (submodule bumped to master, extension.toml version matches).