### PR TITLE
Add Ren'Py extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3890,6 +3890,10 @@
 	path = extensions/remix-min-darker-theme
 	url = https://github.com/FernaandoJr/remix-min-darker-zed.git
 
+[submodule "extensions/renpy"]
+	path = extensions/renpy
+	url = https://github.com/Ozicom23/zed-renpy.git
+
 [submodule "extensions/replicant"]
 	path = extensions/replicant
 	url = https://github.com/pierrenel/replicant.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3957,6 +3957,10 @@ version = "0.2.0"
 submodule = "extensions/remix-min-darker-theme"
 version = "0.0.4"
 
+[renpy]
+submodule = "extensions/renpy"
+version = "0.1.0"
+
 [replicant]
 submodule = "extensions/replicant"
 version = "0.0.2"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

---

Adds language support for [Ren'Py](https://www.renpy.org), the open-source visual novel engine, covering its `.rpy`/`.rpym` script files: https://github.com/Ozicom23/zed-renpy

There is currently no Ren'Py extension in the registry.

**Features**

- Tree-sitter syntax highlighting (grammar vendored inside the extension repository, MIT), outline, auto-indentation for colon blocks, bracket support
- Python injection inside `init python:` blocks, `$` one-liners, `define` values, and conditions
- A bundled MIT-licensed language server (Rust) providing project-wide go-to-definition, hover documentation (including Ren'Py API docs generated from the official documentation), context-aware completion, diagnostics (undefined `jump`/`call` targets, duplicate labels), find references, label rename, and workspace symbols

The language server ships as prebuilt binaries for macOS (arm64/x64), Linux (x64/arm64), and Windows, downloaded from the extension repository's GitHub releases on first use; a binary on PATH or an `lsp.renpy-language-server.binary.path` setting takes precedence. Tested locally as a dev extension on macOS.

License: MIT (the vendored grammar and the bundled Ren'Py API documentation dataset are MIT as well, with licenses included).