### PR TITLE
Add Sagittarius A* theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4118,6 +4118,10 @@
 	path = extensions/sagemath
 	url = https://github.com/rot256/zed-sagemath
 
+[submodule "extensions/sagittarius-a-star-theme"]
+	path = extensions/sagittarius-a-star-theme
+	url = https://github.com/breidenbach0/Sagittarius-A-star.git
+
 [submodule "extensions/salesforce"]
 	path = extensions/salesforce
 	url = https://github.com/Damecek/zed-salesforce-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4191,6 +4191,10 @@ version = "2.0.0"
 submodule = "extensions/sagemath"
 version = "0.1.0"
 
+[sagittarius-a-star-theme]
+submodule = "extensions/sagittarius-a-star-theme"
+version = "0.1.0"
+
 [salesforce]
 submodule = "extensions/salesforce"
 version = "0.0.4"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

- Add the Sagittarius A* theme extension as an HTTPS submodule.
- Register `sagittarius-a-star-theme` at version `0.1.0`.
- Provide light and dark blurred variants with black-and-white UI surfaces and colorful syntax highlighting.

## Why

This makes the Sagittarius A* theme available through Zed's extension registry instead of requiring users to install it as a local development extension.

## User impact

After this pull request is merged and published, users can find `Sagittarius A*` directly from Zed's Extensions page and install either the light or dark variant.

## Validation

- Installed and tested locally as a Zed development extension.
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` — 115 tests passed.
- Validated `extension.toml` metadata and both theme variants in `themes/sagittarius-a-star.json`.
