### PR TITLE
Add sukun-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4422,6 +4422,10 @@
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall
 
+[submodule "extensions/sukun-theme"]
+	path = extensions/sukun-theme
+	url = https://github.com/ahmedash95/sukun.git
+
 [submodule "extensions/sumi-light"]
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4499,6 +4499,10 @@ submodule = "extensions/subliminal-nightfall"
 path = "zed"
 version = "0.1.16"
 
+[sukun-theme]
+submodule = "extensions/sukun-theme"
+version = "0.1.0"
+
 [sumi-light]
 submodule = "extensions/sumi-light"
 version = "0.0.2"


### PR DESCRIPTION
## Summary
  Adds [Sukun](https://github.com/ahmedash95/sukun) — a calm, warm theme for Zed with four variants:
  - **Sukun** — light
  - **Sukun Soft** — light, lower contrast
  - **Sukun Dark** — dark
  - **Sukun Soft Dark** — dark, lower contrast
  ### Previews
  | Name | Preview |
  | --- | --- |
  | Sukun | ![Sukun light](https://github.com/user-attachments/assets/8ebaff7d-5989-47c3-a49c-df8e6d14bf02) |
  | Sukun Soft | ![Sukun Soft light](https://github.com/user-attachments/assets/578acf7c-633b-4f2c-ad04-3715865fc584) |
  | Sukun Dark | ![Sukun Dark](https://github.com/user-attachments/assets/17b90e06-ace4-4673-881d-ee1da656f72e) |
  | Sukun Soft Dark | ![Sukun Soft Dark](https://github.com/user-attachments/assets/a3f8f761-6c39-495d-b56a-1399382176a5) |
  ## Test plan
  - [x] Installed locally as a dev extension
  - [x] All four theme variants apply correctly
  ## Requirements
  - [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.