### PR TITLE
Add Regex-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3962,6 +3962,10 @@
 	path = extensions/regedit
 	url = https://github.com/JasonGH17/regedit
 
+[submodule "extensions/regex-le"]
+	path = extensions/regex-le
+	url = https://github.com/nolindnaidoo/regex-le.git
+
 [submodule "extensions/regex-theme"]
 	path = extensions/regex-theme
 	url = https://github.com/oxnan/RegEx-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4032,6 +4032,11 @@ version = "0.2.0"
 submodule = "extensions/regedit"
 version = "0.0.1"
 
+[regex-le]
+submodule = "extensions/regex-le"
+path = "zed"
+version = "2.2.1"
+
 [regex-theme]
 submodule = "extensions/regex-theme"
 version = "0.11.11"


### PR DESCRIPTION
Adds `regex-le`, a context server that extracts regular expressions from source code, each with a ReDoS safety verdict.

It wraps the extraction engine of the [Regex-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.regex-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`regex-le-mcp`](https://www.npmjs.com/package/regex-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/regex-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`extract_patterns(content, maxResults?)`

Finds literals and RegExp constructors, with flags and 1-based position. Duplicate pattern-and-flags pairs are reported once, at first occurrence.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

The safety verdict travels with the pattern rather than living in a second tool, so "are any of the regexes in this file dangerous?" is one call.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
