### PR TITLE
Add Fennel v0.2.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1434,6 +1434,10 @@
 	path = extensions/fedaykin-themes
 	url = https://github.com/btriapitsyn/zed-fedaykin-themes.git
 
+[submodule "extensions/fennel-zed"]
+	path = extensions/fennel-zed
+	url = https://github.com/notpeter/fennel-zed
+
 [submodule "extensions/ferret"]
 	path = extensions/ferret
 	url = https://github.com/Ferret-Language/ferret-language-support.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1434,8 +1434,8 @@
 	path = extensions/fedaykin-themes
 	url = https://github.com/btriapitsyn/zed-fedaykin-themes.git
 
-[submodule "extensions/fennel-zed"]
-	path = extensions/fennel-zed
+[submodule "extensions/fennel"]
+	path = extensions/fennel
 	url = https://github.com/notpeter/fennel-zed
 
 [submodule "extensions/ferret"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1460,6 +1460,10 @@ version = "0.2.0"
 submodule = "extensions/fedaykin-themes"
 version = "1.0.0"
 
+[fennel]
+submodule = "extensions/fennel"
+version = "0.2.0"
+
 [ferret]
 submodule = "extensions/ferret"
 version = "0.0.11"


### PR DESCRIPTION
Adds fennel language support (tree-sitter, lsp) superseding the existing pulled [fennel extension](https://zed.dev/extensions/fennel). 

- Previously: https://github.com/zed-industries/extensions/pull/2075
- Closes: https://github.com/zed-extensions/lua/issues/55
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
