### PR TITLE
Add robots.txt language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4034,6 +4034,10 @@
 	path = extensions/robot-framework
 	url = https://github.com/mendes-jose/zed-robot.git
 
+[submodule "extensions/robots-txt"]
+	path = extensions/robots-txt
+	url = https://github.com/pleahmacaka/zed-robots-txt.git
+
 [submodule "extensions/roc"]
 	path = extensions/roc
 	url = https://github.com/h2000/zed-roc.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4106,6 +4106,10 @@ version = "0.1.2"
 submodule = "extensions/robot-framework"
 version = "0.0.1"
 
+[robots-txt]
+submodule = "extensions/robots-txt"
+version = "0.1.0"
+
 [roc]
 submodule = "extensions/roc"
 version = "0.1.2"


### PR DESCRIPTION
robots.txt syntax highlighting via [`opa-oz/tree-sitter-robots-txt`](https://github.com/opa-oz/tree-sitter-robots-txt).

## Preview
<img width="380" height="328" alt="{69A62E3E-9AE0-448F-BE0E-C1984C7CB32F}" src="https://github.com/user-attachments/assets/37da2383-1629-406d-9efe-07464d30f5c8" />


- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.