### PR TITLE
Add EBCDIC Converter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1230,6 +1230,10 @@
 	path = extensions/easy-opaque-theme
 	url = https://github.com/KarmanyaIyer/zed-easy-opaque-theme.git
 
+[submodule "extensions/ebcdic-converter"]
+	path = extensions/ebcdic-converter
+	url = https://github.com/postalservice14/zed-ebcdicconverter.git
+
 [submodule "extensions/ebnf"]
 	path = extensions/ebnf
 	url = https://github.com/louiss0/zed-ebnf.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1252,6 +1252,10 @@ version = "1.0.0"
 submodule = "extensions/easy-opaque-theme"
 version = "0.0.1"
 
+[ebcdic-converter]
+submodule = "extensions/ebcdic-converter"
+version = "0.1.0"
+
 [ebnf]
 submodule = "extensions/ebnf"
 version = "1.0.0"


### PR DESCRIPTION
Adds [ebcdic-converter](https://github.com/postalservice14/zed-ebcdicconverter), which converts text between ASCII and 11 EBCDIC codepages (0037, 0273, 0277, 0278, 0280, 0284, 0285, 0297, 0500, 0871, 1047).

It's a port of the VS Code extension [CoderAllan/vscode-ebcdicconverter](https://github.com/CoderAllan/vscode-ebcdicconverter) (MIT). Because extensions can't modify buffers directly, the conversions are exposed as `refactor.rewrite` code actions from a small language server: select text and press `cmd-.`, or convert the whole file with nothing selected. Edits are attached on `codeAction/resolve` rather than up front, since code actions refresh as the cursor moves and converting eagerly would re-convert the whole file on every movement.

The extension does not ship the language server. It checks `worktree.which()` first, then downloads the platform binary from the repository's GitHub releases and caches it.

### Prerequisites

- [x] Tested locally as a dev extension: code actions appear and apply correctly on a selection, and with no selection the whole document is converted.
- [x] MIT licensed, `LICENSE` at the repository root.
- [x] ID and name contain neither `zed` nor `extension`; the ID describes the functionality.
- [x] Does not ship a language server — downloads it, per the publishing prerequisites.
- [x] Not already available: the registry has `cobol` (a grammar) and `mainframe-theme` (a theme), but nothing that converts EBCDIC.
- [x] Contains only what it needs to function.
- [x] `pnpm sort-extensions` run; `extensions.toml` and `.gitmodules` are sorted.
- [x] No Git LFS.
- [x] Extension crate builds on Rust 1.90 (the toolchain this repository packages with) for `wasm32-wasip2`.

### Notes

The conversion tables are generated from upstream's TypeScript by a script rather than transcribed by hand — 22 tables of 256 entries is 5,632 values where a single wrong digit silently corrupts data — and the extension's CI re-runs that derivation to prove the committed tables still match. They were also checked against Python's own `cp037` and `cp500` codecs: 255 of 256 byte mappings agree, the exception being `0x15`, where upstream deliberately maps EBCDIC NEL to `\n` so mainframe line breaks become newlines.

Submodule is pinned to tag `v0.1.0`, which has prebuilt server binaries for macOS (arm64/x64), Linux (arm64/x64, static musl) and Windows x64.