### PR TITLE
Add antigravity extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -154,6 +154,10 @@
 	path = extensions/anticuus
 	url = https://codeberg.org/juanmilkah/anticuus.git
 
+[submodule "extensions/antigravity"]
+	path = extensions/antigravity
+	url = https://github.com/Scottlexium/antigravity.git
+
 [submodule "extensions/anysphere-theme"]
 	path = extensions/anysphere-theme
 	url = https://github.com/stpn48/anysphere-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -158,6 +158,10 @@ version = "1.0.0"
 submodule = "extensions/anticuus"
 version = "0.0.1"
 
+[antigravity]
+submodule = "extensions/antigravity"
+version = "0.0.1"
+
 [anysphere-theme]
 submodule = "extensions/anysphere-theme"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the [antigravity](https://github.com/Scottlexium/antigravity) extension, which brings Gemini support to Zed. It runs a small local bridge daemon that Zed talks to through its built-in OpenAI-compatible custom AI provider support, using the user's own Gemini API key (no subscription or lock-in).

## Checklist

- [x] Repository is public
- [x] `extension.toml` and `Cargo.toml` versions match (`0.0.1`)
- [x] `LICENSE` (MIT) included at the extension root
- [x] `extension.wasm` is not committed to the extension repo
- [x] Tested locally as a dev extension
- [x] Ran `node src/sort-extensions.js` after adding the entry