### PR TITLE
Add Dowe language and icon extensions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1170,10 +1170,6 @@
 	path = extensions/dowe
 	url = https://github.com/usedowe/dowe-zed.git
 
-[submodule "extensions/dowe-icons"]
-	path = extensions/dowe-icons
-	url = https://github.com/usedowe/dowe-zed.git
-
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
 	url = https://github.com/ozacod/zed-doxygen.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1166,6 +1166,10 @@
 	path = extensions/doom-one-theme
 	url = https://github.com/bashln/zed-doom.git
 
+[submodule "extensions/dowe"]
+	path = extensions/dowe
+	url = https://github.com/usedowe/dowe-zed.git
+
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
 	url = https://github.com/ozacod/zed-doxygen.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1170,6 +1170,10 @@
 	path = extensions/dowe
 	url = https://github.com/usedowe/dowe-zed.git
 
+[submodule "extensions/dowe-icons"]
+	path = extensions/dowe-icons
+	url = https://github.com/usedowe/dowe-zed.git
+
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
 	url = https://github.com/ozacod/zed-doxygen.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1191,11 +1191,6 @@ version = "1.0.0"
 submodule = "extensions/dowe"
 version = "0.1.0"
 
-[dowe-icons]
-submodule = "extensions/dowe-icons"
-path = "icons"
-version = "0.1.0"
-
 [doxygen]
 submodule = "extensions/doxygen"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1192,7 +1192,7 @@ submodule = "extensions/dowe"
 version = "0.1.0"
 
 [dowe-icons]
-submodule = "extensions/dowe"
+submodule = "extensions/dowe-icons"
 path = "icons"
 version = "0.1.0"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -1187,6 +1187,15 @@ version = "0.0.2"
 submodule = "extensions/doom-one-theme"
 version = "1.0.0"
 
+[dowe]
+submodule = "extensions/dowe"
+version = "0.1.0"
+
+[dowe-icons]
+submodule = "extensions/dowe"
+path = "icons"
+version = "0.1.0"
+
 [doxygen]
 submodule = "extensions/doxygen"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- Add the Dowe language extension from `https://github.com/usedowe/dowe-zed`.
- Add the separate `dowe-icons` extension from the `icons` subdirectory.
- Register both extensions at version `0.1.0` using HTTPS submodule URLs.

## Why

This makes Dowe discoverable and installable through Zed's official extension registry. The language extension uses the public `v0.1.0` release for managed language-server assets, and the icon theme is kept as a separate extension as required by the current registry structure.

## Validation

- Ran `pnpm sort-extensions`.
- Ran the Dowe extension grammar tests and extension checks.
- Verified the public `usedowe/dowe-zed` release contains macOS, Linux, and Windows language-server assets.
