### PR TITLE
Add Classic ASP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -742,6 +742,10 @@
 	path = extensions/clarity
 	url = https://github.com/stx-labs/clarity-zed.git
 
+[submodule "extensions/classic-asp"]
+	path = extensions/classic-asp
+	url = https://github.com/tom-lewis-altido/zed-classic-asp.git
+
 [submodule "extensions/claude-code-inspired-dark"]
 	path = extensions/claude-code-inspired-dark
 	url = https://github.com/ericbuess/claude-code-inspired-dark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -755,6 +755,10 @@ version = "0.0.1"
 submodule = "extensions/clarity"
 version = "0.1.0"
 
+[classic-asp]
+submodule = "extensions/classic-asp"
+version = "0.1.0"
+
 [claude-code-inspired-dark]
 submodule = "extensions/claude-code-inspired-dark"
 version = "1.0.0"


### PR DESCRIPTION
Adds Classic ASP support with mixed HTML, VBScript, CSS and JavaScript highlighting, outline, indentation, bracket handling, and HTML completions.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.