### PR TITLE
Add jsonl language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2234,6 +2234,10 @@
 	path = extensions/jsonl
 	url = https://github.com/vim-zz/jsonl-syntax-zed.git
 
+[submodule "extensions/jsonl-tools"]
+	path = extensions/jsonl-tools
+	url = https://github.com/sarvagnan/jsonl-tools.git
+
 [submodule "extensions/jsonnet"]
 	path = extensions/jsonnet
 	url = https://github.com/narqo/zed-jsonnet.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2234,8 +2234,8 @@
 	path = extensions/jsonl
 	url = https://github.com/vim-zz/jsonl-syntax-zed.git
 
-[submodule "extensions/jsonl-tools"]
-	path = extensions/jsonl-tools
+[submodule "extensions/jsonl-lsp"]
+	path = extensions/jsonl-lsp
 	url = https://github.com/sarvagnan/jsonl-tools.git
 
 [submodule "extensions/jsonnet"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -2278,8 +2278,8 @@ version = "0.1.1"
 submodule = "extensions/jsonl"
 version = "0.1.1"
 
-[jsonl-tools]
-submodule = "extensions/jsonl-tools"
+[jsonl-lsp]
+submodule = "extensions/jsonl-lsp"
 path = "editors/zed"
 version = "0.1.0"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -2278,6 +2278,11 @@ version = "0.1.1"
 submodule = "extensions/jsonl"
 version = "0.1.1"
 
+[jsonl-tools]
+submodule = "extensions/jsonl-tools"
+path = "editors/zed"
+version = "0.1.0"
+
 [jsonnet]
 submodule = "extensions/jsonnet"
 version = "0.4.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **jsonl-tools**: JSON Lines / NDJSON support with a language server. Provides a JSONL language for `.jsonl`/`.ndjson`/`.ldjson` (tree-sitter-json grammar) plus [`jsonl-lsp`](https://www.npmjs.com/package/@sarvagnan/jsonl-lsp) — auto-installed from npm via Zed's Node runtime — for per-record diagnostics, document/range formatting, record-oriented document symbols, hover inspection of records, and expand/compact code actions.

The extension lives at `editors/zed` in the [jsonl-tools](https://github.com/sarvagnan/jsonl-tools) monorepo (MIT-licensed at that path), and has been tested as a dev extension on Zed 1.11.3.

Note: the existing jsonl extension provides syntax highlighting only. This extension adds language-server integration (diagnostics, formatting, document symbols, hover, and code actions) via jsonl-lsp, which is developed in the same repository as this extension — hence a separate submission rather than a PR against the highlighting-only extension. 