### PR TITLE
Add English to Spanish Translator language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1326,6 +1326,10 @@
 	path = extensions/emoji-completions
 	url = https://github.com/ahockersten/emoji-completions-zed.git
 
+[submodule "extensions/en-es-translator"]
+	path = extensions/en-es-translator
+	url = https://github.com/Theos48/zed-en-es-translator.git
+
 [submodule "extensions/env"]
 	path = extensions/env
 	url = https://github.com/zarifpour/zed-env

--- a/extensions.toml
+++ b/extensions.toml
@@ -1349,6 +1349,11 @@ version = "0.20.2"
 submodule = "extensions/emoji-completions"
 version = "1.1.1"
 
+[en-es-translator]
+submodule = "extensions/en-es-translator"
+path = "zed-extension"
+version = "0.1.0"
+
 [env]
 submodule = "extensions/env"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding my extension.

Adds English to Spanish Translator 0.1.0, a Linux x86_64 extension that downloads an integrity-locked local translation package on first use and translates offline afterward. Translation is exposed as a read-only hover preview and does not modify the source buffer.

Repository: https://github.com/Theos48/zed-en-es-translator
Release: https://github.com/Theos48/zed-en-es-translator/releases/tag/v0.1.0

Local validation:

- installed and tested as a dev extension on Zed 1.11.3, Linux x86_64
- acquired the exact public v0.1.0 package and started the LSP from Zed-owned extension storage
- produced the Spanish hover preview for the public Markdown fixture
- confirmed the fixture Git blob was unchanged
- upstream registry TypeScript build and 111 tests pass with Node 24.18.0 and pnpm 11.11.0