### PR TITLE
Add ByteAsk extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -558,6 +558,10 @@
 	path = extensions/bun-docs-mcp
 	url = https://github.com/kjanat/bun-docs-mcp-zed.git
 
+[submodule "extensions/byteask"]
+	path = extensions/byteask
+	url = https://github.com/ByteAsk/byteask-extensions.git
+
 [submodule "extensions/c3"]
 	path = extensions/c3
 	url = https://github.com/AineeJames/c3-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -568,6 +568,11 @@ version = "0.1.0"
 submodule = "extensions/bun-docs-mcp"
 version = "1.0.0"
 
+[byteask]
+submodule = "extensions/byteask"
+path = "zed"
+version = "0.1.0"
+
 [c3]
 submodule = "extensions/c3"
 version = "0.0.2"


### PR DESCRIPTION
## Description

Adds the ByteAsk extension for Zed: drives [ByteAsk](https://byteask.ai) (a
C/C++ agentic coding harness) via slash commands (`/byteask-exec`,
`/byteask-review`) plus a `context_server_command` integration that lets
Zed's native Agent Panel drive `byteask app-server`.

- Source repo: https://github.com/ByteAsk/byteask-extensions (monorepo; the
  extension lives under `zed/`, added here via `path = "zed"`)
- Release tag used for this submodule pin: `zed-v0.1.0`
  (https://github.com/ByteAsk/byteask-extensions/releases/tag/zed-v0.1.0)
- License: Apache-2.0

## Checks

- [x] Builds against `wasm32-wasip2` (`cargo build --release --target wasm32-wasip2`)
- [x] Tested locally as a dev extension (Install Dev Extension) in Zed
- [x] `extension.toml` version matches the submodule pin's tag