### PR TITLE
Add SudoLang extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4426,6 +4426,10 @@
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall
 
+[submodule "extensions/sudolang"]
+	path = extensions/sudolang
+	url = https://github.com/dylan-gluck/zed-sudolang.git
+
 [submodule "extensions/sumi-light"]
 	path = extensions/sumi-light
 	url = https://github.com/LogicSatinn/sumi-light-zed.git
@@ -5361,6 +5365,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/sudolang"]
-	path = extensions/sudolang
-	url = https://github.com/dylan-gluck/zed-sudolang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5361,3 +5361,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/sudolang"]
+	path = extensions/sudolang
+	url = https://github.com/dylan-gluck/zed-sudolang.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4503,6 +4503,10 @@ submodule = "extensions/subliminal-nightfall"
 path = "zed"
 version = "0.1.16"
 
+[sudolang]
+submodule = "extensions/sudolang"
+version = "0.3.1"
+
 [sumi-light]
 submodule = "extensions/sumi-light"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4505,7 +4505,7 @@ version = "0.1.16"
 
 [sudolang]
 submodule = "extensions/sudolang"
-version = "0.3.1"
+version = "0.3.2"
 
 [sumi-light]
 submodule = "extensions/sumi-light"


### PR DESCRIPTION
Adds [SudoLang](https://github.com/dylan-gluck/zed-sudolang) language support.

SudoLang is a pseudolanguage for instructing LLMs. The extension provides:

- `.sudo` file type, plus `sudo` / `SudoLang` code-fence injection in markdown
- Syntax highlighting, outline, bracket matching, and indentation via [tree-sitter-sudolang](https://github.com/dylan-gluck/tree-sitter-sudolang)
- Optional language-server integration (`sudolang-lsp` resolved from `$PATH`): diagnostics, formatting, hover, completion, go-to-definition

Extension version: 0.3.1 · MIT licensed · `Cargo.lock` committed · no bundled binaries. Developed and used locally as a dev extension.