### PR TITLE
Add jupyter-notebook extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2222,6 +2222,10 @@
 	path = extensions/julia
 	url = https://github.com/JuliaEditorSupport/zed-julia.git
 
+[submodule "extensions/jupyter-notebook"]
+	path = extensions/jupyter-notebook
+	url = https://github.com/ArneshBanerjee/zed-jupyter.git
+
 [submodule "extensions/just"]
 	path = extensions/just
 	url = https://github.com/jackTabsCode/zed-just.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2266,6 +2266,10 @@ version = "0.1.0"
 submodule = "extensions/julia"
 version = "0.1.10"
 
+[jupyter-notebook]
+submodule = "extensions/jupyter-notebook"
+version = "0.1.0"
+
 [just]
 submodule = "extensions/just"
 version = "0.2.0"


### PR DESCRIPTION
Adds the [jupyter-notebook](https://github.com/ArneshBanerjee/zed-jupyter) extension: Jupyter notebook (`.ipynb`) support for Zed.

## What it provides

- **`.ipynb` language support** — "Jupyter Notebook" language using the tree-sitter JSON grammar, with highlighting, outline, and folding.
- **Notebook diagnostics** — live validation of JSON (with error positions) and nbformat structure (invalid cell types, missing fields).
- **Notebook commands as code actions**:
  - *Edit as paired Python script* — converts the notebook to a `# %%` percent-format script (Jupytext-style), so cells can be edited with full LSP/vim support and run interactively with Zed's built-in REPL.
  - *Sync notebook from paired script* — merges edits back, preserving outputs and execution counts of unchanged cells.
  - *Run all cells* — executes the notebook via `jupyter nbconvert --execute` and writes outputs into the file.
  - *Clear all outputs*, and *Initialize empty notebook* for blank `.ipynb` files.

## Implementation notes

- The language server is a single-file, stdlib-only Python script embedded in the extension and run with the user's `python3`; there is no separate binary to download and no third-party Python dependencies. (If bundling it this way conflicts with the no-shipped-language-servers policy, happy to switch to fetching it from a GitHub release instead.)
- Kernel execution is delegated to the user's Jupyter tooling (`nbconvert`/`ipykernel`), which the README documents.

## Testing

- Automated: the server has a test suite covering conversion round-trips, output preservation, and a scripted end-to-end LSP session over stdio (`python3 server/test_server.py`, 8 tests).
- Manual: installed as a dev extension in Zed 1.11.3 on macOS; verified language detection, diagnostics, the code-action menu, and command execution with buffer rewrite via `workspace/applyEdit`.