### PR TITLE
Remove `mcp-server-axiom`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2694,10 +2694,6 @@
 	path = extensions/mcp-server-atproto-docs
 	url = https://github.com/moshyfawn/zed-mcp-server-atproto-docs.git
 
-[submodule "extensions/mcp-server-axiom"]
-	path = extensions/mcp-server-axiom
-	url = https://github.com/zed-extensions/mcp-server-axiom.git
-
 [submodule "extensions/mcp-server-brave-search"]
 	path = extensions/mcp-server-brave-search
 	url = https://github.com/zed-extensions/mcp-server-brave-search.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2746,10 +2746,6 @@ version = "0.2.0"
 submodule = "extensions/mcp-server-atproto-docs"
 version = "0.2.0"
 
-[mcp-server-axiom]
-submodule = "extensions/mcp-server-axiom"
-version = "0.2.0"
-
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"
 version = "0.2.0"


### PR DESCRIPTION
The [Axiom MCP server extension](https://github.com/zed-extensions/mcp-server-axiom) is deprecated.