### PR TITLE
Add Code Translate language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -782,8 +782,8 @@
 	path = extensions/code-stats
 	url = https://github.com/maxdeviant/zed-code-stats.git
 
-[submodule "extensions/code-translate"]
-	path = extensions/code-translate
+[submodule "extensions/code-translate-lsp"]
+	path = extensions/code-translate-lsp
 	url = https://github.com/nazzeDe/code-translate.git
 
 [submodule "extensions/codebabel-ztheme-dark"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -782,6 +782,10 @@
 	path = extensions/code-stats
 	url = https://github.com/maxdeviant/zed-code-stats.git
 
+[submodule "extensions/code-translate"]
+	path = extensions/code-translate
+	url = https://github.com/nazzeDe/code-translate.git
+
 [submodule "extensions/codebabel-ztheme-dark"]
 	path = extensions/codebabel-ztheme-dark
 	url = https://github.com/codebabel-appbag/codebabel-ztheme-dark

--- a/extensions.toml
+++ b/extensions.toml
@@ -795,6 +795,11 @@ version = "0.0.5"
 submodule = "extensions/code-stats"
 version = "0.3.0"
 
+[code-translate]
+submodule = "extensions/code-translate"
+path = "extensions/code-translate"
+version = "0.1.0"
+
 [codebabel-ztheme-dark]
 submodule = "extensions/codebabel-ztheme-dark"
 version = "0.0.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -795,8 +795,8 @@ version = "0.0.5"
 submodule = "extensions/code-stats"
 version = "0.3.0"
 
-[code-translate]
-submodule = "extensions/code-translate"
+[code-translate-lsp]
+submodule = "extensions/code-translate-lsp"
 path = "extensions/code-translate"
 version = "0.1.0"
 


### PR DESCRIPTION
## Summary

Adds Code Translate as a Zed extension from the public repository https://github.com/nazzeDe/code-translate.

- Release: https://github.com/nazzeDe/code-translate/releases/tag/v0.1.0
- Extension version: 0.1.0
- Registry entry uses the monorepo path `extensions/code-translate`.
- The repository includes the accepted MIT license at `extensions/code-translate/LICENSE`.

## Validation

- Zed 1.13.1 development-extension installation passed.
- Exact cached asset: `code-translate-lsp-v0.1.0-x86_64-unknown-linux-musl.tar.gz`.
- Hover passed in Rust, TypeScript, Python, and Markdown; visible `abandon`/`hope` Chinese dictionary entries were observed.
- Coexistence passed with rust-analyzer and the TypeScript/Python language services.
- Offline restart passed with the same data directory and a dead proxy; the exact cached server launched from the completion marker.
- No persistent Code Translate installation, protocol, crash, or restart-loop errors were observed.

Automated evidence:
- CI: https://github.com/nazzeDe/code-translate/actions/runs/30521380373
- Six-target preflight: https://github.com/nazzeDe/code-translate/actions/runs/30521631268
- Release workflow: https://github.com/nazzeDe/code-translate/actions/runs/30522065411
- Validation record: `docs/validation/v0.1.0.md` at commit `84d9c9c`.

Registry checks passed locally: `pnpm build`, `pnpm test` (115 tests), `pnpm sort-extensions`, and selected `pnpm package-extensions code-translate` with the official `zed-extension` CLI.