### PR TITLE
Add Dates-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1058,6 +1058,10 @@
 	path = extensions/datadog-mcp
 	url = https://github.com/robertohuertasm/zed-datadog-mcp.git
 
+[submodule "extensions/dates-le"]
+	path = extensions/dates-le
+	url = https://github.com/nolindnaidoo/dates-le.git
+
 [submodule "extensions/day-shift"]
 	path = extensions/day-shift
 	url = https://github.com/Jean-Tinland/zed-theme-day-shift.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1076,6 +1076,11 @@ version = "0.4.0"
 submodule = "extensions/datadog-mcp"
 version = "0.3.0"
 
+[dates-le]
+submodule = "extensions/dates-le"
+path = "zed"
+version = "2.2.1"
+
 [day-shift]
 submodule = "extensions/day-shift"
 version = "1.0.3"


### PR DESCRIPTION
Adds `dates-le`, a context server that extracts dates and timestamps from logs, data files and code, each with its notation and 1-based line and column.

It wraps the extraction engine of the [Dates-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.dates-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`dates-le-mcp`](https://www.npmjs.com/package/dates-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/dates-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_dates(content, format?, filename?, dedupe?, maxResults?)`

Supports JSON, YAML, CSV, XML, log and plaintext, JavaScript, TypeScript and HTML. Recognises ISO 8601, RFC formats, common regional notations and Unix timestamps.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, which adds the first of this family. Opened separately so each can be reviewed and merged on its own.