### PR TITLE
Add Scrape-LE MCP server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4142,6 +4142,10 @@
 	path = extensions/scls
 	url = https://github.com/d1y/simple-completion-zed
 
+[submodule "extensions/scrape-le"]
+	path = extensions/scrape-le
+	url = https://github.com/nolindnaidoo/scrape-le.git
+
 [submodule "extensions/scss"]
 	path = extensions/scss
 	url = https://github.com/bajrangCoder/zed-scss.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4215,6 +4215,11 @@ version = "0.0.6"
 submodule = "extensions/scls"
 version = "0.0.1"
 
+[scrape-le]
+submodule = "extensions/scrape-le"
+path = "zed"
+version = "2.2.1"
+
 [scss]
 submodule = "extensions/scss"
 version = "0.2.1"


### PR DESCRIPTION
Adds `scrape-le`, a context server that reports whether a path may be crawled, from robots.txt content you already fetched.

It wraps the extraction engine of the [Scrape-LE](https://marketplace.visualstudio.com/items?itemName=nolindnaidoo.scrape-le) VS Code extension, so Zed gets the same behaviour through the agent panel that the editor extension provides through its command palette.

> **Opened as a draft only because of the three-open-PR limit for non-collaborators** — this is complete and ready to review. I'll mark it ready as my other PRs in this family merge. Happy to have it reviewed as-is in the meantime.

### How it works

The extension is a launcher — `npm_package_latest_version` → `npm_install_package` → `Command { node_binary_path()?, … }`, with no logic in the crate. The server it starts is published as [`scrape-le-mcp`](https://www.npmjs.com/package/scrape-le-mcp) and resolves today.

It is also in the official MCP registry as `io.github.nolindnaidoo/scrape-le`, following the note in `docs/src/extensions/mcp-extensions.md` about publishing there as well.

### One tool

`analyze_robots_txt(content, path, maxResults?)`

Given robots.txt contents and a path, reports whether the generic (User-agent: *) rules permit crawling it, along with the crawl delay, disallowed patterns and any sitemaps.

Results are capped by default with `meta.truncated`, so a large input cannot flood the agent's context window. No network access and no filesystem access — content goes in, structured data comes out.

It makes **no network request of its own** — fetch robots.txt with your own HTTP tool and pass what it returned. Reaching an arbitrary origin from inside an agent loop would be an SSRF primitive, so that half is deliberately left to the caller.

### Notes

- `path = "zed"` because the crate lives in a subdirectory of the extension's repo.
- MIT licence symlinked at the extension path.

Companion to #7077, #7078 and #7079. Opened separately so each can be reviewed and merged on its own.
