### PR TITLE
Creating a community port of Gruvbox Concoctis vscode theme for Zed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1838,6 +1838,10 @@
 	path = extensions/gruvbox-baby
 	url = https://github.com/gbo-dev/gruvbox-baby-zed
 
+[submodule "extensions/gruvbox-concoctis-theme"]
+	path = extensions/gruvbox-concoctis-theme
+	url = https://github.com/m3rashid/gruvbox-concoctis-zed-theme.git
+
 [submodule "extensions/gruvbox-crisp-themes"]
 	path = extensions/gruvbox-crisp-themes
 	url = https://github.com/VatsalSy/zed-gruvbox_custom_themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1874,6 +1874,10 @@ version = "0.8.0"
 submodule = "extensions/gruvbox-baby"
 version = "0.0.1"
 
+[gruvbox-concoctis-theme]
+submodule = "extensions/gruvbox-concoctis-theme"
+version = "0.0.1"
+
 [gruvbox-crisp-themes]
 submodule = "extensions/gruvbox-crisp-themes"
 version = "0.2.0"


### PR DESCRIPTION
I recently switched from VsCode to Zed completely and this one thing that was bugging me for so long, it always felt something was missing from the UI. I could not find any theme matching with this theme. So, I created a new theme that ports that vscode theme to Zed. Now it feels much better.

Please publish this to zed extension store so that I can use it on my other machines as well.

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
