### PR TITLE
Add stix-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4338,6 +4338,10 @@
 	path = extensions/stimulus
 	url = https://github.com/vitallium/zed-stimulus
 
+[submodule "extensions/stix-theme"]
+	path = extensions/stix-theme
+	url = https://github.com/GhostVox/Stix.git
+
 [submodule "extensions/strace"]
 	path = extensions/strace
 	url = https://github.com/sigmaSd/zed-strace

--- a/extensions.toml
+++ b/extensions.toml
@@ -4411,6 +4411,10 @@ version = "0.2.0"
 submodule = "extensions/stimulus"
 version = "0.2.0"
 
+[stix-theme]
+submodule = "extensions/stix-theme"
+version = "0.1.0"
+
 [strace]
 submodule = "extensions/strace"
 version = "0.0.3"


### PR DESCRIPTION
## Summary
- Adds Stix, a muted, low-contrast dark/light theme for Zed, as a submodule extension.
- Registers `stix-theme` in `extensions.toml`.

## Test plan
- [x] `pnpm sort-extensions` run to keep `extensions.toml` / `.gitmodules` sorted.
- [x] Installed as a dev extension in Zed and manually verified Stix Dark / Stix Light (to be confirmed by extension author).