### PR TITLE
Add vue-standalone extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5034,6 +5034,10 @@
 	path = extensions/vue-snippets
 	url = https://github.com/rubjo/zed-vue-snippets
 
+[submodule "extensions/vue-standalone"]
+	path = extensions/vue-standalone
+	url = https://github.com/penjj/zed-vue-ext
+
 [submodule "extensions/vue-theme"]
 	path = extensions/vue-theme
 	url = https://github.com/ColasssNotMe/vue-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5120,6 +5120,10 @@ version = "0.4.0"
 submodule = "extensions/vue-snippets"
 version = "0.0.3"
 
+[vue-standalone]
+submodule = "extensions/vue-standalone"
+version = "0.1.0"
+
 [vue-theme]
 submodule = "extensions/vue-theme"
 version = "0.0.1"

--- a/package.json
+++ b/package.json
@@ -28,5 +28,6 @@
     "prettier": "3.9.5",
     "typescript": "5.9.3",
     "vitest": "4.1.10"
-  }
+  },
+  "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }


### PR DESCRIPTION
## Summary

Adds the `vue-standalone` extension for Zed.

## What it does

Provides Vue language support using Volar's **standalone mode**, which runs a complete TypeScript language service in-process without requiring an external tsserver.

This is a fork of the official `vue` extension that addresses the limitation where the official extension's hybrid mode (delegating TypeScript work to tsserver) does not function correctly in Zed.

## Repository

https://github.com/penjj/zed-vue-ext

## npm Package

`zed-vue-standalone@0.1.2` — published to npm registry.

## License

Apache-2.0