### PR TITLE
Add mise extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2902,6 +2902,10 @@
 	path = extensions/mire-theme
 	url = https://github.com/monarcode/mire-theme-zed
 
+[submodule "extensions/mise"]
+	path = extensions/mise
+	url = https://github.com/klochowicz/zed-mise.git
+
 [submodule "extensions/missing-theme"]
 	path = extensions/missing-theme
 	url = https://codeberg.org/dz4k/zed-missing.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2954,6 +2954,10 @@ version = "0.0.1"
 submodule = "extensions/mire-theme"
 version = "0.1.0"
 
+[mise]
+submodule = "extensions/mise"
+version = "0.1.0"
+
 [missing-theme]
 submodule = "extensions/missing-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds the `mise` extension: syntax highlighting, outline, and task-runner integration (gutter run buttons + native task picker) for `mise.toml` config files.

- Extension repo: https://github.com/klochowicz/zed-mise
- Extension id: `mise` (version 0.1.0)
- License: MIT (at repo root)
- Uses the [taplo](https://taplo.tamasfe.dev) language server for schema-aware editing; taplo is downloaded on demand or picked up from $PATH, not vendored.

Tested locally as a dev extension.