### PR TITLE
Add String-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4446,6 +4446,10 @@
 	path = extensions/strace
 	url = https://github.com/sigmaSd/zed-strace
 
+[submodule "extensions/string-le"]
+	path = extensions/string-le
+	url = https://github.com/nolindnaidoo/string-le.git
+
 [submodule "extensions/struct-theme"]
 	path = extensions/struct-theme
 	url = https://gitlab.com/Fake.User/struct-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4523,6 +4523,11 @@ version = "0.2.0"
 submodule = "extensions/strace"
 version = "0.0.3"
 
+[string-le]
+submodule = "extensions/string-le"
+path = "zed"
+version = "2.2.1"
+
 [struct-theme]
 submodule = "extensions/struct-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds `string-le`, a context server that extracts string values from configuration, data files and plain text.

It wraps the extraction engine of the [String-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.string-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`string-le-mcp`](https://www.npmjs.com/package/string-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/string-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_strings(content, format?, filename?, dedupe?, maxResults?)`

Parses JSON, YAML, CSV, TOML, INI and dotenv; for any other format it falls back to quoted strings, so a format is optional but unquoted prose yields nothing.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
