### PR TITLE
Add Summercamp theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4410,8 +4410,8 @@
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
 
-[submodule "extensions/summercamp"]
-	path = extensions/summercamp
+[submodule "extensions/summercamp-theme"]
+	path = extensions/summercamp-theme
 	url = https://github.com/csalmeida/summercamp-zed-theme.git
 
 [submodule "extensions/sunrise-bloom-theme"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4410,6 +4410,10 @@
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
 
+[submodule "extensions/summercamp"]
+	path = extensions/summercamp
+	url = https://github.com/csalmeida/summercamp-zed-theme.git
+
 [submodule "extensions/sunrise-bloom-theme"]
 	path = extensions/sunrise-bloom-theme
 	url = https://github.com/tejasashinde/sunrise-bloom-theme.git
@@ -5341,6 +5345,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/summercamp"]
-	path = extensions/summercamp
-	url = https://github.com/csalmeida/summercamp-zed-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5341,3 +5341,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/summercamp"]
+	path = extensions/summercamp
+	url = https://github.com/csalmeida/summercamp-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4485,6 +4485,10 @@ version = "0.1.16"
 submodule = "extensions/sumi-light"
 version = "0.0.2"
 
+[summercamp]
+submodule = "extensions/summercamp"
+version = "0.0.1"
+
 [sunrise-bloom-theme]
 submodule = "extensions/sunrise-bloom-theme"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4485,8 +4485,8 @@ version = "0.1.16"
 submodule = "extensions/sumi-light"
 version = "0.0.2"
 
-[summercamp]
-submodule = "extensions/summercamp"
+[summercamp-theme]
+submodule = "extensions/summercamp-theme"
 version = "0.0.1"
 
 [sunrise-bloom-theme]


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Summercamp, a dark theme recreated from my [Summercamp VS Code theme](https://github.com/csalmeida/summercamp-vscode-theme), itself based on one of the earliest Zed themes. Tested locally as a dev extension.

<img width="1505" height="900" alt="summercamp_dark" src="https://github.com/user-attachments/assets/a0111694-efb2-4733-8787-b4b07199b28a" />

