### PR TITLE
Add Beast language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -418,6 +418,10 @@
 	path = extensions/bearded-theme
 	url = https://github.com/BeardedBear/bearded-theme-zed.git
 
+[submodule "extensions/beast"]
+	path = extensions/beast
+	url = https://github.com/phtn/beast-ext
+
 [submodule "extensions/bebop-theme"]
 	path = extensions/bebop-theme
 	url = https://github.com/ATTron/zed-bebop-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -427,6 +427,10 @@ version = "1.0.0"
 submodule = "extensions/bearded-theme"
 version = "1.0.0"
 
+[beast]
+submodule = "extensions/beast"
+version = "0.1.0"
+
 [bebop-theme]
 submodule = "extensions/bebop-theme"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant
  guidance for adding my extension.

  ## Summary

  Adds the Beast extension v0.1.0.

  Beast provides language support for `.btsx` files, an indentation-based, Pug-style syntax that compiles to TSX.

  ## Features

  - Syntax highlighting
  - Indentation-aware parsing
  - TSX injection for expressions and attributes
  - Bracket matching
  - Code folding
  - Document outlines

  ## Validation

  - Installed and tested locally as a Zed dev extension
  - Tree-sitter corpus and highlighting tests pass
  - Fuzz tests pass
  - Wasm grammar builds successfully

  Extension repository: https://github.com/phtn/beast-ext