### PR TITLE
Bump laravel to 0.7.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2430,7 +2430,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.6.1"
+version = "0.7.0"
 
 [laravel-official]
 submodule = "extensions/laravel-official"


### PR DESCRIPTION
Bumps `laravel` to v0.7.0.

This PR refactors the branding of the extension to `Laravel (Community Edition)`. 

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.0