### PR TITLE
Add One Dark Pro GNOME theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3306,6 +3306,10 @@
 	path = extensions/one-dark-pro-enhanced
 	url = https://github.com/hadez8877/one-dark-pro-enhanced.git
 
+[submodule "extensions/one-dark-pro-gnome-theme"]
+	path = extensions/one-dark-pro-gnome-theme
+	url = https://github.com/prabhjot0109/zed-one-dark-pro-gnome-theme.git
+
 [submodule "extensions/one-dark-pro-max"]
 	path = extensions/one-dark-pro-max
 	url = https://github.com/kussumma/one-dark-pro-max.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3361,6 +3361,10 @@ version = "0.0.11"
 submodule = "extensions/one-dark-pro-enhanced"
 version = "0.0.12"
 
+[one-dark-pro-gnome-theme]
+submodule = "extensions/one-dark-pro-gnome-theme"
+version = "0.0.1"
+
 [one-dark-pro-max]
 submodule = "extensions/one-dark-pro-max"
 version = "0.0.2"


### PR DESCRIPTION
This PR adds the One Dark Pro GNOME variant theme extension to the registry, ported from the popular VS Code theme.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
