### PR TITLE
Add zenc language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5326,6 +5326,10 @@
 	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git
 
+[submodule "extensions/zenc"]
+	path = extensions/zenc
+	url = https://github.com/PigeonCoding/zenc-zed.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git
@@ -5369,6 +5373,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/zenc"]
-	path = extensions/zenc
-	url = https://github.com/PigeonCoding/zenc-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5369,3 +5369,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zenc"]
+	path = extensions/zenc
+	url = https://github.com/PigeonCoding/zenc-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5415,6 +5415,10 @@ version = "1.4.3"
 submodule = "extensions/zenburn-transparent-theme"
 version = "1.0.0"
 
+[zenc]
+submodule = "extensions/zenc"
+version = "0.0.1"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5417,7 +5417,7 @@ version = "1.0.0"
 
 [zenc]
 submodule = "extensions/zenc"
-version = "0.0.1"
+version = "0.1"
 
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This adds LSP support + syntax highlighting for the Zen C programming language

tested locally on zed v1.12.0 on arch Linux
note: this extension requires you to install zenc manually on your machine
note2: this code was written by AI and review and tested by me (a human), do of that what you want

Thank you for your work.
