### PR TITLE
Add Chalk LSP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -674,6 +674,10 @@
 	path = extensions/chalice-theme
 	url = https://github.com/huangkairan/chalice-theme-zed.git
 
+[submodule "extensions/chalk-lsp"]
+	path = extensions/chalk-lsp
+	url = https://github.com/chalk-ai/chalk-zed.git
+
 [submodule "extensions/chanterelle"]
 	path = extensions/chanterelle
 	url = https://github.com/steffenhaug/chanterelle-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -685,6 +685,10 @@ version = "0.0.2"
 submodule = "extensions/chalice-theme"
 version = "0.1.1"
 
+[chalk-lsp]
+submodule = "extensions/chalk-lsp"
+version = "0.1.0"
+
 [chanterelle]
 submodule = "extensions/chanterelle"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -687,7 +687,7 @@ version = "0.1.1"
 
 [chalk-lsp]
 submodule = "extensions/chalk-lsp"
-version = "0.1.0"
+version = "0.1.1"
 
 [chanterelle]
 submodule = "extensions/chanterelle"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

---

Sorry about https://github.com/zed-industries/extensions/pull/6911 ! Doing things more properly this time.

This extension (https://github.com/chalk-ai/chalk-zed) adds diagnostic support for Chalk projects (https://chalk.ai).