### PR TITLE
Add Ferron extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1434,6 +1434,10 @@
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git
 
+[submodule "extensions/ferron"]
+	path = extensions/ferron
+	url = https://github.com/ferronweb/ferron-zed.git
+
 [submodule "extensions/fff-mcp"]
 	path = extensions/fff-mcp
 	url = https://github.com/dl-alexandre/zed-fff.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1460,6 +1460,10 @@ version = "1.0.0"
 submodule = "extensions/ferret"
 version = "0.0.11"
 
+[ferron]
+submodule = "extensions/ferron"
+version = "0.1.0"
+
 [fff-mcp]
 submodule = "extensions/fff-mcp"
 version = "0.0.1"


### PR DESCRIPTION
This pull request adds a Zed extension for providing editor support for `ferron.conf` files, which are used by [Ferron 3](https://ferron.sh/docs/v3).

I have tested the extension by installing it as a Zed development extension and testing it on some `ferron.conf` example files and non-`ferron.conf` files (and fixing bugs in the Ferron language server).

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
