### PR TITLE
Add Nord Wave theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3222,6 +3222,10 @@
 	path = extensions/nord
 	url = https://github.com/mikasius/zed-nord-theme.git
 
+[submodule "extensions/nord-wave-theme"]
+	path = extensions/nord-wave-theme
+	url = https://github.com/R1N-K0/zed-nord-wave.git
+
 [submodule "extensions/nordic-nvim-theme"]
 	path = extensions/nordic-nvim-theme
 	url = https://github.com/kislikjeka/zed-theme-nordic

--- a/extensions.toml
+++ b/extensions.toml
@@ -3278,6 +3278,10 @@ version = "0.0.3"
 submodule = "extensions/nord"
 version = "0.1.7"
 
+[nord-wave-theme]
+submodule = "extensions/nord-wave-theme"
+version = "0.1.0"
+
 [nordic-nvim-theme]
 submodule = "extensions/nordic-nvim-theme"
 version = "0.0.3"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Nord Wave** — a dark theme that swaps Nord's blue-tinted Polar Night for a flat neutral `#212121` while keeping the Nord accent palette.

Repository: https://github.com/R1N-K0/zed-nord-wave

This is a port of the [Nord Wave](https://github.com/dimitrisnl/nord-wave) VS Code theme by Dimitrios Lytras. The upstream repository publishes no licence file, so the MIT licence in this port covers only the port itself, and `LICENSE` records that all rights in the original theme remain with its author. Attribution and the deviations Zed's theme model required are documented in the README.

Tested locally as a dev extension.