### PR TITLE
Add Black Frieza theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5357,3 +5357,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/black-frieza"]
+	path = extensions/black-frieza
+	url = https://github.com/dylandifilippo/black-frieza.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -438,6 +438,9 @@
 	path = extensions/bitbake
 	url = https://github.com/anikinmd/zed_bitbake.git
 
+[submodule "extensions/black-frieza"]
+	path = extensions/black-frieza
+	url = https://github.com/dylandifilippo/black-frieza.git
 [submodule "extensions/blackfox"]
 	path = extensions/blackfox
 	url = https://github.com/matejcerny/BlackFoxZed.git
@@ -5357,6 +5360,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/black-frieza"]
-	path = extensions/black-frieza
-	url = https://github.com/dylandifilippo/black-frieza.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -441,6 +441,7 @@
 [submodule "extensions/black-frieza"]
 	path = extensions/black-frieza
 	url = https://github.com/dylandifilippo/black-frieza.git
+
 [submodule "extensions/blackfox"]
 	path = extensions/blackfox
 	url = https://github.com/matejcerny/BlackFoxZed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -438,8 +438,8 @@
 	path = extensions/bitbake
 	url = https://github.com/anikinmd/zed_bitbake.git
 
-[submodule "extensions/black-frieza"]
-	path = extensions/black-frieza
+[submodule "extensions/black-frieza-theme"]
+	path = extensions/black-frieza-theme
 	url = https://github.com/dylandifilippo/black-frieza.git
 
 [submodule "extensions/blackfox"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -446,6 +446,10 @@ version = "0.1.0"
 submodule = "extensions/bitbake"
 version = "0.0.4"
 
+[black-frieza]
+submodule = "extensions/black-frieza"
+version = "1.0.0"
+
 [blackfox]
 submodule = "extensions/blackfox"
 version = "0.4.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -446,9 +446,10 @@ version = "0.1.0"
 submodule = "extensions/bitbake"
 version = "0.0.4"
 
-[black-frieza]
-submodule = "extensions/black-frieza"
-version = "1.0.6"
+[black-frieza-theme]
+submodule = "extensions/black-frieza-theme"
+path = "zed/black-frieza"
+version = "1.1.0"
 
 [blackfox]
 submodule = "extensions/blackfox"

--- a/extensions.toml
+++ b/extensions.toml
@@ -448,7 +448,7 @@ version = "0.0.4"
 
 [black-frieza]
 submodule = "extensions/black-frieza"
-version = "1.0.0"
+version = "1.0.6"
 
 [blackfox]
 submodule = "extensions/blackfox"


### PR DESCRIPTION
Adds the **Black Frieza** theme — a balanced dark theme based on [New Darcula](https://github.com/e-simpson/new-darcula-z) (MIT) with more saturated syntax colors and matte khaki-and-violet accents. Two variants: Black Frieza and Black Frieza Darker.

Repo: https://github.com/dylandifilippo/black-frieza (screenshots in the README)

- [x] `extension.toml` with id `black-frieza`
- [x] MIT licensed
- [x] Submodule added and `extensions.toml` entry inserted alphabetically