### PR TITLE
Add EnvSync-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1354,6 +1354,10 @@
 	path = extensions/env
 	url = https://github.com/zarifpour/zed-env
 
+[submodule "extensions/envsync-le"]
+	path = extensions/envsync-le
+	url = https://github.com/nolindnaidoo/envsync-le.git
+
 [submodule "extensions/ep-133-theme"]
 	path = extensions/ep-133-theme
 	url = https://github.com/evgenii-sergeev/zed-ep-133.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1377,6 +1377,11 @@ version = "1.1.1"
 submodule = "extensions/env"
 version = "0.0.2"
 
+[envsync-le]
+submodule = "extensions/envsync-le"
+path = "zed"
+version = "2.2.1"
+
 [ep-133-theme]
 submodule = "extensions/ep-133-theme"
 version = "0.0.3"


### PR DESCRIPTION
Adds `envsync-le`, a context server that reports which keys are missing or extra across a set of dotenv files.

It wraps the extraction engine of the [EnvSync-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.envsync-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`envsync-le-mcp`](https://www.npmjs.com/package/envsync-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/envsync-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`compare_env_files(files[], mode?, templatePath?, caseSensitive?, maxResults?)`

Takes file contents directly. In "auto" mode the reference is the union of all keys; "template" mode compares every file against one named template.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

Only key **names** are returned, never values — a dotenv file is where credentials live and the answer does not need them.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
