### PR TITLE
Add Glass theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1690,6 +1690,10 @@
 	path = extensions/gitlab-ci-ls
 	url = https://github.com/tzabbi/zed-gitlab-ci-ls.git
 
+[submodule "extensions/glass"]
+	path = extensions/glass
+	url = https://github.com/b4bury/zed-glass.git
+
 [submodule "extensions/glazier"]
 	path = extensions/glazier
 	url = https://github.com/airgap/glazier.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1690,8 +1690,8 @@
 	path = extensions/gitlab-ci-ls
 	url = https://github.com/tzabbi/zed-gitlab-ci-ls.git
 
-[submodule "extensions/glass"]
-	path = extensions/glass
+[submodule "extensions/glass-theme"]
+	path = extensions/glass-theme
 	url = https://github.com/b4bury/zed-glass.git
 
 [submodule "extensions/glazier"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1720,6 +1720,10 @@ version = "2025.08.0"
 submodule = "extensions/gitlab-ci-ls"
 version = "1.0.1"
 
+[glass]
+submodule = "extensions/glass"
+version = "0.1.0"
+
 [glazier]
 submodule = "extensions/glazier"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1720,8 +1720,8 @@ version = "2025.08.0"
 submodule = "extensions/gitlab-ci-ls"
 version = "1.0.1"
 
-[glass]
-submodule = "extensions/glass"
+[glass-theme]
+submodule = "extensions/glass-theme"
 version = "0.1.0"
 
 [glazier]


### PR DESCRIPTION
This PR adds **Glass**, a liquid-glass transparent theme for Zed (Dark Glass + Light Glass variants).

- Repository: https://github.com/b4bury/zed-glass
- License: MIT
- Added as a git submodule under `extensions/glass`, pinned to `v0.1.0`.

I have tested the theme locally via Install Dev Extension and confirmed both variants load and render correctly.