### PR TITLE
Add official Laravel language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2382,6 +2382,10 @@
 	path = extensions/laravel
 	url = https://github.com/mike-bronner/zed-laravel.git
 
+[submodule "extensions/laravel-official"]
+	path = extensions/laravel-official
+	url = https://github.com/laravel/zed-extension.git
+
 [submodule "extensions/latex"]
 	path = extensions/latex
 	url = https://github.com/rzukic/zed-latex.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2428,6 +2428,10 @@ version = "1.0.3"
 submodule = "extensions/laravel"
 version = "0.6.0"
 
+[laravel-official]
+submodule = "extensions/laravel-official"
+version = "0.1.0"
+
 [latex]
 submodule = "extensions/latex"
 version = "0.2.3"


### PR DESCRIPTION
## Summary

Laravel now maintains an official Zed extension powered by the [Laravel LSP](https://github.com/laravel/lsp).

This adds it to the marketplace as a separate `laravel-official` listing.

- [x] I've read `CONTRIBUTING.md` and followed the relevant guidance for adding an extension.