### PR TITLE
feat: add romanesca-rosenkreuz-schatten theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5381,3 +5381,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/romanesca-rosenkreuz-schatten"]
+	path = extensions/romanesca-rosenkreuz-schatten
+	url = https://github.com/kasuganozomi/romanesca-rosenkreuz-schatten-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4089,6 +4089,10 @@ version = "0.1.2"
 submodule = "extensions/rockide-language-server"
 version = "0.2.0"
 
+[romanesca-rosenkreuz-schatten]
+submodule = "extensions/romanesca-rosenkreuz-schatten"
+version = "0.1.0"
+
 [ron]
 submodule = "extensions/ron"
 version = "0.0.1"


### PR DESCRIPTION
Adds the Romanesca Rosenkreuz — Schatten theme extension.

## What is this?

A premium dark theme built natively for Zed using the official v0.2.0 schema.
Not auto-converted — written by hand with deliberate color decisions.

**Identity:** Absolute black foundation, neon hot-magenta accent (#ff2d78).

**Color system:**
- 5-level background depth hierarchy (activity rail → tab bar → panel → editor → widgets)
- Full Tree-sitter syntax mapping: keywords, types, strings, functions, variables, parameters, constants
- Hot-magenta primary cursor + collaborative player colors
- Full terminal ANSI palette tuned to the Schatten neon identity

**Extension repo:** https://github.com/kasuganozomi/romanesca-rosenkreuz-schatten-zed-theme

---

- [x] I've read CONTRIBUTING.md and followed the relevant guidance for adding or updating my extension.
