### PR TITLE
Add dotnet extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1166,6 +1166,10 @@
 	path = extensions/doom-one-theme
 	url = https://github.com/bashln/zed-doom.git
 
+[submodule "extensions/dotnet"]
+	path = extensions/dotnet
+	url = https://github.com/Gambl3r08/zed-dotnet.git
+
 [submodule "extensions/doxygen"]
 	path = extensions/doxygen
 	url = https://github.com/ozacod/zed-doxygen.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1187,6 +1187,10 @@ version = "0.0.2"
 submodule = "extensions/doom-one-theme"
 version = "1.0.0"
 
+[dotnet]
+submodule = "extensions/dotnet"
+version = "0.1.0"
+
 [doxygen]
 submodule = "extensions/doxygen"
 version = "0.1.0"


### PR DESCRIPTION
Adds the **.NET** extension: https://github.com/Gambl3r08/zed-dotnet

## What it provides

- **Debugging**: netcoredbg debug adapter + a `dotnet` locator that turns
  `dotnet run` tasks into build-then-debug (assembly resolved via
  `dotnet msbuild -getProperty:TargetPath`), plus a `debugger.scm` for inline
  values.
- **C#**: Roslyn language server (auto-downloaded from nuget.org, started with
  `--autoLoadProjects`), 47 semantic token rules (XML doc comments, embedded
  regex/JSON), runnables for tests/`Main`, tasks, snippets.
- **MSBuild**: one language for `.csproj`/`.fsproj`/`.vbproj`/`.props`/
  `.targets`/`.slnx`/`nuget.config`, with outline and package-management tasks.
- **Razor**: syntax, outline and indents for `.razor`/`.cshtml` (grammar embeds
  full C#); routing to Roslyn co-hosting is wired for users who supply a
  matched server pair.

## Overlap with the existing `csharp` extension

Per the guidelines I first contributed the debugging support upstream:
zed-extensions/csharp#95 (complete, CI-green, unreviewed so far; related to
the stalled zed-extensions/csharp#43 and issue zed-extensions/csharp#12).

This extension's remaining scope — Razor, unified MSBuild, debugging integrated
with runnables and tasks — does not fit as incremental PRs to a C#-only
extension. Both can coexist; if #95 lands upstream, this extension still
provides the rest.

Tree-sitter queries are validated by `cargo test` against the pinned grammar
revisions; the Roslyn path and a full netcoredbg debug session have been
exercised against real projects.

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
