### PR TITLE
Add LyraShield AI MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5489,3 +5489,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/lyrashield-ai"]
+	path = extensions/lyrashield-ai
+	url = https://github.com/ecryptoguru/lyrashield-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5581,3 +5581,6 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+[lyrashield-ai]
+submodule = "extensions/lyrashield-ai"
+version = "0.1.0"


### PR DESCRIPTION
## Summary
- add the LyraShield AI Zed MCP extension as a submodule
- register version 0.1.0 in extensions.toml

## Source
https://github.com/ecryptoguru/lyrashield-zed-extension

## Behavior
The extension launches the published @lyrashield/mcp package. OAuth login uses the shared CLI credential store; the default connection is read-only and workspace-scoped, while writes remain approval-gated.

## Validation
The extension source and manifest are included in the public repository. Local Cargo validation is pending because Rust/Cargo is not installed in this environment.