### PR TITLE
Add zed-path-intellisense extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5285,3 +5285,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zed-path-intellisense"]
+	path = extensions/zed-path-intellisense
+	url = https://github.com/deluxe-catalyst/zed-path-intellisense.git


### PR DESCRIPTION
# Path Intellisense

Adds file path autocompletion inside quotes (`'`, `"`) for multiple languages in Zed, similar to the VS Code Path Intellisense extension.

## Features
- Autocomplete file paths when typing `"./`, `"../`, or `"/` inside strings
- Works with `'` and `"` quotes
- Supports JavaScript, TypeScript, Rust, Python, Go, CSS, HTML, and more
- Shows files one level deep in subdirectories for quick access
- `/` character triggers further directory drill-down

## How it works
The extension launches a native LSP server binary (`zed-path-intellisense-lsp`) that scans the filesystem and returns path completions. The binary must be built by the user or installed via cargo.