### PR TITLE
Add Colors-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -826,6 +826,10 @@
 	path = extensions/colorizer
 	url = https://github.com/tamimhasandev/colorizer.git
 
+[submodule "extensions/colors-le"]
+	path = extensions/colors-le
+	url = https://github.com/nolindnaidoo/colors-le.git
+
 [submodule "extensions/commander-gold-theme"]
 	path = extensions/commander-gold-theme
 	url = https://github.com/koctep/z-commander-gold-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -840,6 +840,11 @@ version = "0.3.1"
 submodule = "extensions/colorizer"
 version = "1.0.6"
 
+[colors-le]
+submodule = "extensions/colors-le"
+path = "zed"
+version = "2.2.1"
+
 [commander-gold-theme]
 submodule = "extensions/commander-gold-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds `colors-le`, a context server that extracts colors from stylesheets and code, with each color's notation and 1-based line and column.

It wraps the extraction engine of the [Colors-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.colors-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`colors-le-mcp`](https://www.npmjs.com/package/colors-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/colors-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_colors(content, format?, filename?, dedupe?, maxResults?)`

Supports CSS, SCSS, LESS, Stylus, HTML, JavaScript, TypeScript, SVG and XML. Reports hex, rgb/rgba, hsl/hsla and named colors as written.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, which adds the first of this family. Opened separately so each can be reviewed and merged on its own.