### PR TITLE
Add zeraphim-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5434,6 +5434,10 @@
 	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git
 
+[submodule "extensions/zeraphim-theme"]
+	path = extensions/zeraphim-theme
+	url = https://github.com/Zeraphim/zed-theme.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5526,6 +5526,10 @@ version = "1.4.3"
 submodule = "extensions/zenburn-transparent-theme"
 version = "1.0.0"
 
+[zeraphim-theme]
+submodule = "extensions/zeraphim-theme"
+version = "0.1.0"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## What

Adds the **Zeraphim** theme extension — a turquoise-and-teal theme with dark and light variants, built from the "Faceted Clarity" design system behind jcdiamante.com.

- Dark variant on `#060a13`, light variant re-derived for `#ffffff` (not just inverted)
- Full syntax, UI, 24-colour terminal, and 8-player color coverage
- 45 syntax captures, 152 style keys per appearance
- MIT licensed, tested locally as a dev extension

### Checklist

- [x] Extension ID `zeraphim-theme` follows the `-theme` suffix convention
- [x] Submodule added via HTTPS URL at `extensions/zeraphim-theme`, commit checked out on `main` (not detached)
- [x] `extension.toml` includes the required fields and matches the `extensions.toml` version (`0.1.0`)
- [x] MIT `LICENSE` included at the extension root
- [x] `pnpm sort-extensions` passes
