### PR TITLE
Update JSON5 to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2236,7 +2236,7 @@ version = "0.0.3"
 
 [json5]
 submodule = "extensions/json5"
-version = "0.1.0"
+version = "0.1.1"
 
 [jsonl]
 submodule = "extensions/jsonl"


### PR DESCRIPTION
## Summary

- update the JSON5 extension submodule to v0.1.1
- add the required MIT license
- improve highlighting, comments, bracket matching, indentation, outline support, Vim text objects, and redactions
- add a JSON5 syntax fixture and Tree-sitter query CI

## Validation

- installed and loaded successfully as a Zed dev extension
- compiled every Tree-sitter query against the pinned grammar
- extension CI passed
- `pnpm sort-extensions` completed successfully
- `pnpm build` passed
- `pnpm test`: 111 tests passed