### PR TITLE
Add monokai-ignite theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2982,8 +2982,8 @@
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git
 
-[submodule "extensions/monokai-ignite"]
-	path = extensions/monokai-ignite
+[submodule "extensions/monokai-ignite-theme"]
+	path = extensions/monokai-ignite-theme
 	url = https://github.com/darkings/monokai-ignite.git
 
 [submodule "extensions/monokai-nebula"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -5409,3 +5409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/monokai-ignite"]
+	path = extensions/monokai-ignite
+	url = https://github.com/darkings/monokai-ignite.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2982,6 +2982,10 @@
 	path = extensions/monochromator-theme
 	url = https://codeberg.org/beem/monochromator.git
 
+[submodule "extensions/monokai-ignite"]
+	path = extensions/monokai-ignite
+	url = https://github.com/darkings/monokai-ignite.git
+
 [submodule "extensions/monokai-nebula"]
 	path = extensions/monokai-nebula
 	url = https://github.com/JacobCallahan/monokai-nebula-zed.git
@@ -5409,6 +5413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/monokai-ignite"]
-	path = extensions/monokai-ignite
-	url = https://github.com/darkings/monokai-ignite.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3037,8 +3037,8 @@ submodule = "extensions/monochromator-theme"
 path = "editors/zed"
 version = "0.2.2"
 
-[monokai-ignite]
-submodule = "extensions/monokai-ignite"
+[monokai-ignite-theme]
+submodule = "extensions/monokai-ignite-theme"
 version = "0.3.0"
 
 [monokai-nebula]

--- a/extensions.toml
+++ b/extensions.toml
@@ -3037,6 +3037,10 @@ submodule = "extensions/monochromator-theme"
 path = "editors/zed"
 version = "0.2.2"
 
+[monokai-ignite]
+submodule = "extensions/monokai-ignite"
+version = "0.3.0"
+
 [monokai-nebula]
 submodule = "extensions/monokai-nebula"
 version = "0.2.6"


### PR DESCRIPTION
Adds the Monokai Ignite theme extension.

- Registers only `monokai-ignite-theme` at version `0.3.0`
- Adds its git submodule at commit `f5382b2c10fc4fa6d8d86c916797065dc9873a87`
- Replaces #7042, whose diff included unrelated extension version changes

Validated with `git diff --check`.
