### PR TITLE
Add tcss extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4622,6 +4622,10 @@
 	path = extensions/tcl
 	url = https://github.com/richnou/kissb-zed-tcl.git
 
+[submodule "extensions/tcss"]
+	path = extensions/tcss
+	url = https://github.com/thenickz/tcss-zed-extension.git
+
 [submodule "extensions/tech49-theme"]
 	path = extensions/tech49-theme
 	url = https://github.com/timdang/tech49_theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4706,6 +4706,10 @@ version = "1.0.0"
 submodule = "extensions/tcl"
 version = "0.0.2"
 
+[tcss]
+submodule = "extensions/tcss"
+version = "0.1.0"
+
 [tech49-theme]
 submodule = "extensions/tech49-theme"
 version = "0.2.3"


### PR DESCRIPTION
Adds the `tcss` extension (Textual CSS syntax highlighting).

- Extension: https://github.com/thenickz/tcss-zed-extension
- Grammar: kraanzu/tree-sitter-tcss (MIT), pinned commit.
- License: MIT.
- Tested locally as a dev extension.