### PR TITLE
Add gemtext language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1638,6 +1638,10 @@
 	path = extensions/gem
 	url = https://github.com/mantou132/gem
 
+[submodule "extensions/gemtext"]
+	path = extensions/gemtext
+	url = https://github.com/trislu/gemcap-language-server.git
+
 [submodule "extensions/genexpr"]
 	path = extensions/genexpr
 	url = https://github.com/isabelgk/genexpr-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1794,6 +1794,10 @@
 	path = extensions/gem
 	url = https://github.com/mantou132/gem
 
+[submodule "extensions/gemtext"]
+	path = extensions/gemtext
+	url = https://github.com/trislu/gemcap-language-server.git
+
 [submodule "extensions/genexpr"]
 	path = extensions/genexpr
 	url = https://github.com/isabelgk/genexpr-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1668,6 +1668,11 @@ submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
 version = "0.0.5"
 
+[gemtext]
+submodule = "extensions/gemtext"
+path = "clients/zed"
+version = "0.0.1"
+
 [genexpr]
 submodule = "extensions/genexpr"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1831,6 +1831,11 @@ submodule = "extensions/gem"
 path = "crates/zed-plugin-gem"
 version = "0.0.5"
 
+[gemtext]
+submodule = "extensions/gemtext"
+path = "clients/zed"
+version = "0.0.1"
+
 [genexpr]
 submodule = "extensions/genexpr"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

This extension provides gemtext language support for Zed. It adds:
- tree-sitter based parsing for `.gmi` or `.gemini` files
- LSP features:  `completion`/`diagnostic`/`folding_range`/`goto_definition`/`semantic_tokens`

## Extension details
- ID: gemtext
- Version: 0.0.1
- Repository: https://github.com/trislu/gemcap-language-server
- Sub-folder: clients/zed
- License: MIT

## Additional info

- gemtext is a simple language from https://geminiprotocol.net/docs/
- gemtext specification: https://geminiprotocol.net/docs/gemtext-specification.gmi
- tree-sitter-gemtext: https://github.com/trislu/tree-sitter-gemtext
- gemcap-language-server: https://github.com/trislu/gemcap-language-server

The extension had been tested locally with below setup, screenshot can be found [here](https://github.com/trislu/gemcap-language-server/blob/6dc844762de254bce6c5ceb41877353eb86a6719/resources/screenshots/client-zed.png).

```bash
# system spec info
Zed: v1.11.3+stable.326.952d712dac48a4af2c54fb22c82d82a9d69b72d4 (Zed) 
OS: Windows 10.0.26200
Memory: 31.1 GiB
Architecture: x86_64
GPU: NVIDIA GeForce RTX 5070 Ti || NVIDIA Corporation || 610.62 r610_45

# installed extension
Installed extensions (5):
- Git Firefly (git-firefly) v0.1.8
- HTML (html) v0.3.1
- Scheme (scheme) v0.0.6
- TOML (toml) v1.0.3
- gemtext (gemtext) v0.0.1 (dev)
```