### PR TITLE
Add Rajzik theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3894,6 +3894,10 @@
 	path = extensions/rainbow-csv
 	url = https://github.com/weartist/zed-rainbow-csv.git
 
+[submodule "extensions/rajzik-theme"]
+	path = extensions/rajzik-theme
+	url = https://github.com/rajzik/vs-code-theme.git
+
 [submodule "extensions/rapture-theme"]
 	path = extensions/rapture-theme
 	url = https://github.com/gabors0/rapture-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3962,6 +3962,11 @@ version = "1.1.0"
 submodule = "extensions/rainbow-csv"
 version = "1.1.0"
 
+[rajzik-theme]
+submodule = "extensions/rajzik-theme"
+path = "packages/zed-theme"
+version = "1.0.3"
+
 [rapture-theme]
 submodule = "extensions/rapture-theme"
 version = "1.0.1"


### PR DESCRIPTION
## Summary
- add the Rajzik theme as a submodule in the extensions registry
- point the registry entry at `packages/zed-theme` in the `vs-code-theme` monorepo
- publish version `1.0.3` from the package's `extension.toml`

## Test plan
- [x] Run `pnpm sort-extensions`
- [x] Run `pnpm test`
- [ ] Install the extension locally in Zed and verify `Rajzik Dark` appears in the theme picker

Made with [Cursor](https://cursor.com)