### PR TITLE
add intellij-lsp-zed extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5409,3 +5409,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/hlucas13/intellij-lsp-zed
+	branch = main

--- a/extensions.toml
+++ b/extensions.toml
@@ -2148,6 +2148,10 @@ version = "0.0.1"
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"
 
+[intellij-lsp]
+submodule = "extensions/intellij-lsp"
+version = "0.1.0"
+
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Description

Adds **IntelliJ LSP** — a language server extension that brings JetBrains IntelliJ IDEA's Java and Kotlin intelligence to Zed.

**Zero setup required.** The extension automatically downloads and installs the server on first launch. No scripts, no manual configuration.

Features: code completion, navigation, refactorings, inspections, and quick-fixes for Maven, Gradle, and Bazel projects. Multi-platform (macOS, Linux, Windows).

- **Repository**: https://github.com/hlucas13/intellij-lsp-zed
- **Languages**: Java, Kotlin
- **License**: MIT (extension) / JetBrains EULA (server, free during preview)

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
