### PR TITLE
Add Mace language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1946,6 +1946,11 @@
 	path = extensions/lydia
 	url = https://github.com/dimitrisnl/lydia-zed-theme
 
+[submodule "extensions/mace"]
+	path = extensions/mace
+	url = https://github.com/louiss0/zed-extension-mace.git
+	branch = release/1.0.0
+
 [submodule "extensions/mach"]
 	path = extensions/mach
 	url = https://github.com/octalide/mach-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1977,6 +1977,10 @@ version = "0.6.1"
 submodule = "extensions/lydia"
 version = "0.0.4"
 
+[mace]
+submodule = "extensions/mace"
+version = "1.0.0"
+
 [mach]
 submodule = "extensions/mach"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- Add the first Mace language extension to the Zed registry at version 1.0.0.
- Track the public extension release branch and Tree-sitter grammar revision.

Mace is a new deterministic, strongly typed configuration language created in 2026. This is its first stable release, providing explicit schemas, predictable evaluation, and editor support for configuration authoring. The extension supplies syntax highlighting, snippets, and the Mace language server while downloading the released Mace binary when needed.

## Verification

- `tree-sitter test` — 132 corpus cases passed.
- `cargo test` and `cargo check` passed in the extension repository.
- The extension repository includes an accepted MIT license.
