### PR TITLE
Add One Dark Pro Port theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4962,6 +4962,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vs-one-dark-pro-port"]
+	path = extensions/vs-one-dark-pro-port
+	url = https://github.com/kossa/vs-one-dark-pro-port.git
+
 [submodule "extensions/vscode-2026-theme"]
 	path = extensions/vscode-2026-theme
 	url = https://github.com/eugenebokhan/zed-vs-code-2026-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5048,6 +5048,10 @@ version = "0.0.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vs-one-dark-pro-port]
+submodule = "extensions/vs-one-dark-pro-port"
+version = "0.1.0"
+
 [vscode-2026-theme]
 submodule = "extensions/vscode-2026-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## One Dark Pro Port

Adds **One Dark Pro Port**, a faithful port of the popular [Binaryify/OneDark-Pro](https://github.com/Binaryify/OneDark-Pro) VS Code theme to Zed.

- **Repository:** https://github.com/kossa/vs-one-dark-pro-port
- **Version:** 0.1.0
- **License:** MIT

### Variants included
- One Dark Pro
- One Dark Pro Darker
- One Dark Pro Flat
- One Dark Pro Vivid
- One Dark Pro Bold

Tested locally as a dev extension.
