### PR TITLE
Add Windows Batch language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5214,6 +5214,10 @@
 	path = extensions/wikitext
 	url = https://github.com/Benjamin-Davies/zed-wikitext.git
 
+[submodule "extensions/windows-batch"]
+	path = extensions/windows-batch
+	url = https://github.com/pleahmacaka/zed-batch.git
+
 [submodule "extensions/wit"]
 	path = extensions/wit
 	url = https://github.com/valentinegb/zed-wit.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5308,6 +5308,10 @@ version = "0.1.0"
 submodule = "extensions/wikitext"
 version = "0.0.1"
 
+[windows-batch]
+submodule = "extensions/windows-batch"
+version = "0.2.0"
+
 [wit]
 submodule = "extensions/wit"
 version = "0.4.0"


### PR DESCRIPTION
Windows Batch (.bat, .cmd) syntax highlighting via [`wharflab/tree-sitter-batch`](https://github.com/wharflab/tree-sitter-batch). LSP via [`rech-editor-batch`](https://github.com/RechInformatica/rech-editor-batch).

I've used this snippet for test:
```batch
@echo off
REM sample used to eyeball highlighting
setlocal enabledelayedexpansion

set "NAME=world"
set /a COUNT=1+2

if not "%NAME%"=="" (
    echo Hello %NAME% %CD% !COUNT!
) else (
    goto :fail
)

for /f "tokens=1,2" %%a in ('dir /b') do (
    call :log %%a
)

dir > nul 2>&1 && echo ok || echo failed

:log
echo [%TIME%] %~1
exit /b 0

:fail
exit /b 1
```

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
