### PR TITLE
Add TaskPaper extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4590,6 +4590,10 @@
 	path = extensions/taskfile
 	url = https://github.com/nickalie/zed-taskfile.git
 
+[submodule "extensions/taskpaper"]
+	path = extensions/taskpaper
+	url = https://github.com/ickc/zed-taskpaper.git
+
 [submodule "extensions/tbilisi-night"]
 	path = extensions/tbilisi-night
 	url = https://github.com/IosebKoplatadze/tbilisi-night-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4673,6 +4673,10 @@ version = "0.0.1"
 submodule = "extensions/taskfile"
 version = "0.1.0"
 
+[taskpaper]
+submodule = "extensions/taskpaper"
+version = "0.3.4"
+
 [tbilisi-night]
 submodule = "extensions/tbilisi-night"
 version = "1.0.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [TaskPaper](https://github.com/ickc/zed-taskpaper) support (v0.3.4) — the plain-text [TaskPaper](https://www.taskpaper.com/) todo format.

The extension bundles:

- a tree-sitter grammar (in-repo, pinned by commit) for projects, tasks, notes and tags, plus highlight/outline/indent queries
- `taskpaper-ls`, a Rust language server shipped as prebuilt binaries for the six Zed targets, providing due-date diagnostics, per-project task counts, and `@done` tooling

MIT licensed. CI runs the grammar and language-server test suites on Linux and macOS.
