### PR TITLE
Add SPICE language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4326,6 +4326,10 @@
 	path = extensions/spai-zero-theme
 	url = https://github.com/BasaiCorp/zed-spai-zero-theme.git
 
+[submodule "extensions/spice-lang"]
+	path = extensions/spice-lang
+	url = https://github.com/MrPoloGit/spice-lang.git
+
 [submodule "extensions/spiceflow-theme"]
 	path = extensions/spiceflow-theme
 	url = https://github.com/remorses/spiceflow-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -4398,6 +4398,10 @@ version = "0.0.1"
 submodule = "extensions/spai-zero-theme"
 version = "0.2.1"
 
+[spice-lang]
+submodule = "extensions/spice-lang"
+version = "0.2.0"
+
 [spiceflow-theme]
 submodule = "extensions/spiceflow-theme"
 version = "0.0.0"


### PR DESCRIPTION
Adds Spice (spice-lang): syntax highlighting and language server support for SPICE circuit netlists (.cir, .sp, .spi, .lib, .mod, .mdl).

Repo: https://github.com/MrPoloGit/spice-lang

Tree-sitter grammar: https://github.com/MrPoloGit/tree-sitter-spice

The companion language server [spice-lsp](https://github.com/MrPoloGit/spice-lsp) is downloaded at runtime from GitHub Releases (v0.2.0), not bundled. It provides completion, hover documentation, go-to-definition and find-references, document symbols, document formatting, and diagnostics (unbalanced blocks, undefined subcircuit/model references, port-count mismatches, duplicate instance names).

LICENSE is present at every repo root.