### PR TITLE
Add skill-language-server 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4222,6 +4222,10 @@
 	path = extensions/sitruuna
 	url = https://github.com/menduz/sitruuna-zed.git
 
+[submodule "extensions/skill-language-server"]
+	path = extensions/skill-language-server
+	url = https://github.com/CyrusNuevoDia/skill-language-server.git
+
 [submodule "extensions/sl4y-theme"]
 	path = extensions/sl4y-theme
 	url = https://github.com/berkantay/zed-theme-sl4y.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4294,6 +4294,11 @@ version = "0.0.12"
 submodule = "extensions/sitruuna"
 version = "0.1.0"
 
+[skill-language-server]
+submodule = "extensions/skill-language-server"
+path = "ext/zed"
+version = "0.0.1"
+
 [sl4y-theme]
 submodule = "extensions/sl4y-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds [skill-language-server](https://github.com/CyrusNuevoDia/skill-language-server) — an LSP for agent skill files (`skills/<name>/SKILL.md`):

- completion with descriptions on `/` and `$` references
- "did you mean" diagnostics on typos
- go to definition, find references
- cross-file rename (folder, frontmatter, and every reference in one edit)

The extension doesn't bundle the server: it prefers a `skill-language-server` binary on PATH, otherwise auto-installs the [npm package](https://www.npmjs.com/package/skill-language-server) and runs it on Zed's bundled Node runtime. MIT licensed (`ext/zed/LICENSE`).