### PR TITLE
Add radical-reborn-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3898,6 +3898,10 @@
 	path = extensions/racket
 	url = https://github.com/zed-extensions/racket.git
 
+[submodule "extensions/radical-reborn-theme"]
+	path = extensions/radical-reborn-theme
+	url = https://github.com/AquaOctet/radical-reborn
+
 [submodule "extensions/railgun"]
 	path = extensions/railgun
 	url = https://github.com/Al-Pharaday/zed-theme-railgun

--- a/extensions.toml
+++ b/extensions.toml
@@ -3966,6 +3966,10 @@ version = "0.2.5"
 submodule = "extensions/racket"
 version = "0.1.1"
 
+[radical-reborn-theme]
+submodule = "extensions/radical-reborn-theme"
+version = "0.1.1"
+
 [railgun]
 submodule = "extensions/railgun"
 version = "1.0.1"


### PR DESCRIPTION
Adds Radical Reborn, a retro-futuristic dark theme — a maintained fork of Dan Hedgecock's Radical (VSCode), ported to Zed.

Repo: https://github.com/AquaOctet/radical-reborn (MIT, pinned at v0.1.1)
Theme JSON validates against the v0.2.0 schema.