### PR TITLE
Add Candela theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -578,6 +578,10 @@
 	path = extensions/call-trans-opt-received
 	url = https://github.com/takk8is/call-trans-opt-received-2-19-98-13-24-18-rec-log-theme-for-zed.git
 
+[submodule "extensions/candela-theme"]
+	path = extensions/candela-theme
+	url = https://github.com/xXCHAVOTAXx/candela-theme.git
+
 [submodule "extensions/canipls-lint"]
 	path = extensions/canipls-lint
 	url = https://github.com/taylorplewe/canipls-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -588,6 +588,10 @@ version = "0.1.1"
 submodule = "extensions/call-trans-opt-received"
 version = "0.1.1"
 
+[candela-theme]
+submodule = "extensions/candela-theme"
+version = "0.0.1"
+
 [canipls-lint]
 submodule = "extensions/canipls-lint"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Candela

A warm, low-fatigue theme (dark + light) for Zed, built on real color math:

- **Perceptual coherence** — accents generated in OKLCH at fixed lightness (L=0.80) and chroma (C=0.115), 8 hues equally spaced. No color dominates.
- **Verified contrast** — body text WCAG AAA (≥7:1); accents AAA in dark, AA+ (≥4.5:1) in light. Measured, not eyeballed.
- **Colorblind-aware** — meaning never rides on red/green alone; red reserved for errors with background + border.
- **Color = identifier, gray = operator** — identifiers colored, operators/punctuation neutral gray.

Repository: https://github.com/xXCHAVOTAXx/candela-theme
Showcase: https://xxchavotaxx.github.io/candela-theme/
License: MIT