### PR TITLE
Add httpYac extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2022,6 +2022,10 @@
 	path = extensions/http
 	url = https://github.com/tie304/zed-http.git
 
+[submodule "extensions/httpyac"]
+	path = extensions/httpyac
+	url = https://github.com/sidux/httpyac-zed.git
+
 [submodule "extensions/hubbamax-theme"]
 	path = extensions/hubbamax-theme
 	url = https://github.com/agrippa1027/zed-hubbamax.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2064,6 +2064,10 @@ version = "0.1.0"
 submodule = "extensions/http"
 version = "0.0.1"
 
+[httpyac]
+submodule = "extensions/httpyac"
+version = "0.2.5"
+
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the httpYac extension for IntelliJ-compatible `.http` and `.rest` requests.

- Syntax highlighting, runnables, and snippets
- IntelliJ-compatible public/private environments
- Environment and variable navigation and diagnostics
- Colored JSON response output

Tested locally as a development extension. `npm run check` passes in the extension repository; the registry build and 115 tests also pass.