### PR TITLE
Add hadal-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1870,6 +1870,10 @@
 	path = extensions/hackthebox-theme
 	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
+[submodule "extensions/hadal"]
+	path = extensions/hadal
+	url = https://github.com/maikel-479/hadal.git
+
 [submodule "extensions/hakimi-deuteranopia-theme"]
 	path = extensions/hakimi-deuteranopia-theme
 	url = https://github.com/zogwosh/hakimi-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1874,8 +1874,8 @@
 	path = extensions/hackthebox-theme
 	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
-[submodule "extensions/hadal"]
-	path = extensions/hadal
+[submodule "extensions/hadal-theme"]
+	path = extensions/hadal-theme
 	url = https://github.com/maikel-479/hadal.git
 
 [submodule "extensions/hakimi-deuteranopia-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1910,8 +1910,8 @@ version = "2.0.0"
 submodule = "extensions/hackthebox-theme"
 version = "0.1.0"
 
-[hadal]
-submodule = "extensions/hadal"
+[hadal-theme]
+submodule = "extensions/hadal-theme"
 version = "0.1.0"
 
 [hakimi-deuteranopia-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1905,6 +1905,10 @@ version = "2.0.0"
 submodule = "extensions/hackthebox-theme"
 version = "0.1.0"
 
+[hadal]
+submodule = "extensions/hadal"
+version = "0.1.0"
+
 [hakimi-deuteranopia-theme]
 submodule = "extensions/hakimi-deuteranopia-theme"
 path = "zed"


### PR DESCRIPTION
Adds the [hadal-theme](https://github.com/maikel-479/hadal) theme to the Zed extension store.

A deep-sea inspired theme available in both dark and light variants.