### PR TITLE
Add snapcode extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4446,8 +4446,8 @@
 	path = extensions/snakemake
 	url = https://github.com/lvignoli/zed-snakemake
 
-[submodule "extensions/snapcod"]
-	path = extensions/snapcod
+[submodule "extensions/snapcode"]
+	path = extensions/snapcode
 	url = https://github.com/mishaldotrs/snapcode.git
 
 [submodule "extensions/snazzy"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4446,6 +4446,10 @@
 	path = extensions/snakemake
 	url = https://github.com/lvignoli/zed-snakemake
 
+[submodule "extensions/snapcod"]
+	path = extensions/snapcod
+	url = https://github.com/mishaldotrs/snapcode.git
+
 [submodule "extensions/snazzy"]
 	path = extensions/snazzy
 	url = https://github.com/Eivs/zed-snazzy

--- a/extensions.toml
+++ b/extensions.toml
@@ -4526,6 +4526,10 @@ version = "1.1.1"
 submodule = "extensions/snakemake"
 version = "0.1.0"
 
+[snapcode]
+submodule = "extensions/snapcode"
+version = "0.1.0"
+
 [snazzy]
 submodule = "extensions/snazzy"
 version = "0.1.3"


### PR DESCRIPTION
# 📸 Snapcode — Polaroid for your code

This PR adds **snapcode**, a tool that takes beautiful, shareable screenshots of
selected code directly from the editor — inspired by
[Polacode](https://github.com/octref/polacode) for VS Code.

**Repository:** https://github.com/mishaldotrs/snapcode

![preview](https://raw.githubusercontent.com/mishaldotrs/snapcode/main/assets/preview.png)

## What it does

Select code → open code actions (`ctrl-.` / `cmd-.`) → **📸 Snapcode: snap
selection as PNG/SVG**. A polished, syntax-highlighted image (gradient backdrop,
window chrome with traffic lights, drop shadow, optional line numbers) is saved
to the workspace root and opened in the editor. Registered for ~45 languages.

## How it works

Since extensions can't use webviews/DOM (Polacode's approach), the rendering is
done by a small companion language server, `snapcode-ls`, which provides the
code actions and renders images via [syntect](https://github.com/trishume/syntect)
(highlighting) + generated SVG + [resvg](https://github.com/linebender/resvg)
(PNG rasterization). JetBrains Mono is bundled (OFL) for identical output on
every machine.

Per the guidelines, the server binary is **not** shipped with the extension:
it is downloaded from the repo's [GitHub releases](https://github.com/mishaldotrs/snapcode/releases)
(Linux/macOS x86_64 + aarch64, Windows x86_64), with fallbacks to a
`snapcode-ls` binary on `PATH` or an explicit path via `lsp.snapcode-ls.binary.path`.

## Checklist

- [x] Tested locally as a dev extension (Linux)
- [x] Unit tests + end-to-end LSP smoke test in the repo
- [x] MIT licensed (`LICENSE` at repo root)
- [x] Extension ID/name contain no forbidden words
- [x] Pre-built server binaries published for all supported platforms
- [x] `pnpm sort-extensions` run
