### PR TITLE
Bump postman-context-server to 0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3712,7 +3712,7 @@ version = "0.1.0"
 
 [postman-context-server]
 submodule = "extensions/postman-context-server"
-version = "0.1.0"
+version = "0.2.0"
 
 [powershell]
 submodule = "extensions/powershell"


### PR DESCRIPTION
Bumps the `postman-context-server` extension to **0.2.0**.

Changes in this release (see [postman-mcp-zed-extension](https://github.com/postmanlabs/postman-mcp-zed-extension)):
- Add a `telemetryEnabled` setting (default `true`) that sets the `POSTMAN_MCP_TELEMETRY` environment variable on the server.
- Improve the missing/empty API key error messages to direct users to the extension's Configure panel.

Submodule updated to commit `167436e`.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.