### PR TITLE
Add Pubspec LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5297,3 +5297,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/pubspec-lsp"]
+	path = extensions/pubspec-lsp
+	url = https://github.com/FrantisekGazo/zed-pubspec-lsp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3710,6 +3710,10 @@
 	path = extensions/psalm
 	url = https://github.com/sebcode/psalm-zed.git
 
+[submodule "extensions/pubspec-lsp"]
+	path = extensions/pubspec-lsp
+	url = https://github.com/FrantisekGazo/zed-pubspec-lsp.git
+
 [submodule "extensions/pug"]
 	path = extensions/pug
 	url = https://github.com/Baw-Appie/zed-pug
@@ -5297,6 +5301,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/pubspec-lsp"]
-	path = extensions/pubspec-lsp
-	url = https://github.com/FrantisekGazo/zed-pubspec-lsp.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3775,6 +3775,10 @@ version = "0.3.2"
 submodule = "extensions/psalm"
 version = "0.0.2"
 
+[pubspec-lsp]
+submodule = "extensions/pubspec-lsp"
+version = "0.1.2"
+
 [pug]
 submodule = "extensions/pug"
 version = "0.0.3"


### PR DESCRIPTION
Adds **Pubspec LSP**, a language-server extension for Flutter/Dart `pubspec.yaml` files (fills the gap that "Pubspec Assist" covers in VS Code).

Repository: https://github.com/FrantisekGazo/zed-pubspec-lsp

Features:
- pub.dev-backed completion of package names and versions in `dependencies` / `dev_dependencies` / `dependency_overrides`
- diagnostics for outdated dependencies (hint) and discontinued packages (warning)
- code actions: update a dependency to latest, update all, sort dependencies alphabetically
- hover with package description, latest version, and pub.dev link

The extension registers a custom `Pubspec` language scoped to `pubspec.yaml` / `pubspec_overrides.yaml` via `path_suffixes`, so ordinary YAML files are unaffected. The language server is a standalone Rust binary the extension downloads per-platform from the extension repo's own GitHub releases (`v0.1.2`), pinned to the extension's version.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.