### PR TITLE
Add human-plus-plus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5501,3 +5501,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/human-plus-plus"]
+	path = extensions/human-plus-plus
+	url = https://github.com/fielding/human-plus-plus.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2101,6 +2101,11 @@ version = "0.0.1"
 submodule = "extensions/hujson"
 version = "1.1.0"
 
+[human-plus-plus]
+submodule = "extensions/human-plus-plus"
+path = "packages/zed-extension"
+version = "1.6.0"
+
 [hurl]
 submodule = "extensions/hurl"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Human++**, a Base24 dark theme (repo: https://github.com/fielding/human-plus-plus, extension lives at `packages/zed-extension`, MIT licensed). Tested locally as a dev extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)