### PR TITLE
Update mcp-server-zuraffa to v5.6.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2863,7 +2863,7 @@ version = "0.0.1"
 
 [mcp-server-zuraffa]
 submodule = "extensions/mcp-server-zuraffa"
-version = "5.6.0"
+version = "5.6.1"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
Release notes:

https://github.com/arrrrny/zuraffa/releases/tag/v5.6.1