### PR TITLE
Add Batcave theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -378,6 +378,10 @@
 	path = extensions/basher
 	url = https://github.com/zed-extensions/bash.git
 
+[submodule "extensions/batcave-theme"]
+	path = extensions/batcave-theme
+	url = https://github.com/mertdeveci5/batcave-theme.git
+
 [submodule "extensions/batman"]
 	path = extensions/batman
 	url = https://github.com/devzaidi/batman-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -386,6 +386,11 @@ version = "0.1.2"
 submodule = "extensions/basher"
 version = "0.0.5"
 
+[batcave-theme]
+submodule = "extensions/batcave-theme"
+path = "zed"
+version = "0.0.1"
+
 [batman]
 submodule = "extensions/batman"
 version = "0.0.3"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

Adds the Batcave dark theme, with a near-black Batcomputer-inspired UI, cyan accents, and matching terminal colors. The extension lives in the repository's `zed` subdirectory alongside its existing VS Code and Ghostty ports.

## Validation

- Validated against the Zed theme v0.2.0 schema
- Verified the 16 terminal colors exactly match the Ghostty theme
- Ran `pnpm sort-extensions`, `pnpm build`, and `pnpm test` (115 tests passed)