### PR TITLE
Add One Dark Pro Blur theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3318,6 +3318,10 @@
 	path = extensions/one-dark-pro
 	url = https://github.com/MordFustang21/zed-one-dark-pro.git
 
+[submodule "extensions/one-dark-pro-blur-theme"]
+	path = extensions/one-dark-pro-blur-theme
+	url = https://github.com/callqh/one-dark-pro-blur.git
+
 [submodule "extensions/one-dark-pro-enhanced"]
 	path = extensions/one-dark-pro-enhanced
 	url = https://github.com/hadez8877/one-dark-pro-enhanced.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3373,6 +3373,10 @@ version = "0.1.0"
 submodule = "extensions/one-dark-pro"
 version = "0.0.11"
 
+[one-dark-pro-blur-theme]
+submodule = "extensions/one-dark-pro-blur-theme"
+version = "0.1.0"
+
 [one-dark-pro-enhanced]
 submodule = "extensions/one-dark-pro-enhanced"
 version = "0.0.12"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3375,7 +3375,7 @@ version = "0.0.11"
 
 [one-dark-pro-blur-theme]
 submodule = "extensions/one-dark-pro-blur-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [one-dark-pro-enhanced]
 submodule = "extensions/one-dark-pro-enhanced"


### PR DESCRIPTION
Adds One Dark Pro Blur, a transparent and blurred theme collection based on One Dark Pro Enhanced and Quiet Light for Zed.

The extension provides five One Dark Pro color variants and one Quiet Light variant, with three opacity levels each. It preserves the upstream syntax and terminal palettes while adapting editor, panel, tab, terminal, and active-line surfaces for Zed's native blurred window appearance.

Validation:

- Tested locally as a Zed dev extension.
- Validated all 18 themes against Zed's official theme schema.
- Ran `pnpm sort-extensions`.
- Ran `pnpm build`.
- Ran `pnpm test` (111 tests passed).

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.