### PR TITLE
Add Spring Tools extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4294,6 +4294,10 @@
 	path = extensions/spinel-theme
 	url = https://github.com/a-lavis/zed-spinel
 
+[submodule "extensions/spring-tools"]
+	path = extensions/spring-tools
+	url = https://github.com/luceat-lux-vestra/zed-spring-tools.git
+
 [submodule "extensions/sql"]
 	path = extensions/sql
 	url = https://github.com/zed-extensions/sql.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4366,6 +4366,10 @@ version = "0.0.1"
 submodule = "extensions/spinel-theme"
 version = "0.1.0"
 
+[spring-tools]
+submodule = "extensions/spring-tools"
+version = "0.1.0"
+
 [sql]
 submodule = "extensions/sql"
 version = "1.1.7"


### PR DESCRIPTION
- [x] I've read
  [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md)
  and followed the relevant guidance for adding or updating my extension.

Adds **Spring Tools** (`spring-tools`, v0.1.0), a Spring Boot language
intelligence companion for Zed's required official Java extension.

- **Repository:** https://github.com/luceat-lux-vestra/zed-spring-tools
- **License:** Apache-2.0
- **Current project commit:**
  [`00b3090`](https://github.com/luceat-lux-vestra/zed-spring-tools/commit/00b3090da661e67fe787a47e8dfa632229112fb2)

The submodule points to the current reviewed project `main`. The extension
version remains `0.1.0` because it has not yet been published.

## Integration boundary

Spring Tools requires and coordinates with the official Java extension. It
contributes the reviewed Spring bundles to the Java-owned JDT LS and runs the
Spring Boot language server through its own coordinator; it does not modify the
official extension or start a second/self-managed Java language server.

## User-visible capabilities

### Configuration files and Spring-specific languages

- Completion, hover, validation, and definition navigation for Spring Boot
  `.properties` and YAML.
- Reviewable `.properties` ↔ YAML conversion and explicit shared-metadata
  reload.
- Dedicated `*.factories` and `META-INF/jpa-named-queries.properties`
  languages, including JPQL validation for named queries and the Boot 3
  unsupported-key error in `spring.factories`.
- Optional `pom.xml` Maven hints and Spring XML-config intelligence when an XML
  extension registers the `XML` language.

### Java intelligence and navigation

- Spring-aware completion for property keys, bean names, scopes, profiles,
  Spring Data repository methods, and injectable beans.
- Request-mapping method templates with import edits, cron completion and
  validation, quick fixes, Spring workspace symbols, and Spring-specific
  references composed with official-Java results.
- Spring Data query intelligence — syntax validation of the JPQL, HQL or SQL
  inside `@Query` or a bare `EntityManager.createQuery(…)`, navigation from a
  query parameter to the method parameter it stands for, and derived
  query-method name proposals.
- SpEL validation wherever Spring reads an expression, the Spring Java
  reconcilers and their quick fixes, and Spring AI annotation validation.
- Static and live Spring CodeLens, native Hover detail, and cron/Spring Data
  inlay hints through standard Zed/LSP surfaces.
- Syntax highlighting for the JPQL/HQL/SQL embedded inside a Java string, which
  Zed requests only when the user turns its own `semantic_tokens` language
  setting on; no extension can set that key, so it is documented rather than
  worked around, and ordinary Java highlighting stays intact when it is on.

### Project and runtime workflows

- A source action discovers executable Boot projects and writes merge-safe,
  reviewable `.zed/tasks.json` and `.zed/debug.json` entries, including bounded
  profile and multi-module selection; Spring's own build commands are answered
  with the same reviewable, wrapper-aware task rather than an invisible
  in-process build.
- Boot version and support-range validation, the Spring Boot patch-upgrade quick
  fix, the per-file Boot project record, and Spring Modulith structure and
  refresh.
- An opt-in generated Structure document preserves Spring's project/group
  hierarchy while Project Symbols remains the exact-location fallback.
- Explicit local-process connect/refresh/disconnect and settings-driven remote
  connection (on the pinned release a declared remote target is offered in the
  process action rather than connecting on declaration, which is an upstream
  change recorded in the project's compatibility notes), live
  bean/endpoint/injection data, bounded memory/GC/logger snapshots, confirmed
  logger-level changes, and opening a running app's page from its request mapping.
- Default-off automatic local connection admits only one unambiguous
  worktree/project match; the explicit process action remains the fallback.
- A default-off setting starts the Spring Tools MCP server that the pinned
  package already contains, inside the same language-server JVM, so Zed's Agent
  can query the live Spring index of the open project over the project's own
  MCP configuration. It is opt-in because it opens a listening socket; a
  one-project-per-worktree limit is recorded rather than hidden. The one upstream
  tool defect this project found and reported is fixed in the pinned release.

Nothing in this inventory is left undecided: the `planned` and `implemented`
columns are both empty. Three capabilities are `blocked-zed-api` with the exact
missing surface named — Spring-specific document highlights (Zed queries the
first capable server only), inlay-hint label commands for the `pom.xml`
"Upgrade to the Latest Patch" hint (Zed builds label parts with no command), and
the AI explanation commands (no extension-reachable Agent surface). Two are
`not-pursued` against upstream's own defaults: Spring Initializr, and completion
prefix elision, which a driven A/B found actively harmful in Zed today and which
is tracked upstream as zed-industries/zed#61646. None of them is silently
emulated.

## Requirements

- The official **Java** extension and JDK 21 or newer.
- At least one Java file must be opened so Zed starts the official Java language
  server and Spring receives the project classpath.
- An XML extension is optional and is only needed for the XML/Maven surfaces
  above.
- Network access is needed for the first pinned Spring Tools artifact download.
  After that first download, the extension has been driven with the network
  denied; only Boot version/support validation degrades, and it does so quietly.

## Pinned external inputs

- Spring Tools `5.3.0.RELEASE`,
  `vscode-spring-boot-2.3.0-RC2.vsix`, downloaded from the official
  `spring-projects/spring-tools` GitHub release at first use. The pin moved from
  `5.2.0.RELEASE` on 2026-08-01 through the project's own refresh gate.
- `tree-sitter-grammars/tree-sitter-properties` at
  `579b62f5ad8d96c2bb331f07d1408c92767531d9` (MIT). The two Spring-specific
  file types require a grammar for Zed language classification; this is the
  same revision already pinned by the official Java extension.

No Spring VSIX/JAR, JDT LS distribution, or Zed binary is committed to the
extension repository.

## Validation scope

Driven integrated capability gates use macOS arm64, Zed 1.10.3, 1.11.3, 1.12.0,
1.12.1 and 1.13.1, official Java 6.8.21/6.8.23, Spring Tools 5.2.0 and 5.3.0,
Eclipse Temurin JDK 25.0.3 and the declared floor 21.0.11, and Spring Boot 3.5.x
fixtures. The current 59-row inventory records 48 capabilities as `verified`, 0
as `implemented`, 0 as `planned`, 3 as `blocked-zed-api`, 0 as
`blocked-upstream`, 6 as `zed-native-equivalent`, and 2 as `not-pursued`.
Additional desktop Zed-integrated tuples remain runtime-unverified; platform
CI is not presented as evidence that the complete Zed desktop lifecycle has
been driven on those hosts.

The build-system axis is resolved on evidence rather than assumed: nine
capabilities were driven against two Gradle 9.5.1 fixtures as well as Maven,
and the one that is Maven-only — the Boot upgrade quick fix, which upstream's
own bytecode shows omits the Gradle case — is stated as a limitation instead of
being presented as working.

Separately, the repository continuously runs an advisory native CI matrix on
GitHub-hosted Linux, macOS, and Windows runners for x86_64 and arm64, plus a JDK
21 floor job. On all six native tuples the matrix verifies runner identity,
JDK 25, Node 24, Rust 1.98.0, Unicode/space path handling, coordinator
capability contracts, native Maven/Gradle wrapper selection, Java bridge
self-test, native Rust tests, checksum-verified startup and real LSP traffic
against the canonical pinned Spring Boot language server, and headless JDT LS
1.60 integration with the current Spring 5.3 Java-extension bundles plus the
bridge built from the tested source. The JDT smoke requires the Spring delegate
command and bridge delegate commands to be advertised and executes the bridge
inside the real JDT runtime. The JDK 21 floor job repeats both real runtime
smokes. The aggregate `platform-gate` passes only after all six native jobs and
the floor job pass.

This is **headless native/runtime integration evidence, not full Zed desktop
support evidence**. Zed desktop + the official Java extension/proxy + JDT LS +
Spring Tools is still an explicitly separate real-host/Registry lifecycle gate
for additional desktop tuples.

- [Capability inventory](https://github.com/luceat-lux-vestra/zed-spring-tools/blob/main/docs/capability-inventory.md)
- [Compatibility evidence](https://github.com/luceat-lux-vestra/zed-spring-tools/blob/main/COMPATIBILITY.md)
- [Known limitations](https://github.com/luceat-lux-vestra/zed-spring-tools/blob/main/LIMITATIONS.md)
- [Platform validation evidence boundary](https://github.com/luceat-lux-vestra/zed-spring-tools/blob/main/docs/platform-validation.md)
