### PR TITLE
Add liveserver-plus-plus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2426,6 +2426,10 @@
 	path = extensions/live-template
 	url = https://github.com/jekst/zed-snippets.git
 
+[submodule "extensions/liveserver-plus-plus"]
+	path = extensions/liveserver-plus-plus
+	url = https://github.com/wasi-master/zed-liveserver-plus-plus.git
+
 [submodule "extensions/llvm-ir"]
 	path = extensions/llvm-ir
 	url = https://github.com/kdkasad/zed-llvm-ir-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -2474,6 +2474,10 @@ version = "0.3.1"
 submodule = "extensions/live-template"
 version = "0.0.4"
 
+[liveserver-plus-plus]
+submodule = "extensions/liveserver-plus-plus"
+version = "1.0.0"
+
 [llvm-ir]
 submodule = "extensions/llvm-ir"
 version = "0.1.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [LiveServer++](https://github.com/wasi-master/zed-liveserver-plus-plus), a live-reloading development server extension.

A `live-server` extension already exists, but it is a thin wrapper with three settings (port, lazy, public). LiveServer++ is a different implementation with a much broader feature set, comparable to the VS Code Live Server extension: hot CSS swap without full reload, SPA fallback mode, proxy rules, directory mounts, HTTPS, CORS and custom headers, ignore globs, reload debounce, gzip/ETag/Range serving, directory listings, LAN/mobile testing, browser launcher, code action controls, and a local control API usable from Zed tasks. The server itself is a single zero-dependency Node.js script embedded in the extension; the only runtime requirement is Node.js 18+.

Tested locally as a dev extension on macOS (multiple worktrees, port fallback, live reload, and CSS hot swap verified in a real browser). Repository is MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)