### PR TITLE
Add cron-sense extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -882,6 +882,10 @@
 	path = extensions/crimson-theme
 	url = https://github.com/kaem-e/zed-crimson-theme.git
 
+[submodule "extensions/cron-sense"]
+	path = extensions/cron-sense
+	url = https://github.com/zxcodes/cron-sense.git
+
 [submodule "extensions/crystal"]
 	path = extensions/crystal
 	url = https://github.com/crystal-lang-tools/zed-crystal.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -898,6 +898,10 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.4"
 
+[cron-sense]
+submodule = "extensions/cron-sense"
+version = "0.1.0"
+
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"

--- a/extensions.toml
+++ b/extensions.toml
@@ -900,7 +900,7 @@ version = "0.0.4"
 
 [cron-sense]
 submodule = "extensions/cron-sense"
-version = "0.1.0"
+version = "0.2.0"
 
 [crystal]
 submodule = "extensions/crystal"

--- a/extensions.toml
+++ b/extensions.toml
@@ -900,7 +900,7 @@ version = "0.0.4"
 
 [cron-sense]
 submodule = "extensions/cron-sense"
-version = "0.2.0"
+version = "0.2.1"
 
 [crystal]
 submodule = "extensions/crystal"


### PR DESCRIPTION
## Extension

Adds **[cron-sense](https://github.com/zxcodes/cron-sense)** — hover tooltips and a code action that translate cron-like schedules into human-readable English.

| Field | Value |
| --- | --- |
| Extension ID | `cron-sense` |
| Version | `0.2.0` |
| Repository | https://github.com/zxcodes/cron-sense |
| License | MIT |

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the [publishing prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites)
- [x] Tested locally as a **dev extension** in Zed
- [x] `extensions.toml` / `.gitmodules` updated and sorted (`pnpm sort-extensions`)
- [x] Extension ID follows naming rules (no `zed` / `extension` in id or name)
- [x] Accepted license (`LICENSE` MIT at repo root)
- [x] **Language server is not shipped inside the extension package** — downloaded from [GitHub Releases](https://github.com/zxcodes/cron-sense/releases/tag/v0.2.0) at runtime (`cron-sense-server.cjs`); npm deps installed via Zed's `npm_install_package` APIs
- [x] Submodule pinned to tag `v0.2.0` (commit on `main`)

## Features

- Hover explanations for cron expressions (`cronstrue`)
- Code action to insert the explanation as a trailing comment (idempotent)

## Testing (dev extension)

- Hover on standard 5-field crons and macros (`@daily`, etc.)
- Code action insert and re-run (replaces comment; no stacked duplicates)
- Works in JSON / YAML / Shell Script contexts

## Notes

- Independent from-scratch implementation for Zed (not a fork of the VS Code source).
- Concept/UX inspired by [tumido/cron-explained](https://github.com/tumido/cron-explained) (credited in README and NOTICE).

Previous submission: #6920 (closed for guidelines; this resubmit addresses shipping the LS at runtime and drops slash commands).