### PR TITLE
Add golang-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1746,6 +1746,10 @@
 	path = extensions/godot-theme
 	url = https://github.com/D4r3NPo/zed-godot-theme.git
 
+[submodule "extensions/golang-snippets"]
+	path = extensions/golang-snippets
+	url = https://github.com/zulerne/zed-go-snippets.git
+
 [submodule "extensions/golangci-lint"]
 	path = extensions/golangci-lint
 	url = https://github.com/zed-extensions/golangci-lint.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1781,6 +1781,10 @@ version = "0.1.5"
 submodule = "extensions/godot-theme"
 version = "1.3.0"
 
+[golang-snippets]
+submodule = "extensions/golang-snippets"
+version = "0.1.0"
+
 [golangci-lint]
 submodule = "extensions/golangci-lint"
 version = "0.2.0"


### PR DESCRIPTION
Adds [golang-snippets](https://github.com/zulerne/zed-go-snippets) - an alternative Go snippets set with shorter prefixes.

Covers common patterns: functions, control flow, error handling, testing, concurrency.

## Why a separate extension?

There is an existing [go-snippets](https://github.com/ayberkgezer/go-zed-snippets) extension (which I used a lot before I got tired of typing `go-` every time and scrolling past template snippets I never use). This one differs in philosophy:

- **Shorter prefixes** - `func`, `iferr`, `forr` instead of `go-func`, `go-iferr`, `go-forr`. Typing `go-` on every snippet gets tedious fast in practice.
- **Focused set** - only common everyday patterns. The existing extension has 60+ snippets including Go template syntax (`{{ range }}`, `{{ define }}`, etc.), sort interface boilerplate, and hello-world apps - useful for some, but bloat for most workflows.
- **Modern Go idioms** - `slog` instead of `log`, `b.Loop()` for benchmarks, `fmt.Errorf("...: %w", err)` for error wrapping.

Contributing these changes upstream would require renaming every prefix and removing most snippets, which would break existing users.