### PR TITLE
Add fswiki language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1674,6 +1674,10 @@
 	path = extensions/fsm
 	url = https://codeberg.org/reesericci/zed-extension-fsm.git
 
+[submodule "extensions/fswiki"]
+	path = extensions/fswiki
+	url = https://github.com/blank71/zed-fswiki
+
 [submodule "extensions/fujihaze-theme"]
 	path = extensions/fujihaze-theme
 	url = https://github.com/BinaryMoura/FujiHaze-Theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1707,7 +1707,7 @@ version = "0.3.0"
 
 [fswiki]
 submodule = "extensions/fswiki"
-version = "1.0.0"
+version = "1.0.1"
 
 [fujihaze-theme]
 submodule = "extensions/fujihaze-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1705,6 +1705,10 @@ version = "0.0.9"
 submodule = "extensions/fsm"
 version = "0.3.0"
 
+[fswiki]
+submodule = "extensions/fswiki"
+version = "1.0.0"
+
 [fujihaze-theme]
 submodule = "extensions/fujihaze-theme"
 version = "1.0.0"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

- https://github.com/blank71/zed-fswiki

`fswiki`, which is `FreeStyleWiki` is a Wiki Syntax.
Original implementation and syntax is at [FreeStyleWiki/fswiki](https://github.com/FreeStyleWiki/fswiki).
This PR is for syntax highlighting, lsp, and formatting.
