### PR TITLE
Add cron-sense extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -882,6 +882,10 @@
 	path = extensions/crimson-theme
 	url = https://github.com/kaem-e/zed-crimson-theme.git
 
+[submodule "extensions/cron-sense"]
+	path = extensions/cron-sense
+	url = https://github.com/zxcodes/cron-sense.git
+
 [submodule "extensions/crystal"]
 	path = extensions/crystal
 	url = https://github.com/crystal-lang-tools/zed-crystal.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -898,6 +898,10 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.4"
 
+[cron-sense]
+submodule = "extensions/cron-sense"
+version = "0.1.0"
+
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"


### PR DESCRIPTION
## Extension

Adds **[cron-sense](https://github.com/zxcodes/cron-sense)** — hover tooltips and a `/cron` slash command that translate cron-like schedules into human-readable English.

| Field | Value |
| --- | --- |
| Extension ID | `cron-sense` |
| Version | `0.1.0` |
| Repository | https://github.com/zxcodes/cron-sense |
| License | MIT |

## Features

- Hover explanations for cron expressions (via a small Node language server + [cronstrue](https://github.com/bradymholt/cRonstrue))
- Code action to insert the explanation as a trailing comment
- `/cron` slash command in the assistant (via [cronspeak](https://crates.io/crates/cronspeak))

## Notes

- Independent from-scratch implementation for Zed (Wasm + LSP). Not a fork of the VS Code extension.
- Concept/UX inspired by [tumido/cron-explained](https://github.com/tumido/cron-explained) (credited in README and NOTICE).
- Language server deps are installed at runtime via Zed's `npm_install_package` APIs; the server script is materialized into the extension work directory (not shipped as a prebuilt binary).

## Testing

Tested locally as a dev extension:

- Hover on standard 5-field crons and macros
- Code action insert / re-run (idempotent, no stacked comments)
- `/cron` slash command