### PR TITLE
Add Stellarium extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4374,6 +4374,10 @@
 	path = extensions/statamic-antlers
 	url = https://github.com/mynetx/zed-statamic-antlers.git
 
+[submodule "extensions/stellarium"]
+	path = extensions/stellarium
+	url = https://github.com/fits-ki/zed-stellarium
+
 [submodule "extensions/stimulus"]
 	path = extensions/stimulus
 	url = https://github.com/vitallium/zed-stimulus

--- a/.gitmodules
+++ b/.gitmodules
@@ -4376,7 +4376,7 @@
 
 [submodule "extensions/stellarium"]
 	path = extensions/stellarium
-	url = https://github.com/fits-ki/zed-stellarium
+	url = https://github.com/fits-ki/stellarium
 
 [submodule "extensions/stimulus"]
 	path = extensions/stimulus

--- a/extensions.toml
+++ b/extensions.toml
@@ -4447,6 +4447,10 @@ version = "0.4.1"
 submodule = "extensions/statamic-antlers"
 version = "0.2.0"
 
+[stellarium]
+submodule = "extensions/stellarium"
+version = "0.1.0"
+
 [stimulus]
 submodule = "extensions/stimulus"
 version = "0.2.0"


### PR DESCRIPTION
## Summary

Adds the `stellarium` extension as an HTTPS Git submodule at version `0.1.0`.

The extension provides Tree-sitter syntax support and a release-pinned language
server for Stellarium Script. Its grammar is published separately at
https://github.com/fits-ki/tree-sitter-stellarium and pinned by exact commit in
`extension.toml`.

## Validation

- standalone extension: `cargo test` (18 passed)
- standalone extension: `cargo build --target wasm32-wasip2 --release`
- registry: `pnpm sort-extensions`
- registry: `pnpm build`
- registry: `pnpm test` (111 passed)

The matching public `v0.1.0` native-language-server release assets are
published at https://github.com/fits-ki/stellarium/releases/tag/v0.1.0.
