### PR TITLE
Add Papyrus language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3530,6 +3530,10 @@
 	path = extensions/papercolor
 	url = https://github.com/emirror-de/papercolor-zed.git
 
+[submodule "extensions/papyrus"]
+	path = extensions/papyrus
+	url = https://github.com/monster-cookie/zed-papyrus.git
+
 [submodule "extensions/paraiso"]
 	path = extensions/paraiso
 	url = https://github.com/treffynnon/zed-Paraiso.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3588,6 +3588,10 @@ version = "1.0.0"
 submodule = "extensions/papercolor"
 version = "0.2.0"
 
+[papyrus]
+submodule = "extensions/papyrus"
+version = "0.1.0"
+
 [paraiso]
 submodule = "extensions/paraiso"
 version = "1.0.2"


### PR DESCRIPTION
Adds Papyrus language support for Starfield, Skyrim Anniversary Edition, and Fallout 4.

The extension provides syntax highlighting, comments, indentation, bracket matching, outline symbols, text-object queries, and syntax diagnostics through papyrus-language-server.

The extension and automatic Windows x64 language-server download were tested successfully in Zed. The language server also publishes Linux x64, macOS Intel, and macOS Apple Silicon binaries from its v0.1.0 release.

Extension repository:
https://github.com/monster-cookie/zed-papyrus

Language-server repository:
https://github.com/monster-cookie/papyrus-language-server