### PR TITLE
Add fleet-blurry-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1494,6 +1494,10 @@
 	path = extensions/flatbuffers
 	url = https://github.com/smpanaro/zed-flatbuffers.git
 
+[submodule "extensions/fleet-blurry-theme"]
+	path = extensions/fleet-blurry-theme
+	url = https://github.com/JoshuaSimon/zed-blurry-themes.git
+
 [submodule "extensions/fleet-themes"]
 	path = extensions/fleet-themes
 	url = https://github.com/skarline/zed-fleet-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1520,6 +1520,10 @@ version = "0.2.0"
 submodule = "extensions/flatbuffers"
 version = "0.0.3"
 
+[fleet-blurry-theme]
+submodule = "extensions/fleet-blurry-theme"
+version = "1.0.0"
+
 [fleet-themes]
 submodule = "extensions/fleet-themes"
 version = "1.2.0"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary
Adds `fleet-blurry-theme` to the Zed extensions registry.

## What’s included
- adds the `zed-blurry-themes` repository as a submodule at `extensions/fleet-blurry-theme`
- adds the `fleet-blurry-theme` entry to `extensions.toml`
- includes version `1.0.0`

## Notes
This is a theme-only extension that provides Fleet-inspired blurry themes for Zed with light, default, and heavy blur variants.