### PR TITLE
Bump laravel to 0.7.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2434,7 +2434,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.6.1"
+version = "0.7.1"
 
 [laravel-official]
 submodule = "extensions/laravel-official"


### PR DESCRIPTION
Bumps `laravel` to v0.7.1.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.1