### PR TITLE
Add skript

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4266,6 +4266,10 @@
 	path = extensions/skill-language-server
 	url = https://github.com/CyrusNuevoDia/skill-language-server.git
 
+[submodule "extensions/skript"]
+	path = extensions/skript
+	url = https://github.com/DaisyCatTs/SkriptZed.git
+
 [submodule "extensions/sl4y-theme"]
 	path = extensions/sl4y-theme
 	url = https://github.com/berkantay/zed-theme-sl4y.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4340,6 +4340,11 @@ submodule = "extensions/skill-language-server"
 path = "ext/zed"
 version = "0.0.1"
 
+[skript]
+submodule = "extensions/skript"
+path = "extension"
+version = "0.1.0"
+
 [sl4y-theme]
 submodule = "extensions/sl4y-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds [Skript](https://github.com/DaisyCatTs/SkriptZed) — language support for [Skript](https://github.com/SkriptLang/Skript), the scripting language Minecraft server owners use to write plugins without writing Java. Zed had no support for it before.

Skript has no context-free grammar: every effect, condition and expression is a pattern string registered at runtime by Skript or an addon, so nothing lexical separates `set {_x} to 5` from `player is op`. The grammar therefore handles structure only — lines, indentation, sections, strings and their `%…%` interpolation — and a language server classifies statements against Skript's published syntax database.

- highlighting, indentation, folding, outline and 61 snippets from the grammar
- hover, completion, diagnostics, go-to-definition, references and rename from `skript-lsp`
- signature help, inlay hints, occurrence highlighting and semantic tokens
- addon support: reads the plugin manifests inside the JARs in a server's `plugins/` folder and loads syntax only for what is actually installed

The extension doesn't bundle the language server — it downloads it from GitHub releases, or uses one already on `PATH` or named in settings. The syntax databases are fetched at runtime rather than vendored, since Skript's is GPL-3.0 and this is MIT.

No colour is defined anywhere in the extension, so it follows whatever theme is active. The grammar is held to SkriptLang's own repository: ~540 real scripts must parse with zero errors on every change.

Tested locally as a dev extension on Windows.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
