### PR TITLE
Add Qwark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3994,6 +3994,10 @@
 	path = extensions/quint
 	url = https://github.com/zdavison/zed-quint.git
 
+[submodule "extensions/qwark-theme"]
+	path = extensions/qwark-theme
+	url = https://github.com/biancofla/qwark.git
+
 [submodule "extensions/r"]
 	path = extensions/r
 	url = https://github.com/ocsmit/zed-r.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4063,6 +4063,10 @@ version = "0.2.2"
 submodule = "extensions/quint"
 version = "0.2.0"
 
+[qwark-theme]
+submodule = "extensions/qwark-theme"
+version = "0.2.0"
+
 [r]
 submodule = "extensions/r"
 version = "0.2.5"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Qwark, a muted green theme family with dark and light variants designed for comfortable long reading and coding sessions.

The extension was installed and tested locally as a dev extension in Zed.