### PR TITLE
Update docker-compose to v0.4.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1169,7 +1169,7 @@ version = "0.1.0"
 
 [docker-compose]
 submodule = "extensions/docker-compose"
-version = "0.1.0"
+version = "0.4.0"
 
 [dockerfile]
 submodule = "extensions/dockerfile"


### PR DESCRIPTION
Release notes:

https://github.com/eth0net/zed-docker-compose/releases/tag/v0.4.0