### PR TITLE
Add LyraShield AI MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5489,3 +5489,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/lyrashield-ai"]
+	path = extensions/lyrashield-ai
+	url = https://github.com/ecryptoguru/lyrashield-zed-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2598,6 +2598,10 @@
 	path = extensions/lydia
 	url = https://github.com/dimitrisnl/lydia-zed-theme
 
+[submodule "extensions/lyrashield-ai"]
+	path = extensions/lyrashield-ai
+	url = https://github.com/ecryptoguru/lyrashield-zed-extension.git
+
 [submodule "extensions/mach"]
 	path = extensions/mach
 	url = https://github.com/octalide/mach-zed.git
@@ -5489,6 +5493,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/lyrashield-ai"]
-	path = extensions/lyrashield-ai
-	url = https://github.com/ecryptoguru/lyrashield-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5581,3 +5581,6 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+[lyrashield-ai]
+submodule = "extensions/lyrashield-ai"
+version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2650,6 +2650,10 @@ version = "0.6.1"
 submodule = "extensions/lydia"
 version = "0.0.4"
 
+[lyrashield-ai]
+submodule = "extensions/lyrashield-ai"
+version = "0.1.0"
+
 [mach]
 submodule = "extensions/mach"
 version = "0.4.2"
@@ -5581,6 +5585,3 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
-[lyrashield-ai]
-submodule = "extensions/lyrashield-ai"
-version = "0.1.0"


### PR DESCRIPTION
## Summary
- add the LyraShield AI Zed MCP extension as a submodule
- register version 0.1.0 in `extensions.toml`
- use the published `lyrashield-zed-extension` commit with its required Apache-2.0 license
- keep `.gitmodules` and `extensions.toml` sorted with `pnpm sort-extensions`

## Source
https://github.com/ecryptoguru/lyrashield-zed-extension/tree/671c32df66344e4375e119032cce1cd730ee05b8

## Behavior
The extension launches the published `@lyrashield/mcp` package. OAuth login uses the shared CLI credential store; the default connection is read-only and workspace-scoped, while writes remain approval-gated.

## Validation
- `pnpm build` passed
- `pnpm test` passed (115 tests)
- `pnpm sort-extensions` passed
- the package validator passed license detection; the final local packaging step requires Zed's `zed-extension` binary, which is supplied by CI

The CLA bot may require the contributor to sign the Zed CLA before review.
