### PR TITLE
Add hive agent server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1954,6 +1954,10 @@
 	path = extensions/hivacruz-theme
 	url = https://github.com/kinoute/zed-hivacruz-theme
 
+[submodule "extensions/hive"]
+	path = extensions/hive
+	url = https://github.com/xn0tdev/hive-zed.git
+
 [submodule "extensions/hledger"]
 	path = extensions/hledger
 	url = https://github.com/juev/hledger-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1991,6 +1991,10 @@ version = "1.0.0"
 submodule = "extensions/hivacruz-theme"
 version = "0.2.0"
 
+[hive]
+submodule = "extensions/hive"
+version = "0.2.0"
+
 [hledger]
 submodule = "extensions/hledger"
 version = "0.1.3"


### PR DESCRIPTION
## Hive — ACP Agent Server

Hive is a native Rust coding agent that speaks the Agent Client Protocol (ACP) over stdio. This extension registers it as an agent server in Zed's Agent Panel.

- **Extension repo:** https://github.com/xn0tdev/hive-zed
- **Hive source:** https://github.com/xn0tdev/hive
- **Binary releases:** https://github.com/xn0tdev/hive/releases

### How it works

The extension downloads a platform-specific Hive binary from GitHub Releases and launches it with `--acp` (ACP server mode). Hive communicates with Zed via JSON-RPC 2.0 over stdio.

### Platforms

- macOS ARM (darwin-aarch64)
- macOS Intel (darwin-x86_64)
- Linux x86_64 (linux-x86_64)
- Windows x86_64 (windows-x86_64)

### Prerequisites

Hive needs a configured provider API key (`~/.config/hive/config.toml` or env var). See the [Hive README](https://github.com/xn0tdev/hive) for setup details.

### Notes

- `sha256` fields in `extension.toml` will be filled after the first release CI run produces archives with checksums.
- Hive supports ACP v1: `initialize`, `session/new`, `session/prompt`, `session/cancel`, `session/set_mode`, plus `session/update` notifications for agent messages, thoughts, tool calls (with diffs), plan updates, mode changes, and usage.