### PR TITLE
Add MVL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3054,6 +3054,10 @@
 	path = extensions/muted
 	url = https://github.com/arifzeeshan/Muted.git
 
+[submodule "extensions/mvl"]
+	path = extensions/mvl
+	url = https://github.com/mvl-lang/mvl-spec.git
+
 [submodule "extensions/naive-ui-intellisense"]
 	path = extensions/naive-ui-intellisense
 	url = https://github.com/tu6ge/zed-naive-ui.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3109,6 +3109,11 @@ version = "0.0.1"
 submodule = "extensions/muted"
 version = "0.0.1"
 
+[mvl]
+submodule = "extensions/mvl"
+path = "editors/zed"
+version = "0.1.5"
+
 [naive-ui-intellisense]
 submodule = "extensions/naive-ui-intellisense"
 version = "0.1.2"


### PR DESCRIPTION
Adds [MVL](https://mvl-lang.org) — Maximum Verifiable Language, a language whose compiler proves eleven properties at compile time (type safety, memory safety, totality, null elimination, error visibility, ownership, effects, termination, data-race freedom, refinement types, information-flow control).

## The extension

| | |
|---|---|
| Extension | [mvl-lang/mvl-spec `editors/zed`](https://github.com/mvl-lang/mvl-spec/tree/main/editors/zed) |
| Grammar | [mvl-lang/tree-sitter-mvl](https://github.com/mvl-lang/tree-sitter-mvl), pinned by revision |
| License | Apache-2.0, at `editors/zed/LICENSE` |
| Version | 0.1.5 |

Provides syntax highlighting, indentation, and registers `mvl-lsp`
([PyPI](https://pypi.org/project/mvl-lsp/)) as a language server.

The extension lives in a subdirectory, hence `path = "editors/zed"` — same arrangement as `agnix` and `air`.

## Prerequisites checklist

- [x] Submodule added over **HTTPS**
- [x] `path` set, since the extension is not at the submodule root
- [x] `version` in `extensions.toml` matches `editors/zed/extension.toml`
- [x] **License at the extension path**, not only the repository root
- [x] `pnpm sort-extensions` run — `extensions.toml` and `.gitmodules` sorted
- [x] `vitest run` — 115 tests pass locally

## On the grammar revision

`extension.toml` pins the grammar by SHA, and the queries reference nodes that must exist at that revision. Our CI now checks out `tree-sitter-mvl` at exactly the pinned SHA and loads each `.scm` against it, failing the build on any query error — so a revision that would break highlighting cannot reach this repo.

That check exists because it bit us: the pin briefly referenced a `ghost` node the pinned grammar did not yet have, and since a query error invalidates the entire file, all highlighting went silent. Fixed, and now guarded.
