### PR TITLE
Update MoonBit to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3079,7 +3079,7 @@ version = "0.2.1"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.1.7"
+version = "0.2.0"
 
 [moonlight]
 submodule = "extensions/moonlight"


### PR DESCRIPTION
## Summary

Updates the MoonBit extension to **v0.2.0**.

### Highlights

- migrate to the native `moon lsp` language server
- remove the Node.js/npm dependency
- update the pinned upstream Tree-sitter grammar
- simplify the extension implementation
- update documentation and metadata

### Validation

- `cargo check`
- Tree-sitter query validation
- syntax fixture parsing
- local testing in Zed