### PR TITLE
Add Voidline theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5034,6 +5034,10 @@
 	path = extensions/vivid-void-theme
 	url = https://github.com/fn-jakubkarp/zed-vivid-void-theme.git
 
+[submodule "extensions/voidline-theme"]
+	path = extensions/voidline-theme
+	url = https://github.com/knownIndie/voidline-zed-theme
+
 [submodule "extensions/vrl"]
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5126,7 +5126,7 @@ version = "0.0.1"
 
 [voidline-theme]
 submodule = "extensions/voidline-theme"
-version = "0.1.0"
+version = "0.1.1"
 
 [vrl]
 submodule = "extensions/vrl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5124,6 +5124,10 @@ version = "1.0.0"
 submodule = "extensions/vivid-void-theme"
 version = "0.0.1"
 
+[voidline-theme]
+submodule = "extensions/voidline-theme"
+version = "0.1.0"
+
 [vrl]
 submodule = "extensions/vrl"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

- Adds Voidline Themes as a new theme extension.
- Registers `voidline-theme` at version `0.1.1`.
- Adds the public MIT-licensed repository as an HTTPS submodule.

Voidline contains five variants: Slate, Glass, Signal, Dusk, and Dawn. The family uses low-glare carbon-black surfaces, restrained text contrast, and focused syntax colors.

## Validation

- Installed the exact repository in Zed Preview as a dev extension.
- Confirmed all five variants appear in the theme selector.
- Validated the theme against Zed's v0.2.0 theme schema.
- Ran `pnpm sort-extensions`.
- Ran `pnpm build`.
- Ran `pnpm test`: 111 tests passed.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
