### PR TITLE
Add RouterOS Script extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4062,6 +4062,10 @@
 	path = extensions/roto
 	url = https://github.com/tertsdiepraam/zed-extension-roto.git
 
+[submodule "extensions/routeros"]
+	path = extensions/routeros
+	url = https://github.com/DamirManyapov/zed-routeros.git
+
 [submodule "extensions/rover"]
 	path = extensions/rover
 	url = https://github.com/rover-app/zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.5.0"
+version = "0.5.1"
 
 [rover]
 submodule = "extensions/rover"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4134,6 +4134,10 @@ version = "0.0.1"
 submodule = "extensions/roto"
 version = "0.1.0"
 
+[routeros]
+submodule = "extensions/routeros"
+version = "0.1.0"
+
 [rover]
 submodule = "extensions/rover"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.2.1"
+version = "0.3.0"
 
 [rover]
 submodule = "extensions/rover"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.1.0"
+version = "0.2.0"
 
 [rover]
 submodule = "extensions/rover"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.2.0"
+version = "0.2.1"
 
 [rover]
 submodule = "extensions/rover"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.3.0"
+version = "0.5.0"
 
 [rover]
 submodule = "extensions/rover"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4136,7 +4136,7 @@ version = "0.1.0"
 
 [routeros]
 submodule = "extensions/routeros"
-version = "0.5.1"
+version = "0.8.0"
 
 [rover]
 submodule = "extensions/rover"


### PR DESCRIPTION
Adds MikroTik RouterOS `.rsc` support — syntax highlighting, offline completion and diagnostics.

- Extension: https://github.com/DamirManyapov/zed-routeros (MIT)
- Grammar: https://github.com/DamirManyapov/tree-sitter-routeros (MIT)
- Language server: https://github.com/DamirManyapov/routeros-lsp (MIT)

### Highlighting

RouterOS exports have a few properties that break generic highlighters, and the grammar is built around them:

- Backslash line continuations, including ones that split a quoted string in half
- CRLF line endings, which every export uses
- Nested properties — `channel.frequency=5180`, and a leading dot (`.mode=ap`) continuing the previous group
- Both path spellings: `/ip firewall filter` (exports) and `/ip/firewall/filter` (scripts), with an optional inline command
- Slashes inside values, so `address=0.0.0.0/8` stays a value rather than a path

Scripting is covered as well: `:local`/`:global`, `:if`/`do=`/`else=`, `:foreach`, `:for`, `:while`, command substitution, parenthesized expressions, and array/record literals. Also outline navigation by config section, folding, bracket matching and auto-indent.

### Completion and diagnostics

The language server is downloaded from GitHub Releases on first use — nothing is bundled with the extension. It carries its own command tree and value types, so everything works offline, with no router or credentials involved.

Completion covers command paths and their parameters, and notes when a parameter is newer than most releases (`vrf · 7.21+`). Diagnostics report unknown path segments, values that contradict their parameter's type (`mtu=78000` → `expected 'auto' or integer 0..65536`), a property set twice on one command, and undeclared variables under RouterOS scoping rules.

The command tree merges the 60 per-version trees published by `tikoci/restraml` (Unlicense); value types are harvested from a live device at build time.

Highlighting never depends on the server and keeps working if it is disabled.

### Testing

Grammar parses three real-world exports (RouterOS 7.20–7.21, up to 15k lines) with zero errors, plus its own corpus. Diagnostics produce no false positives on those same exports while still catching genuine mistakes. 38 unit tests. Tested locally as a dev extension.