### PR TITLE
Update ObjectScript to v1.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3340,7 +3340,7 @@ version = "1.0.1"
 
 [objectscript]
 submodule = "extensions/objectscript"
-version = "1.4.0"
+version = "1.5.0"
 
 [obsidian-sunset]
 submodule = "extensions/obsidian-sunset"


### PR DESCRIPTION
This update adds the objectscript langauge server
to the extension. Additionally, highlighting
updates were added and the commit for the
objectscript grammars was updated to the
most recent one. Details on the language server features
are described [here](https://github.com/intersystems/zed-objectscript/pull/9#issue-4675257253).