### PR TITLE
Update mcp-server-master-go to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2812,7 +2812,7 @@ version = "0.0.1"
 
 [mcp-server-master-go]
 submodule = "extensions/mcp-server-master-go"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-memory]
 submodule = "extensions/mcp-server-memory"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.


update  mcp-server-master-go add args

- master_go_rules
  Optional: List of design rules to apply. Each entry is passed as a `--rule` argument.

- master_go_proxy
  Optional: HTTP/HTTPS proxy URL, for example `http://127.0.0.1:7890`.

- master_go_format
  Optional: Default design-data output format: `json`, `yaml`, or `tree`.

- master_go_debug
  Optional: Enables detailed MCP debug output.

- master_go_disable_default_rules
  Optional: Disables the upstream MCP server's default rules.

- master_go_extra_headers
  Optional: Object of custom HTTP headers. These override upstream default headers, including authentication when the same key is used.


