### PR TITLE
Update deep-slate-theme to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1086,7 +1086,7 @@ version = "0.1.0"
 
 [deep-slate-theme]
 submodule = "extensions/deep-slate-theme"
-version = "0.0.1"
+version = "0.1.1"
 
 [defold]
 submodule = "extensions/defold"


### PR DESCRIPTION
Updates Deep Slate to v0.1.1.

- Updates the submodule to c24d751085a645afdef217a6880088d12cb22a36.
- Updates the matching registry version in extensions.toml.
- Replaces #6855, which omitted the registry version bump.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.