### PR TITLE
Update greycat to v0.1.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1800,7 +1800,7 @@
 
 [submodule "extensions/greycat"]
 	path = extensions/greycat
-	url = https://github.com/maxleiko/zed-greycat-extension.git
+	url = https://hub.datathings.com/greycat-oss/zed-greycat-extension.git
 
 [submodule "extensions/grimaces-birthday"]
 	path = extensions/grimaces-birthday

--- a/extensions.toml
+++ b/extensions.toml
@@ -1835,7 +1835,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.7"
+version = "0.1.9"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
Bumps the `greycat` extension to v0.1.9.

The extension and its `tree-sitter-greycat` grammar are hosted on https://hub.datathings.com/greycat-oss. This PR also updates the `extensions/greycat` submodule URL to that host; the previous GitHub mirror is retired.

Supersedes #6863.