### PR TITLE
Add Paths-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3546,6 +3546,10 @@
 	path = extensions/path-server-lsp
 	url = https://github.com/kunlinglio/path-server.git
 
+[submodule "extensions/paths-le"]
+	path = extensions/paths-le
+	url = https://github.com/nolindnaidoo/paths-le.git
+
 [submodule "extensions/pathy"]
 	path = extensions/pathy
 	url = https://github.com/gokulp01/pathy.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3605,6 +3605,11 @@ submodule = "extensions/path-server-lsp"
 path = "extensions/zed"
 version = "1.4.1"
 
+[paths-le]
+submodule = "extensions/paths-le"
+path = "zed"
+version = "2.2.1"
+
 [pathy]
 submodule = "extensions/pathy"
 version = "0.1.0"


### PR DESCRIPTION
Adds `paths-le`, a context server that extracts file and directory paths from configuration and code, each classified and located.

It wraps the extraction engine of the [Paths-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.paths-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`paths-le-mcp`](https://www.npmjs.com/package/paths-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/paths-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_paths(content, format?, filename?, dedupe?, maxResults?)`

Supports JSON, TOML, CSV, dotenv, JavaScript, TypeScript, HTML and CSS. Each path is classified as file, relative, absolute or url.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

Paths are reported exactly as written — nothing is resolved against a workspace or touched on disk.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
