### PR TITLE
Add Go CodeLens extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1750,6 +1750,10 @@
 	path = extensions/gn
 	url = https://github.com/dsa28s/zed-gn-language.git
 
+[submodule "extensions/go-codelens"]
+	path = extensions/go-codelens
+	url = https://github.com/Johnny0x38E/go-codelens-for-zed.git
+
 [submodule "extensions/go-snippets"]
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1786,6 +1786,10 @@ version = "0.2.4"
 submodule = "extensions/gn"
 version = "1.4.0"
 
+[go-codelens]
+submodule = "extensions/go-codelens"
+version = "0.3.2"
+
 [go-snippets]
 submodule = "extensions/go-snippets"
 version = "0.1.5"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

Adds Go CodeLens, an auxiliary language server extension that provides
reference counts and interface implementation CodeLens entries for Go.

## Motivation

`gopls` remains Zed's primary Go language server, but it does not expose
these relationship details as CodeLens entries. Go's implicit interface
implementation model makes this information especially useful when
navigating larger codebases.

Go CodeLens complements `gopls` and does not replace it. Completion,
diagnostics, formatting, rename, and other standard Go language features
remain provided by `gopls`.

## Features

- Reference counts for functions, methods, types, interfaces, and fields
- Interface implementation CodeLens entries
- Navigation through standard LSP commands
- Support for unsaved editor buffers
- Support for `_test.go` files and `go.work` workspaces
- Incremental analysis with bounded caches and cancellation handling
- macOS, Linux, and Windows support on arm64 and x86-64

## Verification

- Tested locally as a Zed development extension
- Verified CodeLens navigation and reference counts
- Verified the versioned native server download from the `v0.3.2` release
- Go tests, race tests, vet, and lint checks pass
- Rust/Wasm checks pass
- GitHub Actions pass for all supported release targets

The `v0.3.2` release contains six native language-server binaries and
`SHA256SUMS`:

https://github.com/Johnny0x38E/go-codelens-for-zed/releases/tag/v0.3.2

The extension repository is publicly available and licensed under MIT.
Native binaries are not committed to the extension repository; the adapter
downloads the matching release asset and verifies it using SHA-256.
