### PR TITLE
Update Skript to v0.2.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4364,7 +4364,7 @@ version = "0.0.1"
 [skript]
 submodule = "extensions/skript"
 path = "extension"
-version = "0.2.3"
+version = "0.2.5"
 
 [sl4y-theme]
 submodule = "extensions/sl4y-theme"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Updates Skript from 0.2.3 to 0.2.5.

Two bugs reported against real scripts, both of which flagged correct code:

- Skript registers 45 functions of its own at runtime — `floor`, `abs`, `mod` and so on — which are declared in no script, so calling one was reported as a missing function.
- The indent unit is inferred per top-level structure, not per file. Seven of the 540 scripts Skript itself ships switch between tabs and spaces between structures, so a per-file rule rejected valid files.

Also in this range: skript-reflect's Java calls (`Bukkit.getVersion`, `Material.DIAMOND`, `{_item}.getItemMeta()`) are now highlighted. No Skript pattern describes them, so they previously sat as plain text, which in a reflect-heavy script is most of the file. They are matched by shape rather than classified, and neither form occurs anywhere in the scripts Skript ships.

The version in `extension.toml` at the referenced commit is 0.2.5.
