### PR TITLE
Add Monobrut theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2950,6 +2950,10 @@
 	path = extensions/molten-theme
 	url = https://github.com/vaqxai/zed-molten-theme.git
 
+[submodule "extensions/monobrut-theme"]
+	path = extensions/monobrut-theme
+	url = https://github.com/akullpp/monobrut-theme.git
+
 [submodule "extensions/monochromator-theme"]
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3004,6 +3004,10 @@ version = "0.2.1"
 submodule = "extensions/molten-theme"
 version = "1.0.0"
 
+[monobrut-theme]
+submodule = "extensions/monobrut-theme"
+version = "0.1.0"
+
 [monochromator-theme]
 submodule = "extensions/monochromator-theme"
 path = "editors/zed"


### PR DESCRIPTION
Adds [Monobrut](https://github.com/akullpp/monobrut-theme), a high-contrast brutalist theme collection with Default, Breuer, and Säure variants.

Tested locally in Zed as a development extension.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding my extension.
