### PR TITLE
Add erlang-qol-snippets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1386,6 +1386,10 @@
 	path = extensions/erlang
 	url = https://github.com/zed-extensions/erlang.git
 
+[submodule "extensions/erlang-qol-snippets"]
+	path = extensions/erlang-qol-snippets
+	url = https://github.com/ACodingDay/erlang-qol-snippets.git
+
 [submodule "extensions/esmerald-theme"]
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1410,6 +1410,10 @@ version = "0.1.0"
 submodule = "extensions/erlang"
 version = "0.3.0"
 
+[erlang-qol-snippets]
+submodule = "extensions/erlang-qol-snippets"
+version = "0.1.0"
+
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
 version = "0.1.2"


### PR DESCRIPTION
Erlang QoL snippets: module and comment templates for the Zed editor.

- 11 module templates (gen_server, gen_statem, supervisor, header with include guard, empty, CT, poolboy worker, cowboy websocket/REST handler, lager handler, escript)
- 3 comment templates and 14 everyday code snippets
- Ported from the MIT-licensed VSCode extension erlang-code-generation (Qualia91)
- Snippets-only extension, no Rust/WASM build required