### PR TITLE
Add VASP language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5054,6 +5054,10 @@
 	path = extensions/vapor-theme
 	url = https://github.com/felipetesc/vapor-theme.git
 
+[submodule "extensions/vasp"]
+	path = extensions/vasp
+	url = https://github.com/ECHOUniverse/zed-vasp.git
+
 [submodule "extensions/vcard"]
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5147,6 +5147,10 @@ version = "2.0.0"
 submodule = "extensions/vapor-theme"
 version = "0.0.2"
 
+[vasp]
+submodule = "extensions/vasp"
+version = "0.1.0"
+
 [vcard]
 submodule = "extensions/vcard"
 version = "0.3.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5149,7 +5149,7 @@ version = "0.0.2"
 
 [vasp]
 submodule = "extensions/vasp"
-version = "0.1.0"
+version = "0.2.0"
 
 [vcard]
 submodule = "extensions/vcard"


### PR DESCRIPTION
Adds the [VASP](https://www.vasp.at/) language extension (`vasp` v0.2.0) for editing VASP input files.

**What it provides**
- Syntax highlighting for `INCAR` / `POSCAR` / `CONTCAR` / `KPOINTS` via three dedicated tree-sitter grammars — including VASP 6.5 `IMAGE_N { … }` per-image blocks and slash-namespaced tags (`KERNEL_TRUNCATION/*`, `PLUGINS/*`)
- `vasp-lsp` language server (downloaded from GitHub Releases, SHA-256 verified at runtime, never bundled):
  - Diagnostics with rule codes (E101–H321): unparseable lines, wrong value types, unknown/deprecated/duplicate tags, structure errors
  - End-of-line inlay hints for POSCAR/CONTCAR/KPOINTS
  - Hover docs and completion for **all 610 official INCAR tags** (VASP Wiki snapshot-verified; parameterized tags like `LIBXC1_Pn` and namespaced tags included)

**Compliance**
- `schema_version = 1`; id `vasp`, name `VASP` (no `zed-`/`extension` tokens)
- MIT license at extension root (content-validated by CI)
- Language server not shipped in the extension (downloaded + verified at runtime)
- Grammar `rev`s pinned; `src/parser.c` committed in each grammar repository
- `extensions.toml` version `0.2.0` matches `extension.toml`

All checks (package / danger / CLA) green. Full pre-publish verification checklist: `docs/发布核验清单.md` in the extension repo.
