### PR TITLE
Add nvchad-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3246,6 +3246,10 @@
 	path = extensions/nunjucks
 	url = https://github.com/stormwarning/zed-nunjucks.git
 
+[submodule "extensions/nvchad-theme"]
+	path = extensions/nvchad-theme
+	url = https://github.com/KitsuneKode/nvchad-themes.git
+
 [submodule "extensions/nvim-nightfox"]
 	path = extensions/nvim-nightfox
 	url = https://github.com/cange/nightfox.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3300,6 +3300,11 @@ version = "0.0.1"
 submodule = "extensions/nunjucks"
 version = "0.0.7"
 
+[nvchad-theme]
+submodule = "extensions/nvchad-theme"
+path = "zed-extension"
+version = "1.0.2"
+
 [nvim-nightfox]
 submodule = "extensions/nvim-nightfox"
 version = "0.10.2"


### PR DESCRIPTION
## Extension: `nvchad-theme`

Adds all 94 [NvChad/base46 v3.0](https://github.com/NvChad/base46) themes for Zed.

- [x] I've read [CONTRIBUTING.md](https://github.com/KitsuneKode/extensions/blob/add-nvchad-theme/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
- [x] Extension ID is `nvchad-theme` (unique, verified no conflicts)
- [x] `extensions.toml` entry is in the correct alphabetical position with `path = "zed-extension"`
- [x] Submodule URL uses HTTPS and points to public repo: `https://github.com/KitsuneKode/nvchad-themes.git`
- [x] `extension.toml` version (`1.0.2`) matches `extensions.toml`
- [x] MIT LICENSE in both repo root and `zed-extension/`
- [x] `pnpm sort-extensions` completed cleanly — `extensions.toml` and `.gitmodules` are sorted
- [x] Tested locally as a dev extension via **zed: install dev extension** → `zed-extension/`
- [x] 8 hero theme screenshots included (1896×1018 PNGs)
- [x] No Git LFS in submodule

### Repository

https://github.com/KitsuneKode/nvchad-themes

### Screenshots

| Theme | Preview |
|-------|---------|
| Tokyonight | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/tokyonight.png) |
| Kanagawa | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/kanagawa.png) |
| Catppuccin | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/catppuccin.png) |
| Nord | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/nord.png) |
| Rxyhn | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/rxyhn.png) |
| One Dark | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/onedark.png) |
| Gruvbox | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/gruvbox.png) |
| Everforest | ![](https://raw.githubusercontent.com/KitsuneKode/nvchad-themes/v1.0.2/assets/screenshots/zed/everforest.png) |