### PR TITLE
Add Live Tennis MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2470,6 +2470,10 @@
 	path = extensions/live-template
 	url = https://github.com/jekst/zed-snippets.git
 
+[submodule "extensions/livetennis-mcp"]
+	path = extensions/livetennis-mcp
+	url = https://github.com/livetennisapi/zed-livetennis-mcp.git
+
 [submodule "extensions/llvm-ir"]
 	path = extensions/llvm-ir
 	url = https://github.com/kdkasad/zed-llvm-ir-extension

--- a/extensions.toml
+++ b/extensions.toml
@@ -2520,6 +2520,10 @@ version = "0.3.1"
 submodule = "extensions/live-template"
 version = "0.0.4"
 
+[livetennis-mcp]
+submodule = "extensions/livetennis-mcp"
+version = "0.1.0"
+
 [llvm-ir]
 submodule = "extensions/llvm-ir"
 version = "0.1.1"


### PR DESCRIPTION
Adds the Live Tennis MCP Server as a context-server extension.

**Repository:** https://github.com/livetennisapi/zed-livetennis-mcp

Real-time tennis for the Zed agent panel — live scores, upcoming matches, results, player profiles and fixtures across ATP, WTA, Challenger and ITF, via the [Live Tennis API](https://livetennisapi.com)'s MCP server (12 read-only tools). Odds and win-probability tools exist but require a paid plan; the free tier (no card) covers scores/players/fixtures: https://livetennisapi.com/subscribe/free

Implementation notes, per the contributing guidelines:
- The MCP server is **not vendored** — the extension installs the `livetennisapi-mcp` npm package at runtime via `npm_install_package` (pinned to latest) and spawns it with `node_binary_path()`.
- The API key is taken **only** from `ContextServerSettings` and passed as an env var to the spawned server; the extension never reads the ambient environment. `context_server_configuration` is implemented, so an unconfigured user gets setup instructions with a copy-pasteable settings block rather than a bare error.
- MIT licensed, `Cargo.lock` committed, builds clean against `zed_extension_api` 0.7 on `wasm32-wasip2` from a fresh clone with `--locked`.
- **Tested locally as a dev extension** on Zed 1.11.3: the extension loads, the unconfigured path renders the setup instructions, and with a key configured Zed's own MCP client received all 12 tool schemas over its live connection (verified in `Zed.log`, `tools/list` in ~10ms); tool calls against the installed artifact returned live match data.
- Submodule uses the HTTPS URL; entry placed by `sort-extensions`; forked from a personal account.