### PR TITLE
Creating a community port of Gruvbox Concoctis vscode theme for Zed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -706,6 +706,10 @@
 	path = extensions/cherri
 	url = https://github.com/videah/zed-cherri.git
 
+[submodule "extensions/chill-theme"]
+	path = extensions/chill-theme
+	url = https://github.com/m3rashid/chill-theme.git
+
 [submodule "extensions/chocolate"]
 	path = extensions/chocolate
 	url = https://github.com/brunozalc/zed-chocolate

--- a/extensions.toml
+++ b/extensions.toml
@@ -717,6 +717,10 @@ version = "0.5.0"
 submodule = "extensions/cherri"
 version = "0.1.0"
 
+[chill-theme]
+submodule = "extensions/chill-theme"
+version = "0.1.0"
+
 [chocolate]
 submodule = "extensions/chocolate"
 version = "0.0.2"


### PR DESCRIPTION
I recently switched from VsCode to Zed completely and this one thing that was bugging me for so long, it always felt something was missing from the UI. I could not find any theme matching with this theme. So, I created a new theme that ports that vscode theme to Zed. Now it feels much better.

Please publish this to zed extension store so that I can use it on my other machines as well.

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
