### PR TITLE
Update mcp-server-zuraffa to v5.6.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2883,7 +2883,7 @@ version = "0.0.1"
 
 [mcp-server-zuraffa]
 submodule = "extensions/mcp-server-zuraffa"
-version = "5.6.1"
+version = "5.6.2"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
Release notes:

https://github.com/arrrrny/zuraffa-zed/releases/tag/v5.6.2