### PR TITLE
Add orange-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3354,6 +3354,10 @@
 	path = extensions/optima-theme
 	url = https://github.com/iftekhar-ifat/optima-theme.git
 
+[submodule "extensions/orange-theme"]
+	path = extensions/orange-theme
+	url = https://github.com/guntherdoescode/orange.git
+
 [submodule "extensions/org"]
 	path = extensions/org
 	url = https://github.com/hron/zed-org

--- a/extensions.toml
+++ b/extensions.toml
@@ -3409,6 +3409,10 @@ version = "0.1.0"
 submodule = "extensions/optima-theme"
 version = "0.0.1"
 
+[orange-theme]
+submodule = "extensions/orange-theme"
+version = "0.1.0"
+
 [org]
 submodule = "extensions/org"
 version = "0.0.1"


### PR DESCRIPTION
Adds the **Orange** theme (id: `orange-theme`), Orange on Black zed theme.

### Checklist
- [x] Tested locally as a dev extension (works perfectly in Zed)
- [x] Includes an accepted open-source license (`CC-BY-4.0`)
- [x] Submodule URL uses HTTPS (`https://github.com/guntherdoescode/orange.git`)
- [x] ID matches the naming convention (ends with `-theme`)
- [x] Extension list sorted using `pnpm sort-extensions`