### PR TITLE
Add PyPilot language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3930,10 +3930,6 @@
 	path = extensions/pylsp
 	url = https://github.com/rgbkrk/python-lsp-zed-extension.git
 
-[submodule "extensions/pypilot"]
-	path = extensions/pypilot
-	url = https://github.com/Abdullah-Masood-05/pypilot.git
-
 [submodule "extensions/pyrefly"]
 	path = extensions/pyrefly
 	url = https://github.com/zed-extensions/pyrefly.git
@@ -3945,6 +3941,10 @@
 [submodule "extensions/python-autodoc-lsp"]
 	path = extensions/python-autodoc-lsp
 	url = https://github.com/eallender/zed-python-autodoc.git
+
+[submodule "extensions/python-env-doctor"]
+	path = extensions/python-env-doctor
+	url = https://github.com/Abdullah-Masood-05/pypilot.git
 
 [submodule "extensions/python-refactoring"]
 	path = extensions/python-refactoring

--- a/.gitmodules
+++ b/.gitmodules
@@ -3950,8 +3950,8 @@
 	path = extensions/python-autodoc-lsp
 	url = https://github.com/eallender/zed-python-autodoc.git
 
-[submodule "extensions/python-env-doctor"]
-	path = extensions/python-env-doctor
+[submodule "extensions/python-env-language-server"]
+	path = extensions/python-env-language-server
 	url = https://github.com/Abdullah-Masood-05/pypilot.git
 
 [submodule "extensions/python-refactoring"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -3786,6 +3786,10 @@
 	path = extensions/pylsp
 	url = https://github.com/rgbkrk/python-lsp-zed-extension.git
 
+[submodule "extensions/pypilot"]
+	path = extensions/pypilot
+	url = https://github.com/Abdullah-Masood-05/pypilot.git
+
 [submodule "extensions/pyrefly"]
 	path = extensions/pyrefly
 	url = https://github.com/zed-extensions/pyrefly.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4020,8 +4020,8 @@ version = "0.24.0"
 submodule = "extensions/python-autodoc-lsp"
 version = "0.1.1"
 
-[python-env-doctor]
-submodule = "extensions/python-env-doctor"
+[python-env-language-server]
+submodule = "extensions/python-env-language-server"
 path = "extension"
 version = "0.1.1"
 

--- a/extensions.toml
+++ b/extensions.toml
@@ -3853,6 +3853,11 @@ version = "0.0.1"
 submodule = "extensions/pylsp"
 version = "0.0.1"
 
+[pypilot]
+submodule = "extensions/pypilot"
+path = "extension"
+version = "0.1.0"
+
 [pyrefly]
 submodule = "extensions/pyrefly"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3998,11 +3998,6 @@ version = "0.0.1"
 submodule = "extensions/pylsp"
 version = "0.0.1"
 
-[pypilot]
-submodule = "extensions/pypilot"
-path = "extension"
-version = "0.1.1"
-
 [pyrefly]
 submodule = "extensions/pyrefly"
 version = "0.0.1"
@@ -4014,6 +4009,11 @@ version = "0.24.0"
 
 [python-autodoc-lsp]
 submodule = "extensions/python-autodoc-lsp"
+version = "0.1.1"
+
+[python-env-doctor]
+submodule = "extensions/python-env-doctor"
+path = "extension"
 version = "0.1.1"
 
 [python-refactoring]

--- a/extensions.toml
+++ b/extensions.toml
@@ -4001,7 +4001,7 @@ version = "0.0.1"
 [pypilot]
 submodule = "extensions/pypilot"
 path = "extension"
-version = "0.1.0"
+version = "0.1.1"
 
 [pyrefly]
 submodule = "extensions/pyrefly"


### PR DESCRIPTION
## Summary

PyPilot builds a project's virtual environment on the Python version its dependencies actually support, instead of whatever interpreter happens to be active. It reads `requires_python` and wheel tags directly from PyPI, so a dependency with no wheel for your Python version is caught before the install fails with an unrelated error.

It also catches two things package metadata alone can't:

- **API removed between releases.** It reads the package as installed on disk and flags an attribute access that no longer exists, rather than waiting for the `AttributeError` at runtime.
- **A GPU driver too old for the wheel.** For pip-installed frameworks it reads the NVIDIA driver version and matches the CUDA-enabled torch/tensorflow build the driver actually supports.

Every answer comes from package metadata, wheel tags, and static driver/framework tables. There are no API keys and no calls to a model.

The extension itself (`extension/`) is a thin WASM shim under 200 lines: it detects the platform, downloads the matching native helper binary from this repo's releases, and registers it as a language server. All real logic lives in the helper, which also works standalone from any terminal.

- Repo: https://github.com/Abdullah-Masood-05/pypilot
- Tested locally as a dev extension per `zed: install dev extension`.
- License: Apache-2.0 for the extension crate that compiles into the distributed binary (AGPL-3.0 for the helper it downloads, which Zed's license rules exempt).

## Test plan

- [x] `cargo test -p pypilot-helper` passes
- [x] `cargo build -p pypilot-zed --target wasm32-unknown-unknown --release` builds clean
- [x] CI green on all platforms (linux-x64, macos-x64, macos-arm64, windows-x64)
- [x] Release `v0.1.0` published with all four platform assets the shim expects
- [x] Loaded as a dev extension in Zed and verified it activates on a Python project