### PR TITLE
Add hadal-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1870,6 +1870,10 @@
 	path = extensions/hackthebox-theme
 	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
+[submodule "extensions/hadal"]
+	path = extensions/hadal
+	url = https://github.com/maikel-479/hadal.git
+
 [submodule "extensions/hakimi-deuteranopia-theme"]
 	path = extensions/hakimi-deuteranopia-theme
 	url = https://github.com/zogwosh/hakimi-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1874,8 +1874,8 @@
 	path = extensions/hackthebox-theme
 	url = https://github.com/b00tk1ll/hackthebox-zed-theme.git
 
-[submodule "extensions/hadal"]
-	path = extensions/hadal
+[submodule "extensions/hadal-theme"]
+	path = extensions/hadal-theme
 	url = https://github.com/maikel-479/hadal.git
 
 [submodule "extensions/hakimi-deuteranopia-theme"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1910,8 +1910,8 @@ version = "2.0.0"
 submodule = "extensions/hackthebox-theme"
 version = "0.1.0"
 
-[hadal]
-submodule = "extensions/hadal"
+[hadal-theme]
+submodule = "extensions/hadal-theme"
 version = "0.1.0"
 
 [hakimi-deuteranopia-theme]

--- a/extensions.toml
+++ b/extensions.toml
@@ -1905,6 +1905,10 @@ version = "2.0.0"
 submodule = "extensions/hackthebox-theme"
 version = "0.1.0"
 
+[hadal]
+submodule = "extensions/hadal"
+version = "0.1.0"
+
 [hakimi-deuteranopia-theme]
 submodule = "extensions/hakimi-deuteranopia-theme"
 path = "zed"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## What

Adds the **Hadal** theme extension — a deep-sea inspired theme with dark and light variants.

- Dark variant with a deep ocean blue background, teal and cyan accents
- Light variant with clean white background, teal accents
- Full syntax highlighting with 101 captures, 176 style keys per variant
- Complete terminal ANSI color support (16 colors + dim/bright variants)
- 8 player cursor colors for collaboration
- MIT licensed, tested locally as a dev extension

### Checklist

- [x] Extension ID `hadal-theme` follows the `-theme` suffix convention
- [x] Submodule added via HTTPS URL at `extensions/hadal-theme`, commit checked out on `main` (not detached)
- [x] `extension.toml` includes the required fields and matches the `extensions.toml` version (`0.1.0`)
- [x] MIT `LICENSE` included at the extension root
- [x] Theme tested locally as a dev extension
- [x] Theme validated against Zed theme v0.2.0 schema