### PR TITLE
Adding Garry's Mod Lua language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1734,10 +1734,6 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
-[submodule "extensions/glua"]
-	path = extensions/glua
-	url = https://github.com/darkfated/zed-glua.git
-
 [submodule "extensions/gn"]
 	path = extensions/gn
 	url = https://github.com/dsa28s/zed-gn-language.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1734,6 +1734,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/glua"]
+	path = extensions/glua
+	url = https://github.com/darkfated/zed-glua.git
+
 [submodule "extensions/gn"]
 	path = extensions/gn
 	url = https://github.com/dsa28s/zed-gn-language.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1734,6 +1734,10 @@
 	path = extensions/gleam-theme
 	url = https://github.com/DanielleMaywood/gleam-theme-zed
 
+[submodule "extensions/glua"]
+	path = extensions/glua
+	url = https://github.com/darkfated/zed-glua
+
 [submodule "extensions/gn"]
 	path = extensions/gn
 	url = https://github.com/dsa28s/zed-gn-language.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1771,7 +1771,7 @@ version = "0.2.4"
 
 [glua]
 submodule = "extensions/glua"
-version = "0.2.0"
+version = "0.2.1"
 
 [gn]
 submodule = "extensions/gn"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1771,7 +1771,7 @@ version = "0.2.4"
 
 [glua]
 submodule = "extensions/glua"
-version = "0.1.0"
+version = "0.2.0"
 
 [gn]
 submodule = "extensions/gn"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1769,6 +1769,10 @@ submodule = "extensions/zed"
 path = "extensions/glsl"
 version = "0.2.4"
 
+[glua]
+submodule = "extensions/glua"
+version = "0.1.0"
+
 [gn]
 submodule = "extensions/gn"
 version = "1.4.0"


### PR DESCRIPTION
Garry's Mod is a popular modding platform, similar to Roblox. This PR adds support for developing Garry's Mod projects in Zed

https://github.com/darkfated/zed-glua/

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
