### PR TITLE
Add cendre theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -658,6 +658,10 @@
 	path = extensions/cem
 	url = https://github.com/bennypowers/cem.git
 
+[submodule "extensions/cendre-theme"]
+	path = extensions/cendre-theme
+	url = https://github.com/Aejkatappaja/cendre.git
+
 [submodule "extensions/cfengine"]
 	path = extensions/cfengine
 	url = https://github.com/olehermanse/zed-cfengine.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -669,6 +669,11 @@ submodule = "extensions/cem"
 path = "extensions/zed"
 version = "0.11.0"
 
+[cendre-theme]
+submodule = "extensions/cendre-theme"
+path = "extras/zed"
+version = "0.1.0"
+
 [cfengine]
 submodule = "extensions/cfengine"
 version = "1.0.5"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

A dark theme whose five hues were each computed from something measurable in a wood fire rather than chosen: Planck's law at 1300 K for the coals, and published emission wavelengths for the rest, pushed through the CIE 1931 colour matching functions into OKLCH. Three variants ship in the one extension, differing only in the depth of the ground under the same pigments.

The extension lives at `extras/zed` inside the colorscheme repository, via the `path` field, so the theme stays generated from the same palette table as the Neovim, terminal and CLI ports beside it. A test re-renders every one of them and fails if a committed file has drifted, which is what keeps them from disagreeing about a colour.

Tested locally as a dev extension before opening this. All 142 keys of the v0.2.0 style schema are populated, and every value traces back to a palette token.

Repository: https://github.com/Aejkatappaja/cendre
Licence: MIT, at the repository root.
