### PR TITLE
Add hover-dict extension (v0.1.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1994,6 +1994,10 @@
 	path = extensions/houdini-vex
 	url = https://github.com/igor-elovikov/hou-vex-zed.git
 
+[submodule "extensions/hover-dict"]
+	path = extensions/hover-dict
+	url = https://github.com/Nahida-aa/hover-dict.git
+
 [submodule "extensions/hp42s"]
 	path = extensions/hp42s
 	url = https://codeberg.org/brechanbech/tree-sitter-hp42s.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2031,6 +2031,10 @@ version = "0.0.2"
 submodule = "extensions/houdini-vex"
 version = "0.0.1"
 
+[hover-dict]
+submodule = "extensions/hover-dict"
+version = "0.1.0"
+
 [hp42s]
 submodule = "extensions/hp42s"
 version = "0.3.0"


### PR DESCRIPTION
Add hover-dict extension (v0.1.0)

Offline hover translation for code identifiers. Splits camelCase / snake_case / kebab-case, looks up a built-in 760k-word dictionary, and renders the meaning on hover (English→Chinese). Selecting Chinese text queries Chinese→English. Fully offline, no network required.

Submodule: Nahida-aa/hover-dict @ 20d3598
license = "MIT"

Dictionary data: derived from ECDICT (skywind3000) under CC BY-NC 4.0; extension code under MIT.