### PR TITLE
Add django-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1158,6 +1158,10 @@
 	path = extensions/django
 	url = https://github.com/joshuadavidthomas/zed-django.git
 
+[submodule "extensions/django-lsp"]
+	path = extensions/django-lsp
+	url = https://github.com/patrick91/django-lsp.git
+
 [submodule "extensions/django-snippets"]
 	path = extensions/django-snippets
 	url = https://github.com/bencres/zed-django-snippets.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1180,6 +1180,11 @@ version = "0.2.4"
 submodule = "extensions/django"
 version = "0.2.2"
 
+[django-lsp]
+submodule = "extensions/django-lsp"
+path = "extensions/zed-extension"
+version = "0.1.0"
+
 [django-snippets]
 submodule = "extensions/django-snippets"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the `django-lsp` extension, which provides Django ORM query completions in Python files without replacing Zed's general Python language servers.

The extension uses an existing `django-lsp` executable from `PATH` when available, otherwise it downloads the matching executable from the latest GitHub release. macOS (Apple Silicon and Intel), Linux (ARM64 and x86-64), and Windows (x86-64) are supported.

Extension repository: https://github.com/patrick91/django-lsp

## Validation

- built the extension for `wasm32-wasip1` with its locked dependencies
- passed extension formatting and Clippy with warnings denied
- confirmed the latest release contains all five expected server executables
- passed this repository's TypeScript build and all 115 tests
- validated the extension-local MIT license with this repository's license validator
- ran `pnpm sort-extensions`

Closes patrick91/django-lsp#9 once published.
