### PR TITLE
Add dep-beacon 1.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1094,6 +1094,10 @@
 	path = extensions/deno
 	url = https://github.com/zed-extensions/deno.git
 
+[submodule "extensions/dep-beacon"]
+	path = extensions/dep-beacon
+	url = https://github.com/santi020k/dep-beacon
+
 [submodule "extensions/dependi"]
 	path = extensions/dependi
 	url = https://github.com/mpiton/zed-dependi.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1112,6 +1112,11 @@ version = "0.0.2"
 submodule = "extensions/deno"
 version = "0.1.2"
 
+[dep-beacon]
+submodule = "extensions/dep-beacon"
+path = "extensions/dep-beacon"
+version = "1.0.1"
+
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"


### PR DESCRIPTION
Publishes dep-beacon 1.0.1.\n\nSource: https://github.com/santi020k/dep-beacon/tree/f35e66e78c746648f3715fbcb9348c98bcda96ce/extensions/dep-beacon