### PR TITLE
Add santi020k-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4102,6 +4102,10 @@
 	path = extensions/salesforce
 	url = https://github.com/Damecek/zed-salesforce-extension.git
 
+[submodule "extensions/santi020k-theme"]
+	path = extensions/santi020k-theme
+	url = https://github.com/santi020k/santi020k-theme
+
 [submodule "extensions/scala"]
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4174,6 +4174,11 @@ version = "0.1.0"
 submodule = "extensions/salesforce"
 version = "0.0.4"
 
+[santi020k-theme]
+submodule = "extensions/santi020k-theme"
+path = "packages/santi020k-zed-theme"
+version = "1.0.0"
+
 [scala]
 submodule = "extensions/scala"
 version = "0.2.3"


### PR DESCRIPTION
Publishes santi020k-theme 1.0.0.

Source: https://github.com/santi020k/santi020k-theme/tree/0a31f7efb725438478f7f8a5896127deb86063e0/packages/santi020k-zed-theme

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
