### PR TITLE
Add HearthCode theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1902,6 +1902,10 @@
 	path = extensions/hc-monokai-theme
 	url = https://github.com/p404/zed-hc-monokai.git
 
+[submodule "extensions/hearthcode-theme"]
+	path = extensions/hearthcode-theme
+	url = https://github.com/hearth-code/hearthcode-zed.git
+
 [submodule "extensions/helios-theme"]
 	path = extensions/helios-theme
 	url = https://github.com/heliosgraphics/helios-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1938,6 +1938,10 @@ version = "0.1.0"
 submodule = "extensions/hc-monokai-theme"
 version = "0.0.1"
 
+[hearthcode-theme]
+submodule = "extensions/hearthcode-theme"
+version = "3.7.5"
+
 [helios-theme]
 submodule = "extensions/helios-theme"
 version = "0.0.8"


### PR DESCRIPTION
Adds HearthCode Theme with four generated variants: Moss Dark, Moss Light, Ember Dark, and Ember Light.

The extension was installed and tested locally as a Zed dev extension. Both theme-family JSON files also validate against Zed's v0.2.0 theme schema.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
