### PR TITLE
Add VSCode Modern Tweaked theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5214,6 +5214,10 @@
 	path = extensions/vscode-modern
 	url = https://github.com/fabrialberio/zed-vscode-modern-theme.git
 
+[submodule "extensions/vscode-modern-tweaked-theme"]
+	path = extensions/vscode-modern-tweaked-theme
+	url = https://github.com/maxhu08/modern-tweaked-zed.git
+
 [submodule "extensions/vscode-monokai-charcoal"]
 	path = extensions/vscode-monokai-charcoal
 	url = https://github.com/d1y/vscode-monokaicharcoal.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5308,6 +5308,10 @@ version = "0.0.2"
 submodule = "extensions/vscode-modern"
 version = "0.1.2"
 
+[vscode-modern-tweaked-theme]
+submodule = "extensions/vscode-modern-tweaked-theme"
+version = "0.1.0"
+
 [vscode-monokai-charcoal]
 submodule = "extensions/vscode-monokai-charcoal"
 version = "0.0.2"


### PR DESCRIPTION
Adds VSCode Modern Tweaked, a collection of flatter, refined variants of the VS Code Modern dark and light themes.

Included themes:
- VSCode Dark Modern Tweaked
- VSCode Darker Modern Tweaked
- VSCode Light Modern Tweaked

Validation performed:
- Theme JSON validated against the Zed v0.2.0 theme schema
- Registry entries sorted with `pnpm sort-extensions`
- Registry TypeScript build passed
- Registry test suite passed (115 tests)

Extension repository: https://github.com/maxhu08/modern-tweaked-zed