### PR TITLE
Add URLs-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4930,6 +4930,10 @@
 	path = extensions/urdf
 	url = https://github.com/MorningFrog/zed-urdf.git
 
+[submodule "extensions/urls-le"]
+	path = extensions/urls-le
+	url = https://github.com/nolindnaidoo/urls-le.git
+
 [submodule "extensions/usd"]
 	path = extensions/usd
 	url = https://github.com/elkraneo/zed-usd.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5021,6 +5021,11 @@ version = "0.1.6"
 submodule = "extensions/urdf"
 version = "0.1.0"
 
+[urls-le]
+submodule = "extensions/urls-le"
+path = "zed"
+version = "2.2.1"
+
 [usd]
 submodule = "extensions/usd"
 version = "0.1.0"


### PR DESCRIPTION
Adds `urls-le`, a context server that extracts URLs from documentation, configuration and code — each with its protocol and 1-based line and column.

It wraps the extraction engine of the [URLs-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.urls-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no extraction logic in the crate. The server it starts is published as [`urls-le-mcp`](https://www.npmjs.com/package/urls-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/urls-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_urls(content, format?, filename?, dedupe?, maxResults?)`

Supports Markdown, HTML, CSS, JavaScript, TypeScript, JSON, YAML, Properties, TOML, INI and XML. Results are capped at 500 by default with `meta.truncated`, so a large file cannot flood the agent's context window.

No network access and no filesystem access — content goes in, structured data comes out.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.
- Verified locally as a dev extension in Zed: the server starts, appears under MCP Servers, and the tool returns results in the agent panel.
