### PR TITLE
Add oh-lucy-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3270,6 +3270,10 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
+[submodule "extensions/oh-lucy-theme"]
+	path = extensions/oh-lucy-theme
+	url = https://github.com/MoonTory/oh-lucy-theme.git
+
 [submodule "extensions/oldbook-theme"]
 	path = extensions/oldbook-theme
 	url = https://github.com/gko/oldbook-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3325,6 +3325,10 @@ path = "crates/extension-zed"
 submodule = "extensions/oh-lucy"
 version = "0.0.1"
 
+[oh-lucy-theme]
+submodule = "extensions/oh-lucy-theme"
+version = "0.1.0"
+
 [oldbook-theme]
 submodule = "extensions/oldbook-theme"
 version = "1.5.5"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This adds [Oh Lucy Theme](https://github.com/MoonTory/oh-lucy-theme), a faithful port of the Oh Lucy VS Code theme to Zed. This port includes five variants: Lucy, Lucy Evening, Lucy Dawn, Lucy Midnight, and the light Lucy Day. It is MIT licensed and the README includes screenshots of every variant.

I'm aware there is an existing oh-lucy extension and I want to acknowledge the work that went into it. My port started from scratch and has a different scope, since it covers both original variants plus three new ones, so it felt more appropriate to submit it as its own extension rather than propose replacing the existing one. That said, I'm happy to rename the extension ID or adjust the approach in whatever way works best for the registry.