### PR TITLE
Add obsidian-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3290,6 +3290,10 @@
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git
 
+[submodule "extensions/obsidian-theme"]
+	path = extensions/obsidian-theme
+	url = https://github.com/narcilee7/zed-obsidian-theme.git
+
 [submodule "extensions/oc-2-theme"]
 	path = extensions/oc-2-theme
 	url = https://github.com/nstlgy/oc-2-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -3346,6 +3346,10 @@ version = "1.4.0"
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"
 
+[obsidian-theme]
+submodule = "extensions/obsidian-theme"
+version = "0.1.0"
+
 [oc-2-theme]
 submodule = "extensions/oc-2-theme"
 version = "0.0.1"


### PR DESCRIPTION
This PR adds the [obsidian-theme](https://github.com/narcilee7/zed-obsidian-theme) extension: a faithful port of Obsidian's default theme (dark and light) for Zed.

Colors are derived from Obsidian's official CSS variables (base palette, extended colors, accent `hsl(254, 80%, 68%)`) and the default theme's syntax highlighting mapping. The theme file is validated against Zed's theme schema v0.2.0.