### PR TITLE
Add Lucent Blur theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2518,6 +2518,10 @@
 	path = extensions/luau
 	url = https://github.com/4teapo/zed-luau
 
+[submodule "extensions/lucent-blur-theme"]
+	path = extensions/lucent-blur-theme
+	url = https://github.com/callqh/lucent-blur.git
+
 [submodule "extensions/lume-theme"]
 	path = extensions/lume-theme
 	url = https://github.com/danfry1/lume-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2569,6 +2569,10 @@ version = "0.1.9"
 submodule = "extensions/luau"
 version = "0.3.8"
 
+[lucent-blur-theme]
+submodule = "extensions/lucent-blur-theme"
+version = "0.3.0"
+
 [lume-theme]
 submodule = "extensions/lume-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds [Lucent Blur](https://github.com/callqh/lucent-blur) `0.3.0`, a focused
theme extension with three variants:

- `Lucent Blur Mix` — dark, with a softly mixed translucent surface
- `Lucent Blur Flat` — dark, with a more neutral translucent surface
- `Lucent Blur Light` — light, tuned for bright backgrounds

This supersedes #6901. Following the review feedback there, the project was
renamed from One Dark Pro Blur to Lucent Blur and reduced from 18 upstream-style
variants to three deliberately maintained themes.

## Why this is a separate extension

Lucent Blur is not intended to replace or duplicate the existing One Dark Pro
or Quiet Light ports. Those extensions preserve their source themes, whereas
Lucent Blur treats translucent UI behavior as its primary design:

- editor, panel, tab bar, terminal, toolbar, gutter, and scrollbar surfaces are
  transparent and use Zed's native `blurred` appearance;
- active tabs, selections, icons, active lines, focus borders, and hover states
  have independently tuned contrast so they remain readable over changing
  wallpaper colors;
- only two dark variants and one light variant are shipped, rather than
  republishing the original theme collections with opacity permutations.

Contributing these changes upstream would change the visual scope and default
surface behavior of otherwise conventional One Dark Pro Enhanced and Quiet
Light ports. Keeping Lucent Blur independent lets those projects remain faithful
ports while this extension can evolve its blur-specific interaction system.
The source palettes and licenses remain attributed in the repository.


- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
