### PR TITLE
Update Uno Flat theme to 0.1.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4889,7 +4889,7 @@ version = "0.0.5"
 
 [unoflat]
 submodule = "extensions/unoflat"
-version = "0.1.4"
+version = "0.1.5"
 
 [urdf]
 submodule = "extensions/urdf"


### PR DESCRIPTION
Updates the Uno Flat theme extension to v0.1.5.

Changes in this release:
- Darkened the tab bar
- Muted the inlay hint color

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QznM7rtSJNvecTd9sbVuPz