### PR TITLE
Add Spring Tools extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5198,6 +5198,10 @@
 	path = extensions/zed-legacy-themes
 	url = https://github.com/zed-extensions/legacy-themes.git
 
+[submodule "extensions/zed-spring-tools"]
+	path = extensions/zed-spring-tools
+	url = https://github.com/luceat-lux-vestra/zed-spring-tools.git
+
 [submodule "extensions/zedbox"]
 	path = extensions/zedbox
 	url = https://github.com/isaiah-hamilton/zedbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5282,6 +5282,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-spring-tools]
+submodule = "extensions/zed-spring-tools"
+version = "0.1.0"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Spring Tools** (`spring-tools`, v0.1.0) — Spring Boot language intelligence for Zed, powered by the Spring Boot Language Server.

- **Repository:** https://github.com/luceat-lux-vestra/zed-spring-tools
- **License:** Apache-2.0
- **What it does:** Hover/definition and validation for `application.properties`/`.yml`, Spring project symbol search, and inlay hints (cron expressions, Spring Data query parameters). It requires the official Java extension; an XML extension additionally routes `pom.xml` to the server for Maven hints ("Add Spring Boot Starters", "Upgrade to the Latest Patch").
- Tested locally as a dev extension against real Spring Boot projects before submission.