### PR TITLE
Add StyLua extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4326,6 +4326,10 @@
 	path = extensions/stylelint
 	url = https://github.com/florian-sanders/zed-stylelint.git
 
+[submodule "extensions/stylua"]
+	path = extensions/stylua
+	url = https://github.com/PatrykBr/zed-stylua.git
+
 [submodule "extensions/styx"]
 	path = extensions/styx
 	url = https://github.com/bearcove/styx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4399,6 +4399,10 @@ version = "0.0.1"
 submodule = "extensions/stylelint"
 version = "3.0.0"
 
+[stylua]
+submodule = "extensions/stylua"
+version = "1.0.0"
+
 [styx]
 submodule = "extensions/styx"
 path = "editors/zed-styx"


### PR DESCRIPTION
Adds a StyLua extension providing formatting support for Lua and Luau.

The extension uses StyLua from the worktree PATH when available. Otherwise, it
downloads the appropriate binary from the official StyLua GitHub releases.

Tested locally as a Zed dev extension with both Lua and Luau.

Extension repository:
https://github.com/PatrykBr/zed-stylua

Licence: MIT

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
