### PR TITLE
Add HTTP Request Client extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2014,6 +2014,10 @@
 	path = extensions/http
 	url = https://github.com/tie304/zed-http.git
 
+[submodule "extensions/http-request-client"]
+	path = extensions/http-request-client
+	url = https://github.com/feapps/zed-api-client.git
+
 [submodule "extensions/hubbamax-theme"]
 	path = extensions/hubbamax-theme
 	url = https://github.com/agrippa1027/zed-hubbamax.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2066,7 +2066,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.2.0"
+version = "0.2.1"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2056,6 +2056,10 @@ version = "0.1.0"
 submodule = "extensions/http"
 version = "0.0.1"
 
+[http-request-client]
+submodule = "extensions/http-request-client"
+version = "0.1.1"
+
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2195,7 +2195,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.2.4"
+version = "0.2.5"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2066,7 +2066,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.2.1"
+version = "0.2.4"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2058,7 +2058,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.1.2"
+version = "0.1.3"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2058,7 +2058,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.1.1"
+version = "0.1.2"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2066,7 +2066,7 @@ version = "0.0.1"
 
 [http-request-client]
 submodule = "extensions/http-request-client"
-version = "0.1.3"
+version = "0.2.0"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## HTTP Request Client

Syntax highlighting and inline request execution for `.http` / `.rest` files
(REST Client style), backed by a language server.

- Repository: https://github.com/feapps/zed-api-client
- Version: 0.1.1
- License: MIT
- Grammar: fork of `rest-nvim/tree-sitter-http` (public at `feapps/tree-sitter-http`)
- The language server binary is distributed per-platform via GitHub Releases.
