### PR TITLE
Add p5.js snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3490,6 +3490,10 @@
 	path = extensions/p4
 	url = https://github.com/gaetschwartz/zed-p4.git
 
+[submodule "extensions/p5js-snippets"]
+	path = extensions/p5js-snippets
+	url = https://github.com/manursutil/p5js-zed-extension.git
+
 [submodule "extensions/pace-pro-theme"]
 	path = extensions/pace-pro-theme
 	url = https://github.com/VMachihin/pace-theme-pro.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3547,6 +3547,10 @@ version = "0.1.3"
 submodule = "extensions/p4"
 version = "0.0.1"
 
+[p5js-snippets]
+submodule = "extensions/p5js-snippets"
+version = "0.1.0"
+
 [pace-pro-theme]
 submodule = "extensions/pace-pro-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- add the `p5js-snippets` extension at version `0.1.0`
- provide curated JavaScript snippets for p5.js lifecycle functions, global and instance mode, input handlers, preloading, responsive canvases, and accessibility descriptions
- keep the extension data-only, using Zed's existing JavaScript tooling and p5's official declarations

## Why

p5.js sketches are JavaScript, so this extension adds focused authoring shortcuts without introducing a duplicate language, grammar, language server, or completion provider.

## Validation

- installed and tested locally as a development extension in Zed 1.14.2
- verified snippet completion in a JavaScript buffer
- verified global-mode and instance-mode p5 hover documentation through Zed's JavaScript language service
- ran `pnpm sort-extensions`
- ran `pnpm build`
- ran `pnpm test` (115 tests passed)
