### PR TITLE
Add xml-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5210,6 +5210,10 @@
 	path = extensions/xml
 	url = https://github.com/sweetppro/zed-xml.git
 
+[submodule "extensions/xml-lsp"]
+	path = extensions/xml-lsp
+	url = https://github.com/speedata/xml-lsp.git
+
 [submodule "extensions/xy-zed"]
 	path = extensions/xy-zed
 	url = https://github.com/zarifpour/xy-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5302,6 +5302,11 @@ version = "0.1.0"
 submodule = "extensions/xml"
 version = "0.1.0"
 
+[xml-lsp]
+submodule = "extensions/xml-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [xy-zed]
 submodule = "extensions/xy-zed"
 version = "0.1.4"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [xml-lsp](https://github.com/speedata/xml-lsp), a language server for XML documents described by RELAX NG schemas: validation while typing, schema-driven completion (context-aware elements, attributes, values, tag skeletons), hover documentation, go-to-definition/references and rename for schema-annotated symbols, quick fixes, formatting, semantic tokens, and inlay hints. It attaches to the XML language provided by the XML extension; the server binary is downloaded from the project's GitHub releases (five platform targets). Developed against the speedata Publisher layout schemas, but any RELAX NG grammar works.