### PR TITLE
Add IntelliJ LSP — JetBrains Java & Kotlin language server for Zed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2138,6 +2138,10 @@
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git
 
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/hlucas13/intellij-lsp-zed.git
+
 [submodule "extensions/intellij-newui-theme"]
 	path = extensions/intellij-newui-theme
 	url = https://github.com/kpitt/zed-theme-intellij-newui.git
@@ -5489,7 +5493,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/intellij-lsp"]
-	path = extensions/intellij-lsp
-	url = https://github.com/hlucas13/intellij-lsp-zed.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -5489,3 +5489,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/hlucas13/intellij-lsp-zed.git
+	branch = main

--- a/extensions.toml
+++ b/extensions.toml
@@ -2184,6 +2184,10 @@ version = "0.1.0"
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
 version = "0.1.0"
+[intellij-lsp]
+submodule = "extensions/intellij-lsp"
+version = "0.2.0"
+
 
 [intl-lens]
 submodule = "extensions/intl-lens"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2181,13 +2181,13 @@ version = "0.0.1"
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"
 
-[intellij-newui-theme]
-submodule = "extensions/intellij-newui-theme"
-version = "0.1.0"
 [intellij-lsp]
 submodule = "extensions/intellij-lsp"
 version = "0.2.0"
 
+[intellij-newui-theme]
+submodule = "extensions/intellij-newui-theme"
+version = "0.1.0"
 
 [intl-lens]
 submodule = "extensions/intl-lens"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Description

**IntelliJ LSP** brings JetBrains' IntelliJ IDEA language server for Java and
Kotlin to Zed — code completion, navigation, refactorings, inspections,
quick-fixes, and Maven/Gradle/Bazel project support.  Multi-platform: macOS, Linux, and Windows.  The server binary (~368 MB) is downloaded automatically from
JetBrains' own CDN after the user explicitly accepts the JetBrains EULA.

- **Repository**: https://github.com/hlucas13/intellij-lsp-zed
- **Languages**: Java, Kotlin
- **License**: MIT (extension code) / JetBrains EULA (server, downloaded at runtime — not shipped)
- **EULA**: https://www.jetbrains.com/legal/docs/toolbox/user/
- **Server docs**: https://www.jetbrains.com/help/intellij-vscode/About-instance.html

### Context — prior PR #7089

This extension was previously submitted as PR #7089 and closed with two specific
objections:

1. **Open VSX API usage at runtime** — the extension queried the Open VSX API
   on every fresh install to resolve the latest download URL, risking rate
   limits and terms-of-use issues at scale.
2. **EULA silently bypassed** — the server was downloaded and launched without
   the user ever seeing or accepting the JetBrains EULA.

Both are resolved in v0.2.0.

### What changed

**No Open VSX API queries at extension runtime.** The extension reads a
pinned, per-version JetBrains CDN URL from `server-artifacts.json` (embedded
at compile time) and downloads the server binary from
`download-cdn.jetbrains.com` — all 6 platform architectures are pinned with
verified URLs.  The extension itself makes zero calls to any registry API.

The maintainer's CI (`auto-update.yml`) does touch Open VSX: on the 1st and
15th of each month it queries the API once to check for a new vsix release,
and if one is found it downloads the vsix wrapper for each platform from
`openvsx.eclipsecontent.org` to extract `server-bundle.json` and rebuild the
pin.  This is real traffic against Open VSX's infrastructure, but it is
biweekly, single-maintainer, runs on GitHub's CI and never on an end-user's
machine, and its volume does not scale with adoption of the extension.  A
second CI workflow (`monitor.yml`) verifies the pinned CDN URLs are still
reachable on the same schedule.

**Explicit EULA consent gate.** The extension refuses to download or execute
the server unless the user has set
`"lsp": { "intellij-server": { "settings": { "accept_jetbrains_eula": true } } }`
in their Zed `settings.json`.  The EULA link
(https://www.jetbrains.com/legal/docs/toolbox/user/) is printed in the
first-run error message and prominently linked in the README.  The consent
flag is re-checked on every launch, so version upgrades are covered.  The
EULA acceptance hash is computed from the bundled `EULA.txt` (SHA‑256, first
16 hex chars — matching the real JetBrains VS Code extension's logic
verified against its minified source).

**Additional good-faith improvements made while resolving the above:**

- `intellij.dataSharing` (`"full"` / `"anonymous"` / `"none"`) is an
  independent consent axis from EULA acceptance, defaulting to `none`
  (telemetry disabled) — data sharing is opt-in only.
- `server_path` setting takes priority over both the sandbox cache and the
  pinned auto-download, giving users full control to point at a
  self-managed server binary with zero automated downloads.
- The official sha256 hashes from `server-bundle.json` are recorded in
  `server-artifacts.json`, but runtime verification is not currently
  implemented — `zed_extension_api` 0.7.0's `download_file` does not expose
  raw bytes post-extraction.  This limitation is documented in the README.

### What's outside our control

The IntelliJ LSP server remains proprietary software distributed solely by
JetBrains.  The extension does not bundle, vendor, or redistribute it — it is
downloaded at runtime from JetBrains' own CDN, only after the user has
accepted the EULA.  If JetBrains ever publishes a sanctioned, stable download
endpoint or an official integration, this extension's pin can point at it
directly.

### Validation

| Check | Status |
|---|---|
| `cargo fmt -- --check` | ✅ |
| `cargo clippy --target wasm32-wasip2 -- -D warnings` | ✅ |
| `cargo test` (18/18) | ✅ |
| WASM build + `cmp` sync with `extension.wasm` | ✅ |
| `npx prettier --check` | ✅ |
