### PR TITLE
Add carve language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -606,6 +606,10 @@
 	path = extensions/cargo-tom
 	url = https://github.com/frederik-uni/zed-cargotom.git
 
+[submodule "extensions/carve"]
+	path = extensions/carve
+	url = https://github.com/markup-carve/zed-carve.git
+
 [submodule "extensions/cassette-futurism-theme"]
 	path = extensions/cassette-futurism-theme
 	url = https://github.com/taotao7/cassette-futurism-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -616,6 +616,10 @@ version = "0.2.0"
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
 
+[carve]
+submodule = "extensions/carve"
+version = "0.1.0"
+
 [cassette-futurism-theme]
 submodule = "extensions/cassette-futurism-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the **Carve** extension: syntax highlighting + language server for [Carve](https://github.com/markup-carve/carve), a post-Markdown lightweight markup language (`.crv`).

- Repository: https://github.com/markup-carve/zed-carve
- Version: 0.1.0 (pinned to the `v0.1.0` release commit)
- Grammar: `tree-sitter-carve`
- Language server: `@markup-carve/carve-lsp` (installed from npm on first use) for diagnostics, hover, and document symbols

I have tested this extension locally as a dev extension.