### PR TITLE
Add Dark Dracula theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1022,6 +1022,10 @@
 	path = extensions/dark-discord
 	url = https://github.com/zangetsu02/zed-discord-theme.git
 
+[submodule "extensions/dark-dracula-theme"]
+	path = extensions/dark-dracula-theme
+	url = https://github.com/everton-dgn/zed-dark-dracula.git
+
 [submodule "extensions/dark-glass-theme"]
 	path = extensions/dark-glass-theme
 	url = https://github.com/MagnusPladsen/dark-glass-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1040,6 +1040,10 @@ version = "0.0.4"
 submodule = "extensions/dark-discord"
 version = "2.0.0"
 
+[dark-dracula-theme]
+submodule = "extensions/dark-dracula-theme"
+version = "1.0.0"
+
 [dark-glass-theme]
 submodule = "extensions/dark-glass-theme"
 version = "0.3.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Dark Dracula**, a darker take on the Dracula palette.

Repository: https://github.com/everton-dgn/zed-dark-dracula

## How it differs from the existing Dracula themes

The catalog already has `dracula`, `dracula-flat`, `dark-material-dracula` and
`sweet-dracula`. Dark Dracula is derived from Sweet Dracula (MIT, attributed in
THIRD_PARTY_NOTICES.md) and changes two things the existing ones do not:

- Deeper editor and panel backgrounds, for low-light and OLED displays.
- Rebalanced contrast across syntax tokens, so comments and punctuation recede
  while types and functions stay legible against the darker base.

These are palette-wide changes rather than fixes that fit inside Sweet Dracula
without altering its identity, which is why this is a separate extension.

## Testing

Installed and used locally as a dev extension in Zed.