### PR TITLE
Add Publora extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3790,6 +3790,10 @@
 	path = extensions/psalm
 	url = https://github.com/sebcode/psalm-zed.git
 
+[submodule "extensions/publora"]
+	path = extensions/publora
+	url = https://github.com/publora-team/zed-publora.git
+
 [submodule "extensions/pug"]
 	path = extensions/pug
 	url = https://github.com/Baw-Appie/zed-pug

--- a/extensions.toml
+++ b/extensions.toml
@@ -3857,6 +3857,10 @@ version = "0.3.2"
 submodule = "extensions/psalm"
 version = "0.0.2"
 
+[publora]
+submodule = "extensions/publora"
+version = "0.1.0"
+
 [pug]
 submodule = "extensions/pug"
 version = "0.0.3"


### PR DESCRIPTION
Adds **Publora**, a context server extension for publishing and scheduling social media posts from Zed's agent — LinkedIn, X, Instagram, Threads, TikTok, YouTube, Facebook, Bluesky, Mastodon and Telegram.

Repository: https://github.com/publora-team/zed-publora (MIT)

**How it works.** Publora runs a hosted MCP server over streamable HTTP, and Zed launches context servers over stdio, so the extension runs [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) as a proxy — Zed installs and updates that npm package itself, the same pattern used by other remote MCP extensions here. Authentication is OAuth 2.1 with PKCE and dynamic client registration: the browser opens once on first start, and later launches reconnect silently. There is no API key to paste into settings.

**Tested locally as a dev extension** before opening this PR, on Zed 1.13.2 (macOS):

- built for `wasm32-wasip1` and converted to a component with `wasm-tools component new`
- Zed loads it without errors (`extensions updated. loading 2`)
- with `context_servers.publora` enabled, Zed installed `mcp-remote` into its work directory and started the server: `node .../extensions/work/publora/node_modules/mcp-remote/dist/proxy.js https://mcp.publora.com/mcp`, and the process stayed connected
- the OAuth handshake to `mcp.publora.com` completes and the token is cached, so subsequent starts need no interaction

To be precise about what wasn't covered: I verified the server starts and connects, not an end-to-end tool call from the agent panel, since that needs a configured model provider.

Publora is a commercial service with a free tier; the extension itself is free and open source.