### PR TITLE
Add Selene extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4022,6 +4022,10 @@
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git
 
+[submodule "extensions/selene"]
+	path = extensions/selene
+	url = https://github.com/PatrykBr/zed-selene.git
+
 [submodule "extensions/selene-abyss-theme"]
 	path = extensions/selene-abyss-theme
 	url = https://github.com/envoidia/zed-selene-abyss.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4092,6 +4092,10 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.2.0"
 
+[selene]
+submodule = "extensions/selene"
+version = "1.0.0"
+
 [selene-abyss-theme]
 submodule = "extensions/selene-abyss-theme"
 version = "0.0.3"


### PR DESCRIPTION
Adds live Selene diagnostics for Lua and Luau.

Selene is a command-line linter and does not provide an LSP server. This
extension therefore includes a small JavaScript bridge that runs Selene against
the active document and publishes its results as Zed diagnostics.

The extension does not bundle Selene itself. It uses Selene from the worktree
PATH when available and otherwise downloads it from the official Selene
releases:

https://github.com/Kampfkarren/selene

Tested locally as a Zed dev extension with both Lua and Luau.

Extension repository:
https://github.com/PatrykBr/zed-selene

Licence: MIT

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.