### PR TITLE
Update ssh-config to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4455,7 +4455,7 @@ version = "0.0.4"
 
 [ssh-config]
 submodule = "extensions/ssh-config"
-version = "0.3.0"
+version = "0.4.0"
 
 [stan]
 submodule = "extensions/stan"


### PR DESCRIPTION
Updates ssh-config extension to v0.4.0.

It now uses the latest [tree-sitter-ssh-config](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config), which adds [support for inline comments](https://github.com/tree-sitter-grammars/tree-sitter-ssh-config/commit/0c35b243392268f48fd096607da192d76c843398).

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
