### PR TITLE
Add Crabbox extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -874,6 +874,10 @@
 	path = extensions/cql
 	url = https://github.com/Akzestia/zed-cql.git
 
+[submodule "extensions/crabbox"]
+	path = extensions/crabbox
+	url = https://github.com/openclaw/crabbox.git
+
 [submodule "extensions/crates-lsp"]
 	path = extensions/crates-lsp
 	url = https://github.com/appelgriebsch/zed-crates-lsp

--- a/extensions.toml
+++ b/extensions.toml
@@ -890,6 +890,11 @@ version = "0.1.0"
 submodule = "extensions/cql"
 version = "3.0.0"
 
+[crabbox]
+submodule = "extensions/crabbox"
+version = "0.1.0"
+path = "integrations/zed"
+
 [crates-lsp]
 submodule = "extensions/crates-lsp"
 version = "0.2.0"


### PR DESCRIPTION
Adds Crabbox to the Zed extension registry.

* Extension ID: `crabbox`
* Version: `0.1.0`
* Repository: `https://github.com/openclaw/crabbox`
* Extension path: `integrations/zed`
* License: MIT, included at the extension path

Crabbox provides YAML configuration support, snippets, and CLI-backed tasks for validating configuration, provisioning reusable execution environments, running selected commands remotely, inspecting environments, connecting over SSH, and stopping resources.

Validation completed:

* Installed and tested as a Zed development extension

* `node scripts/check-zed-extension.mjs`

* `node scripts/test-zed-extension-e2e.mjs`

* `pnpm sort-extensions`

* `pnpm build`

* `pnpm test`

* `git diff --check`

* [x] I've read `CONTRIBUTING.md` and followed the relevant guidance for adding an extension.
