### PR TITLE
Add Cursor Theme Pack 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -946,6 +946,10 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
+[submodule "extensions/cursor-pack-theme"]
+	path = extensions/cursor-pack-theme
+	url = https://github.com/nexmoe/cursor-themes-for-zed.git
+
 [submodule "extensions/custom-code-folding-lsp"]
 	path = extensions/custom-code-folding-lsp
 	url = https://github.com/tomchor/zed-custom-code-folding.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -946,8 +946,8 @@
 	path = extensions/cursor-dark-theme
 	url = https://github.com/loosheng/zed-cursor-dark-theme.git
 
-[submodule "extensions/cursor-pack-theme"]
-	path = extensions/cursor-pack-theme
+[submodule "extensions/cursor-theme-pack"]
+	path = extensions/cursor-theme-pack
 	url = https://github.com/nexmoe/cursor-themes-for-zed.git
 
 [submodule "extensions/custom-code-folding-lsp"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -964,6 +964,10 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
+[cursor-pack-theme]
+submodule = "extensions/cursor-pack-theme"
+version = "2.0.0"
+
 [custom-code-folding-lsp]
 submodule = "extensions/custom-code-folding-lsp"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -964,8 +964,8 @@ version = "1.1.2"
 submodule = "extensions/cursor-dark-theme"
 version = "0.0.1"
 
-[cursor-pack-theme]
-submodule = "extensions/cursor-pack-theme"
+[cursor-theme-pack]
+submodule = "extensions/cursor-theme-pack"
 version = "2.0.0"
 
 [custom-code-folding-lsp]


### PR DESCRIPTION
Adds Cursor Theme Pack v2.0.0 as an all-in-one extension containing:

- Cursor Dark
- Cursor Dark Midnight
- Cursor Dark High Contrast
- Cursor Light

Unlike the existing individual Cursor-inspired extensions, this package provides the complete four-theme family from one consistently generated source, including the Light and High Contrast variants.

This resubmission addresses the publishing issues in #5422:

- uses the theme-specific `cursor-theme-pack` extension ID
- uses the matching `extensions/cursor-theme-pack` submodule path
- keeps `.gitmodules` and `extensions.toml` sorted with `pnpm sort-extensions`
- points to a public HTTPS repository commit on its `main` branch
- includes an accepted MIT license at the extension root

Validation:

- `bun run check` in the extension repository (`Checked 4 generated themes`)
- `pnpm sort-extensions`
- `pnpm test` (`115 passed`)
- `pnpm build`
- `git diff --check`

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.