### PR TITLE
ci: Migrate to `pnpm/setup` step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,11 @@ jobs:
           clean: false
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
-          version: 11.11.x
-
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: "package.json"
-          cache: "pnpm"
-          check-latest: true
+          version: 11
+          runtime: node@24.19.0
+          cache: true
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
         with:
@@ -54,9 +50,6 @@ jobs:
         run: |
           wget --quiet "https://zed-extension-cli.nyc3.digitaloceanspaces.com/$ZED_EXTENSION_CLI_SHA/x86_64-unknown-linux-gnu/zed-extension"
           chmod +x zed-extension
-
-      - name: Install dependencies
-        run: pnpm install
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -19,19 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+      - uses: pnpm/setup@f7d0e5f4b1b3089d2799ef9722859e7ba314c4c8 # v1
         with:
-          version: 11.11.x
-
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          node-version-file: "package.json"
-          cache: "pnpm"
-          check-latest: true
-
-      - name: Install dependencies
-        run: pnpm install
+          version: 11
+          runtime: node@24.19.0
+          cache: true
 
       - name: Run Danger
         run: pnpm run danger ci


### PR DESCRIPTION
Migrates to the successor as noted in https://github.com/pnpm/action-setup