### PR TITLE
Update agnix to v0.48.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -73,7 +73,7 @@ version = "0.2.1"
 [agnix]
 submodule = "extensions/agnix"
 path = "editors/zed"
-version = "0.17.0"
+version = "0.48.0"
 
 [agno-theme]
 submodule = "extensions/agno-theme"


### PR DESCRIPTION
Updates the agnix extension from v0.17.0 to v0.48.0.

- Points the submodule at the tagged v0.48.0 release commit
- Updates the registry version to 0.48.0
- The extension manifest at that commit reports 0.48.0 and includes an accepted MIT license

Release: https://github.com/agent-sh/agnix/releases/tag/v0.48.0