### PR TITLE
Update mcp-server-master-go to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2816,7 +2816,7 @@ version = "0.0.1"
 
 [mcp-server-master-go]
 submodule = "extensions/mcp-server-master-go"
-version = "0.0.1"
+version = "0.0.2"
 
 [mcp-server-memory]
 submodule = "extensions/mcp-server-memory"


### PR DESCRIPTION
Release notes:

https://github.com/aizigao/zed-mcp-server-master-go/releases/tag/v0.0.2