### PR TITLE
Add Skript language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4266,6 +4266,10 @@
 	path = extensions/skill-language-server
 	url = https://github.com/CyrusNuevoDia/skill-language-server.git
 
+[submodule "extensions/skript"]
+	path = extensions/skript
+	url = https://github.com/DaisyCatTs/SkriptZed.git
+
 [submodule "extensions/sl4y-theme"]
 	path = extensions/sl4y-theme
 	url = https://github.com/berkantay/zed-theme-sl4y.git
@@ -5409,6 +5413,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/skript"]
-	path = extensions/skript
-	url = https://github.com/DaisyCatTs/SkriptZed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5409,3 +5409,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/skript"]
+	path = extensions/skript
+	url = https://github.com/DaisyCatTs/SkriptZed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4340,6 +4340,11 @@ submodule = "extensions/skill-language-server"
 path = "ext/zed"
 version = "0.0.1"
 
+[skript]
+submodule = "extensions/skript"
+path = "extension"
+version = "0.2.3"
+
 [sl4y-theme]
 submodule = "extensions/sl4y-theme"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds support for [Skript](https://github.com/SkriptLang/Skript), the scripting language used to write Minecraft server plugins. It has a large user base and no editor support in Zed today.

Skript is unusual in a way that shapes the extension: it has no context-free grammar. Every effect, condition, expression and event is a pattern string registered at runtime by Skript or one of its addons — 2,660 in core Skript alone — so nothing lexical distinguishes `set {_x} to 5` from `player is op`. The tree-sitter grammar therefore handles structure only (lines, indentation, sections, strings and their interpolation, variables, comments, and the handful of headers with a fixed shape), and a language server classifies each statement against Skript's published syntax database and returns the result as semantic tokens.

That means `semantic_tokens` needs to be `"combined"` for statements to be coloured; the README covers it, and `highlights.scm` stands on its own without it.

The language server also provides completion, hover, go-to-definition, find references, rename, formatting, inlay hints and diagnostics. It is fetched from GitHub releases, with prebuilt binaries for the five platforms Zed supports.

Tested locally as a dev extension.
