### PR TITLE
Add Soufflé language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4314,6 +4314,10 @@
 	path = extensions/sorbet
 	url = https://github.com/notchairmk/zed-sorbet
 
+[submodule "extensions/souffle"]
+	path = extensions/souffle
+	url = https://github.com/panosdimak/zed-souffle.git
+
 [submodule "extensions/sourcepawn"]
 	path = extensions/sourcepawn
 	url = https://github.com/tsuza/zed-sourcepawn-ext.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4386,6 +4386,10 @@ version = "0.1.0"
 submodule = "extensions/sorbet"
 version = "0.1.1"
 
+[souffle]
+submodule = "extensions/souffle"
+version = "0.1.0"
+
 [sourcepawn]
 submodule = "extensions/sourcepawn"
 version = "0.0.1"


### PR DESCRIPTION
Adds Soufflé language support (id: souffle).

- Repository: https://github.com/panosdimak/zed-souffle (MIT licensed)
- Version: 0.1.0 (submodule pinned at HEAD of `main`)
- Grammar: [langston-barrett/tree-sitter-souffle](https://github.com/langston-barrett/tree-sitter-souffle), pinned by SHA (0ca94fad)
- Provides: Tree-sitter syntax highlighting (highlights, brackets, indents, outline) for `.dl`; plus a language-server bridge ([souffle-lsp-plugin](https://github.com/jdaridis/souffle-lsp-plugin)) that runs the souffle-lsp-plugin jar over stdio,
resolving the jar from the `jar_path` setting or the plugin's GitHub releases, and locating Java from PATH/JAVA_HOME. Highlighting/indent/outline work without Java; only LSP features
(hover, go-to-definition, diagnostics) require it.

Validation performed:

- Compiles clean to wasm32-wasip2 via Zed's dev-extension build.
- Every languages/souffle/*.scm query compiles against the pinned grammar.
- Installed as a dev extension and tested against a real preprocessor-heavy Soufflé codebase (~120 .dl files): highlighting, outline, and LSP hover/go-to-definition all verified working.


- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
