### PR TITLE
Update rumdl to v0.0.3 and point at maintained repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3996,7 +3996,7 @@
 
 [submodule "extensions/rumdl"]
 	path = extensions/rumdl
-	url = https://github.com/inflation/zed-rumdl.git
+	url = https://github.com/rvben/zed-rumdl.git
 
 [submodule "extensions/runescape-icon-theme"]
 	path = extensions/runescape-icon-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -4066,7 +4066,7 @@ version = "0.16.14"
 
 [rumdl]
 submodule = "extensions/rumdl"
-version = "0.0.1"
+version = "0.0.3"
 
 [runescape-icon-theme]
 submodule = "extensions/runescape-icon-theme"


### PR DESCRIPTION
I maintain rumdl itself (https://github.com/rvben/rumdl). This repoints the `rumdl` extension to the actively maintained repo so it tracks rumdl releases, and bumps it to v0.0.3.

The current submodule points at `inflation/zed-rumdl`. The previous maintainer has agreed to hand it off: inflation/zed-rumdl#6 ("Sure, go ahead").

- Repoint `extensions/rumdl` to https://github.com/rvben/zed-rumdl
- Bump to v0.0.3 (fixes the release-asset name in the auto-downloader)

Thanks!
