### PR TITLE
Add Secrets-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4146,6 +4146,10 @@
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git
 
+[submodule "extensions/secrets-le"]
+	path = extensions/secrets-le
+	url = https://github.com/nolindnaidoo/secrets-le.git
+
 [submodule "extensions/selene-abyss-theme"]
 	path = extensions/selene-abyss-theme
 	url = https://github.com/envoidia/zed-selene-abyss.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4219,6 +4219,11 @@ version = "0.0.1"
 submodule = "extensions/scss"
 version = "0.2.1"
 
+[secrets-le]
+submodule = "extensions/secrets-le"
+path = "zed"
+version = "2.2.1"
+
 [selene-abyss-theme]
 submodule = "extensions/selene-abyss-theme"
 version = "0.0.3"


### PR DESCRIPTION
Adds `secrets-le`, a context server that detects hardcoded secrets in source and configuration, without ever returning the credential.

It wraps the extraction engine of the [Secrets-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.secrets-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`secrets-le-mcp`](https://www.npmjs.com/package/secrets-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/secrets-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`detect_secrets(content, sensitivity?, includeApiKeys?, includePasswords?, includeTokens?, includePrivateKeys?, maxResults?)`

Reports each finding by type, confidence, key name and 1-based position.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

**Values are never returned.** Previews are truncated and length-annotated, and the surrounding context line has the secret masked out, so a finding can be located without the credential leaving the machine it was found on. There is no argument that turns this off.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
