### PR TITLE
Add Candela Themes extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -590,6 +590,10 @@
 	path = extensions/candela-theme
 	url = https://github.com/xXCHAVOTAXx/candela-theme.git
 
+[submodule "extensions/candela-themes"]
+	path = extensions/candela-themes
+	url = https://github.com/schovi/candela-themes-zed.git
+
 [submodule "extensions/canipls-lint"]
 	path = extensions/canipls-lint
 	url = https://github.com/taylorplewe/canipls-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -600,6 +600,10 @@ version = "0.1.1"
 submodule = "extensions/candela-theme"
 version = "0.0.1"
 
+[candela-themes]
+submodule = "extensions/candela-themes"
+version = "0.2.0"
+
 [canipls-lint]
 submodule = "extensions/canipls-lint"
 version = "0.0.1"


### PR DESCRIPTION
This adds **Candela Themes**, a family of color themes (light and dark) tuned for eye-strain comfort: low-glare backgrounds, desaturated accents, and WCAG-AA contrast throughout.

- Extension repo (HTTPS submodule): https://github.com/schovi/candela-themes-zed, tagged `v0.2.0`, includes an accepted license.
- Source of truth: https://github.com/schovi/candela-themes (themes are generated from it).
- Tested locally as a dev extension.

Note: there is an unrelated `candela-theme` (singular) extension by a different author. This is a separate, coordinated multi-theme family published under the `candela-themes` id.