### PR TITLE
Update verilog to v0.0.19

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5045,7 +5045,7 @@ version = "1.1.0"
 
 [verilog]
 submodule = "extensions/verilog"
-version = "0.0.18"
+version = "0.0.19"
 
 [version14-theme]
 submodule = "extensions/version14-theme"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Release notes: https://github.com/someone13574/zed-verilog-extension/releases/tag/v0.0.19