### PR TITLE
Add Lini language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2394,6 +2394,10 @@
 	path = extensions/lilypond
 	url = https://github.com/nwhetsell/lilypond-zed-extension
 
+[submodule "extensions/lini"]
+	path = extensions/lini
+	url = https://github.com/monfa-red/lini
+
 [submodule "extensions/linkerscript"]
 	path = extensions/linkerscript
 	url = https://github.com/notpeter/linkerscript-zed.git
@@ -5285,6 +5289,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/lini"]
-	path = extensions/lini
-	url = https://github.com/monfa-red/lini

--- a/.gitmodules
+++ b/.gitmodules
@@ -5285,3 +5285,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/lini"]
+	path = extensions/lini
+	url = https://github.com/monfa-red/lini

--- a/extensions.toml
+++ b/extensions.toml
@@ -2440,6 +2440,11 @@ version = "0.0.1"
 submodule = "extensions/lilypond"
 version = "0.0.9"
 
+[lini]
+submodule = "extensions/lini"
+path = "editors/zed"
+version = "0.1.0"
+
 [linkerscript]
 submodule = "extensions/linkerscript"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds syntax highlighting for [Lini](https://github.com/monfa-red/lini) (`.lini`) — a text-to-diagram language for diagrams, charts, and technical drawings that compiles to SVG.

The extension lives in the Lini monorepo under `editors/zed` (hence `path`); the tree-sitter grammar is pinned by commit in its `extension.toml` and the generated parser is committed. Tested locally as a dev extension on macOS (Zed compiles the grammar cleanly; highlighting verified against the repo's 33 sample files, which parse with zero ERROR nodes). MIT licensed.