### PR TITLE
Add ABAP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5357,3 +5357,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/abap"]
+	path = extensions/abap
+	url = https://github.com/zooloo303/zed-abap.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,6 +18,10 @@
 	path = extensions/a-touch-of-lilac-theme
 	url = https://github.com/szymkab/a-touch-of-lilac-theme
 
+[submodule "extensions/abap"]
+	path = extensions/abap
+	url = https://github.com/zooloo303/zed-abap.git
+
 [submodule "extensions/abysswalker-theme"]
 	path = extensions/abysswalker-theme
 	url = https://github.com/ModusTeam/abysswalker-zed.git
@@ -5361,6 +5365,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/abap"]
-	path = extensions/abap
-	url = https://github.com/zooloo303/zed-abap.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5445,3 +5445,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[abap]
+submodule = "extensions/abap"
+version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -18,6 +18,10 @@ version = "0.1.0"
 submodule = "extensions/a-touch-of-lilac-theme"
 version = "0.0.1"
 
+[abap]
+submodule = "extensions/abap"
+version = "0.4.0"
+
 [abysswalker-theme]
 submodule = "extensions/abysswalker-theme"
 version = "0.1.0"
@@ -5448,8 +5452,4 @@ version = "0.0.1"
 
 [zwirn]
 submodule = "extensions/zwirn"
-version = "0.2.0"
-
-[abap]
-submodule = "extensions/abap"
 version = "0.2.0"


### PR DESCRIPTION
Adds an ABAP + ABAP CDS language extension.

- **Languages:** ABAP (`.abap`, incl. abapGit `.clas.abap`) and ABAP CDS (`.asddls`, `.asddlx`).
- **Grammars:** two MIT tree-sitter grammars I wrote — [tree-sitter-abap](https://github.com/zooloo303/tree-sitter-abap) and [tree-sitter-abap-cds](https://github.com/zooloo303/tree-sitter-abap-cds) — for highlighting, outline, brackets, indentation.
- **Language server:** thin stdio wrapper around [@abaplint/core](https://github.com/abaplint/abaplint) (MIT) for diagnostics, hover, go-to-definition, references, rename, formatting. The server is **not shipped in the extension** — it's downloaded from the extension repo's GitHub releases at runtime, per the guidelines.
- ID `abap` contains no `zed`/`extension`; MIT-licensed; no theme bundled.

**Testing:** installed as a dev extension in Zed and verified on real abapGit-serialized sources (classes + CDS views) — highlighting, outline, and inline abaplint diagnostics all working for both ABAP and ABAP CDS.