### PR TITLE
Add TeXpresso Live extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4554,6 +4554,10 @@
 	path = extensions/texpresso
 	url = https://github.com/lnay/zed-texpresso.git
 
+[submodule "extensions/texpresso-live"]
+	path = extensions/texpresso-live
+	url = https://github.com/Maymall/texpresso-zed.git
+
 [submodule "extensions/textproto"]
 	path = extensions/textproto
 	url = https://github.com/mikn/zed-textproto.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4637,7 +4637,7 @@ version = "0.0.3"
 
 [texpresso-live]
 submodule = "extensions/texpresso-live"
-version = "0.1.1"
+version = "0.1.2"
 
 [textproto]
 submodule = "extensions/textproto"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4637,7 +4637,7 @@ version = "0.0.3"
 
 [texpresso-live]
 submodule = "extensions/texpresso-live"
-version = "0.1.0"
+version = "0.1.1"
 
 [textproto]
 submodule = "extensions/textproto"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4635,6 +4635,10 @@ version = "1.0.0"
 submodule = "extensions/texpresso"
 version = "0.0.3"
 
+[texpresso-live]
+submodule = "extensions/texpresso-live"
+version = "0.1.0"
+
 [textproto]
 submodule = "extensions/textproto"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds the `texpresso-live` Zed extension from [Maymall/texpresso-zed](https://github.com/Maymall/texpresso-zed) at version `0.1.2`.

The Registry already contains the distinct `texpresso` extension. This contribution intentionally uses a separate, unique ID and source repository. TeXpresso Live provides a persistent LSP adapter with isolated root sessions, unsaved multi-file VFS synchronization, UTF-16 incremental changes, rollback-aware diagnostics, and child-process cleanup.

## Publishing prerequisites

- [x] Read `CONTRIBUTING.md` and the extension publishing prerequisites.
- [x] Public source repository with an Apache-2.0 license.
- [x] Does not bundle its language server into the extension: Zed downloads the version-pinned [adapter-v0.1.2 GitHub Release asset](https://github.com/Maymall/texpresso-zed/releases/tag/adapter-v0.1.2) through the public extension API.
- [x] Source CI passed on Linux, macOS, and Windows: Node lint, typecheck, build, 44 adapter tests (including fake-TeXpresso E2E), Rust fmt/check/test, and the wasm32-wasip2 release build.
- [x] A release-adapter smoke stages the published asset in an empty Zed-style work directory, clears `PATH`, and asserts that the configured absolute `texpressoCommand` is the process actually spawned.
- [x] Registry `package`, `danger`, and CLA checks pass for this PR.

## Notes

Users still install TeXpresso and their TeX distribution locally; Zed supplies the Node runtime for the downloaded adapter. The viewer is TeXpresso's native external window. The automated adapter suite runs on Linux, macOS, and Windows; native viewer behavior still requires a desktop smoke test on the target platform.
