### PR TITLE
Add serpdive MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4138,6 +4138,10 @@
 	path = extensions/sergio-tech-code-black-theme
 	url = https://github.com/sergios-tech/sergio-tech-code-black-zed-theme.git
 
+[submodule "extensions/serpdive"]
+	path = extensions/serpdive
+	url = https://github.com/serpdive/zed-serpdive-mcp.git
+
 [submodule "extensions/seti-icons"]
 	path = extensions/seti-icons
 	url = https://github.com/d1y/zed-seti-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4208,6 +4208,10 @@ version = "0.0.1"
 submodule = "extensions/sergio-tech-code-black-theme"
 version = "1.0.0"
 
+[serpdive]
+submodule = "extensions/serpdive"
+version = "0.1.0"
+
 [seti-icons]
 submodule = "extensions/seti-icons"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **SERPdive** as a context server extension: web search for AI agents that returns the extracted, answer-ready content of each source page instead of a list of links, cleaned and sized for a context window. It wraps the `serpdive-mcp` npm package over stdio, in the same shape as the existing `mcp-server-tavily` extension.

Measured, not asserted: on a public, replayable 1,000-question benchmark judged blind by an independent model, SERPdive runs at the same speed as Tavily, feeds the LLM 20.2% fewer tokens, and wins 60.7% of decided quality duels against Tavily's default search — methodology and per-question results at https://github.com/edendalexis/serpdive-benchmark.

Extension repository: https://github.com/serpdive/zed-serpdive-mcp (MIT). One tool, `serpdive_search`, with two retrieval depths (fast key sentences, or full page content) and an optional written answer built from the sources. Free tier: 1,000 credits/month, no card.

**Tested locally as a dev extension**, per CONTRIBUTING:

- Builds clean for `wasm32-wasip2` (the target this repo's CI uses) with Rust 1.97.
- Installed into Zed 1.11.3 as a dev extension: the extension host loaded it, ran `context_server_command`, installed `serpdive-mcp@0.1.5` into the extension work directory, and started the server — `node .../extensions/work/serpdive/node_modules/serpdive-mcp/bin/serpdive-mcp.js` was running with the key from settings.
- Drove the underlying MCP server through the same invocation the extension uses: `initialize` returns the server info, `tools/list` returns `serpdive_search`.
- Missing-key path returns the intended error rather than panicking.

In this repo: `pnpm sort-extensions` (both `extensions.toml` and `.gitmodules` are sorted and the sorter is a no-op on re-run), `pnpm build`, and `pnpm test` (111 tests) all pass locally.

A key is created at https://serpdive.com/dashboard/keys and the free tier needs no card.
