### PR TITLE
Add Numbers-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3282,6 +3282,10 @@
 	path = extensions/nuisance
 	url = https://github.com/xtrasmal/zed-theme-nuisance.git
 
+[submodule "extensions/numbers-le"]
+	path = extensions/numbers-le
+	url = https://github.com/nolindnaidoo/numbers-le.git
+
 [submodule "extensions/numscript"]
 	path = extensions/numscript
 	url = https://github.com/bamorim/zed-numscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3338,6 +3338,11 @@ version = "1.0.0"
 submodule = "extensions/nuisance"
 version = "0.0.7"
 
+[numbers-le]
+submodule = "extensions/numbers-le"
+path = "zed"
+version = "2.2.1"
+
 [numscript]
 submodule = "extensions/numscript"
 version = "0.0.1"


### PR DESCRIPTION
Adds `numbers-le`, a context server that extracts numeric values from configuration, data files and plain text.

It wraps the extraction engine of the [Numbers-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.numbers-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`numbers-le-mcp`](https://www.npmjs.com/package/numbers-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/numbers-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_numbers(content, format?, filename?, dedupe?, maxResults?)`

Parses JSON, YAML, CSV, TOML, INI and dotenv; anything else is scanned as plain text, so a format is optional rather than required.

Results are capped at 500 by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
