### PR TITLE
Update cue to v0.0.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -967,7 +967,7 @@ version = "0.0.2"
 
 [cue]
 submodule = "extensions/cue"
-version = "0.0.4"
+version = "0.0.5"
 
 [curry]
 submodule = "extensions/curry"


### PR DESCRIPTION
Release notes:

https://github.com/jkasky/zed-cue/releases/tag/v0.0.5