### PR TITLE
Add Genko writing support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1650,6 +1650,10 @@
 	path = extensions/genexpr
 	url = https://github.com/isabelgk/genexpr-zed.git
 
+[submodule "extensions/genko-writing"]
+	path = extensions/genko-writing
+	url = https://github.com/necofuryai/genko-zed.git
+
 [submodule "extensions/geno"]
 	path = extensions/geno
 	url = https://github.com/jlyonsmith/zed-geno.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1680,6 +1680,10 @@ version = "0.0.5"
 submodule = "extensions/genexpr"
 version = "0.1.0"
 
+[genko-writing]
+submodule = "extensions/genko-writing"
+version = "0.1.0"
+
 [geno]
 submodule = "extensions/geno"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1682,7 +1682,7 @@ version = "0.1.0"
 
 [genko-writing]
 submodule = "extensions/genko-writing"
-version = "0.1.0"
+version = "0.1.1"
 
 [geno]
 submodule = "extensions/geno"


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Genko (`genko-writing`) v0.1.1, a Japanese fiction writing extension.

This submission:

- recognizes `.genko` files as Genko Novel;
- highlights headings, dialogue, explicit ruby, emphasis, Aozora annotations, and HTML comments;
- provides document-wide body character counts through an English-language LSP hover.

The v0.1.1 patch translates the hover label to English for the current publishing prerequisites. Character-count behavior and the release asset contract are unchanged.

Validation:

- originally installed and tested the extension locally as a dev extension with Zed Preview 1.15.0;
- passed the source repository Rust, Tree-sitter grammar, Cargo deny, and Dependency Review checks for v0.1.1;
- ran `pnpm sort-extensions`, `pnpm build`, and all 115 registry tests against the updated Registry branch;
- published and checksum-verified the six `genko-ls` platform assets in [v0.1.1](https://github.com/necofuryai/genko-zed/releases/tag/v0.1.1), and verified the immutable GitHub Release attestation.
