### PR TITLE
Add friendly-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1578,6 +1578,10 @@
 	path = extensions/freshjuice-themes
 	url = https://github.com/freshjuice-dev/zed-themes.git
 
+[submodule "extensions/friendly-snippets"]
+	path = extensions/friendly-snippets
+	url = https://github.com/WynnCr/zed-friendly-snippets.git
+
 [submodule "extensions/frieren-theme"]
 	path = extensions/frieren-theme
 	url = https://github.com/PR454D/frieren-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1605,6 +1605,10 @@ version = "0.0.1"
 submodule = "extensions/freshjuice-themes"
 version = "0.1.0"
 
+[friendly-snippets]
+submodule = "extensions/friendly-snippets"
+version = "0.0.1"
+
 [frieren-theme]
 submodule = "extensions/frieren-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This PR introduces the `friendly-snippets` extension to the Zed extensions registry.
This extension is a full Zed-compatible port of the popular [friendly-snippets](https://github.com/rafamadriz/friendly-snippets) Neovim plugin, providing a comprehensive and curated collection of code snippets for a wide variety of languages and frameworks.

**Highlights:**
  - Provides snippets for over 100 different languages and tools out of the box.
  - Descriptions have been injected with inline code previews, so developers can see exactly what the snippet expands into directly from Zed's autocomplete side-popup.