### PR TITLE
Add csv-toolkit extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -922,6 +922,10 @@
 	path = extensions/csv
 	url = https://github.com/huacnlee/zed-csv.git
 
+[submodule "extensions/csv-toolkit"]
+	path = extensions/csv-toolkit
+	url = https://github.com/ickc/zed-csv-toolkit.git
+
 [submodule "extensions/ctags"]
 	path = extensions/ctags
 	url = https://github.com/mazurel/zed-ctags.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -940,6 +940,10 @@ path = "packages/csskit_zed"
 submodule = "extensions/csv"
 version = "0.0.3"
 
+[csv-toolkit]
+submodule = "extensions/csv-toolkit"
+version = "0.3.0"
+
 [ctags]
 submodule = "extensions/ctags"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -942,7 +942,7 @@ version = "0.0.3"
 
 [csv-toolkit]
 submodule = "extensions/csv-toolkit"
-version = "0.3.0"
+version = "0.4.0"
 
 [ctags]
 submodule = "extensions/ctags"


### PR DESCRIPTION
Adds [csv-toolkit](https://github.com/ickc/zed-csv-toolkit) v0.4.0 — rainbow columns for CSV/TSV/SSV/PSV plus a language server: ragged-row diagnostics, column-aware hover (column name, index, inferred type), an inline table view, and markdown-table preview.

MIT licensed. Tested locally as a dev extension.

### Overlap with an existing extension

`rainbow-csv` already ships the same grammar (`coroa/rainbow-csv-tree-sitter`, same pinned commit) for the same four languages, so I want to be upfront about the duplication rather than have a reviewer find it.

The reason this is a separate extension rather than a PR against `rainbow-csv` is that the added value is a language server, and an extension cannot attach a language server to languages another extension defines — `language_servers` entries only bind to languages declared in the same `extension.toml`. Carrying the LSP therefore requires re-declaring the grammar and the four languages. Folding the server into `rainbow-csv` would mean adding a Rust binary, a release pipeline, and cross-platform asset downloads to what is currently a grammar-only extension, which seemed like a bigger imposition on its maintainer than shipping alongside it.

Users should install one or the other, not both — Zed registers languages by name, so two extensions declaring `CSV` will contend for it. The README says so plainly, and names both `rainbow-csv` and `csv` (which uses a different CSV grammar) so people can pick.

I'm happy to take direction here if you would rather this were merged into an existing extension.

### Note on what the binary writes

Nothing, unless asked. v0.4.0 (this update) removes the automatic Jupyter kernelspec install that v0.3.0 did at language-server start — see the review thread below. Activating the language server, or opening a CSV, now writes only inside the directory Zed designates for the extension.

The inline table view still renders through Zed's REPL and so still needs four kernelspecs, but installing them is now an explicit user action: an opt-in in the user's own settings (`"lsp": { "csv-ls": { "initialization_options": { "install_kernelspecs": true } } }`), or a `csv-ls install-kernelspecs` invocation from a terminal. Without one of those, the server writes nothing and logs one line saying the table view is off and how to enable it. It never overwrites a kernelspec it did not install, and `csv-ls uninstall-kernelspecs` removes what it added. Details are in the extension's README.
