### PR TITLE
Add DLUnire Dark theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5409,3 +5409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/dlunire-theme"]
+	path = extensions/dlunire-theme
+	url = https://github.com/dlunire/zed-dlunire-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -1148,7 +1148,7 @@
 
 [submodule "extensions/dlunire-dark"]
 	path = extensions/dlunire-dark
-	url = https://github.com/dlunire/zed-dlunire-theme
+	url = git@github.com:dlunire/zed-dlunire-theme.git
 
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose

--- a/.gitmodules
+++ b/.gitmodules
@@ -5409,6 +5409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/dlunire-theme"]
-	path = extensions/dlunire-theme
+[submodule "extensions/dlunire-dark"]
+	path = extensions/dlunire-dark
 	url = https://github.com/dlunire/zed-dlunire-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -1146,6 +1146,10 @@
 	path = extensions/djot
 	url = https://github.com/nzoschke/zed-djot.git
 
+[submodule "extensions/dlunire-dark"]
+	path = extensions/dlunire-dark
+	url = https://github.com/dlunire/zed-dlunire-theme
+
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose
 	url = https://github.com/eth0net/zed-docker-compose.git
@@ -5409,6 +5413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/dlunire-dark"]
-	path = extensions/dlunire-dark
-	url = https://github.com/dlunire/zed-dlunire-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -1148,7 +1148,7 @@
 
 [submodule "extensions/dlunire-dark"]
 	path = extensions/dlunire-dark
-	url = git@github.com:dlunire/zed-dlunire-theme.git
+	url = https://github.com/dlunire/zed-dlunire-theme.git
 
 [submodule "extensions/docker-compose"]
 	path = extensions/docker-compose

--- a/extensions.toml
+++ b/extensions.toml
@@ -1186,7 +1186,7 @@ version = "0.1.0"
 
 [dlunire-dark]
 submodule = "extensions/dlunire-dark"
-version = "1.0.1"
+version = "1.0.2"
 
 [docker-compose]
 submodule = "extensions/docker-compose"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1169,7 +1169,7 @@ version = "0.1.0"
 
 [dlunire-dark]
 submodule = "extensions/dlunire-dark"
-version = "1.0.1"
+version = "1.0.2"
 
 [docker-compose]
 submodule = "extensions/docker-compose"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1169,7 +1169,7 @@ version = "0.1.0"
 
 [dlunire-dark]
 submodule = "extensions/dlunire-dark"
-version = "1.0.0"
+version = "1.0.1"
 
 [docker-compose]
 submodule = "extensions/docker-compose"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5499,3 +5499,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[dlunire-dark]
+submodule = "extensions/dlunire-dark"
+version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1167,6 +1167,10 @@ version = "0.0.1"
 submodule = "extensions/djot"
 version = "0.1.0"
 
+[dlunire-dark]
+submodule = "extensions/dlunire-dark"
+version = "1.0.0"
+
 [docker-compose]
 submodule = "extensions/docker-compose"
 version = "0.1.0"
@@ -5499,7 +5503,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-
-[dlunire-dark]
-submodule = "extensions/dlunire-dark"
-version = "1.0.0"


### PR DESCRIPTION
 Adds the DLUnire Dark color theme suite (v1.0.2) to the Zed extension registry.
  
  ### Summary
  
  • Extension ID: dlunire-dark
  • Version: 1.0.2
  • Repository: https://github.com/dlunire/zed-dlunire-theme
  • License: MIT
  
  ### Included Variants (4 Themes)
  
  • DLUnire Dark: Pure ultra-dark high-contrast palette (#010305) with classic semantic syntax highlighting.
  • DLUnire Dark Soft: Graphite/slate background (#07090b) designed to reduce visual fatigue during long coding sessions.
  • DLUnire Dark Cyber: High-saturation cyberpunk palette on #010305 with dedicated semantic tokens for interfaces, structs, enums, and functions.         
  • DLUnire Dark Cyber Soft: The Cyber palette on a softer blue-slate dark background (#04080C).
  
  ### Key Features & Polish
  
  • Diagnostics & Git: Complete styling for error, warning, info, hint, and VCS statuses.
  • Terminal: Tailored 16-color ANSI terminal palette for both Classic and Cyber variants.
  • UI Chrome: Cyan-tinted alpha borders, distinct active/inactive tab contrast, and customized status bar.
  • Documentation: README with embedded video demonstration and preview screenshots across multiple languages (PHP, Rust, Svelte, TypeScript, Bash).  