### PR TITLE
chore: update intellij-lsp to v0.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2138,6 +2138,10 @@
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git
 
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/hlucas13/intellij-lsp-zed.git
+
 [submodule "extensions/intellij-newui-theme"]
 	path = extensions/intellij-newui-theme
 	url = https://github.com/kpitt/zed-theme-intellij-newui.git
@@ -5489,7 +5493,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/intellij-lsp"]
-	path = extensions/intellij-lsp
-	url = https://github.com/hlucas13/intellij-lsp-zed.git
-	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -5489,3 +5489,7 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/hlucas13/intellij-lsp-zed.git
+	branch = main

--- a/extensions.toml
+++ b/extensions.toml
@@ -2184,6 +2184,10 @@ version = "0.1.0"
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
 version = "0.1.0"
+[intellij-lsp]
+submodule = "extensions/intellij-lsp"
+version = "0.2.0"
+
 
 [intl-lens]
 submodule = "extensions/intl-lens"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2181,13 +2181,13 @@ version = "0.0.1"
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"
 
-[intellij-newui-theme]
-submodule = "extensions/intellij-newui-theme"
-version = "0.1.0"
 [intellij-lsp]
 submodule = "extensions/intellij-lsp"
 version = "0.2.0"
 
+[intellij-newui-theme]
+submodule = "extensions/intellij-newui-theme"
+version = "0.1.0"
 
 [intl-lens]
 submodule = "extensions/intl-lens"


### PR DESCRIPTION
Auto-updated pinned IntelliJ LSP server to **0.0.8**.

Server version bumped automatically by CI.  No manual changes.