### PR TITLE
Add VSCode 2026 Themes extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5058,6 +5058,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vscode-2026-semantic-theme"]
+	path = extensions/vscode-2026-semantic-theme
+	url = https://github.com/realSergiy/vscode_2026_theme_zed.git
+
 [submodule "extensions/vscode-2026-theme"]
 	path = extensions/vscode-2026-theme
 	url = https://github.com/eugenebokhan/zed-vs-code-2026-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5149,6 +5149,10 @@ version = "0.0.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vscode-2026-semantic-theme]
+submodule = "extensions/vscode-2026-semantic-theme"
+version = "0.1.2"
+
 [vscode-2026-theme]
 submodule = "extensions/vscode-2026-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [VSCode 2026 Themes](https://github.com/realSergiy/vscode_2026_theme_zed) — ports of VS Code's built-in **Dark 2026** and **Light 2026** themes.

The themes are generated from the vendored upstream VS Code sources, with full support for LSP semantic tokens.
Tested to ensure verbatim colors vs the original.