### PR TITLE
Update HearthCode theme to v3.7.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1952,7 +1952,7 @@ version = "0.0.1"
 
 [hearthcode-theme]
 submodule = "extensions/hearthcode-theme"
-version = "3.7.5"
+version = "3.7.7"
 
 [helios-theme]
 submodule = "extensions/helios-theme"


### PR DESCRIPTION
Updates HearthCode Theme from 3.7.5 to 3.7.7.

This release:

- separates Ember property and string colors more clearly in Dark and Light
- updates the extension description and generated marketing image
- keeps all four Moss/Ember Dark/Light theme variants generated from the same source color system

The mirror manifest reports version 3.7.7, the submodule points to the published `hearth-code/hearthcode-zed` commit, and all four theme files pass HearthCode's Zed v0.2.0 schema audit.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for updating my extension.
