### PR TITLE
Update lucent-blur-theme to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2579,7 +2579,7 @@ version = "0.3.8"
 
 [lucent-blur-theme]
 submodule = "extensions/lucent-blur-theme"
-version = "0.3.0"
+version = "0.4.0"
 
 [lume-theme]
 submodule = "extensions/lume-theme"


### PR DESCRIPTION
## Summary

Updates Lucent Blur from `0.3.0` to `0.4.0`.

This release adds Light, Blur, and Heavy transparency levels to each palette and refines active UI accents, borders, dividers, indent guides, and wrap guides for a softer translucent workspace.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.