### PR TITLE
Add Quint extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3892,7 +3892,7 @@
 
 [submodule "extensions/quint"]
 	path = extensions/quint
-	url = https://github.com/fhalim/quint.git
+	url = https://github.com/fhalim/zed-quint.git
 
 [submodule "extensions/r"]
 	path = extensions/r

--- a/.gitmodules
+++ b/.gitmodules
@@ -3890,6 +3890,10 @@
 	path = extensions/quill
 	url = https://github.com/CraftQuill/zed-theme-quill.git
 
+[submodule "extensions/quint"]
+	path = extensions/quint
+	url = https://github.com/fhalim/quint.git
+
 [submodule "extensions/r"]
 	path = extensions/r
 	url = https://github.com/ocsmit/zed-r.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3958,6 +3958,11 @@ version = "0.8.0"
 submodule = "extensions/quill"
 version = "0.2.2"
 
+[quint]
+submodule = "extensions/quint"
+path = "editor-plugins/zed"
+version = "0.1.0"
+
 [r]
 submodule = "extensions/r"
 version = "0.2.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3960,7 +3960,6 @@ version = "0.2.2"
 
 [quint]
 submodule = "extensions/quint"
-path = "editor-plugins/zed"
 version = "0.1.0"
 
 [r]


### PR DESCRIPTION
## Summary

Adds the [Quint](https://quint-lang.org) specification language as a Zed extension:

- Syntax highlighting via the [`gruhn/tree-sitter-quint`](https://github.com/gruhn/tree-sitter-quint) grammar — the same grammar used by Helix's built-in Quint support, pinned to a specific commit on its `release` branch.
- `quint-language-server` integration. The extension does not bundle a language server binary: it resolves an explicit Zed settings override, then `quint-language-server` on `$PATH`, and only falls back to installing `@informalsystems/quint-language-server` from npm itself.

The extension source is at [`fhalim/zed-quint`](https://github.com/fhalim/zed-quint), a standalone repo maintained by me. It was originally developed in-tree inside the [Quint monorepo](https://github.com/quint-co/quint) (`editor-plugins/zed/`, alongside the existing Emacs/Vim plugins there) via [quint-co/quint#2007](https://github.com/quint-co/quint/pull/2007), but that PR is closed: the monorepo's root `.gitattributes` declares `*.mp4 filter=lfs` for unrelated demo videos, which fails this registry's no-LFS submodule check regardless of `extensions.toml`'s `path` field (the check runs `git submodule foreach` at the submodule root, ignoring `path`). Splitting the extension into its own repo was the only way to satisfy that check, so this PR submodules `fhalim/zed-quint` directly with no `path` needed.

## Compliance with publishing prerequisites

- ID/name (`quint`) contain none of the reserved words (`zed`, `Zed`, `extension`)
- `extension.toml` has all required fields: `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- No bundled language server binary (see above)
- No theme/icon theme bundled
- Licensed under Apache 2.0 (`LICENSE` at the `fhalim/zed-quint` repo root — an accepted license)
- No Git LFS anywhere in the submoduled repo (verified locally with the same `git submodule foreach` check CI runs)
- `pnpm sort-extensions` run; `extensions.toml`/`.gitmodules` are in sorted order
- No existing extension provides Quint support

## Test plan

- [x] `cargo build --release --target wasm32-wasip1` compiles cleanly
- [x] `zed: install dev extension`: grammar builds and loads without error
- [x] Opened a `.qnt` file (`examples/tutorials/booleans.qnt` from quint-co/quint): language identified as Quint, syntax highlighting renders correctly (keywords, constants, comments, function names)
- [x] Outline/breadcrumb navigation works (confirmed nested `booleansLesson › myAnd4` breadcrumb, built from `outline.scm`)
- [x] Reproduced CI's no-LFS submodule check and the license validator (`retrieveLicenseCandidates`/`validateLicense`) locally against the new submodule — both pass
- [ ] `zed: open log`: confirm `quint-language-server` starts, diagnostics/hover/go-to-definition work
- [ ] Exercise all three LSP resolution paths (PATH binary, npm fallback, explicit settings override)

Opening as draft until the remaining LSP checks above are done and the CLA is signed for `fhalim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAztELiZAeTYq9fbAJY65j
