### PR TITLE
Add Fastly VCL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1406,6 +1406,10 @@
 	path = extensions/fastapi-snippets
 	url = https://github.com/NarmadaWeb/fastapi-snippets-zed.git
 
+[submodule "extensions/fastly-vcl"]
+	path = extensions/fastly-vcl
+	url = https://github.com/fastly/zed-fastly-vcl.git
+
 [submodule "extensions/fedaykin-themes"]
 	path = extensions/fedaykin-themes
 	url = https://github.com/btriapitsyn/zed-fedaykin-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1432,6 +1432,10 @@ version = "0.1.1"
 submodule = "extensions/fastapi-snippets"
 version = "0.2.0"
 
+[fastly-vcl]
+submodule = "extensions/fastly-vcl"
+version = "0.1.0"
+
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"
 version = "1.0.0"


### PR DESCRIPTION
Add [Fastly Varnish Configuration Language](https://www.fastly.com/documentation/reference/vcl/) support for Zed.

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.