### PR TITLE
Add LyraShield AI MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2622,6 +2622,10 @@
 	path = extensions/lydia
 	url = https://github.com/dimitrisnl/lydia-zed-theme
 
+[submodule "extensions/lyrashield-mcp"]
+	path = extensions/lyrashield-mcp
+	url = https://github.com/ecryptoguru/lyrashield-zed-extension.git
+
 [submodule "extensions/mach"]
 	path = extensions/mach
 	url = https://github.com/octalide/mach-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2674,6 +2674,10 @@ version = "0.6.1"
 submodule = "extensions/lydia"
 version = "0.0.4"
 
+[lyrashield-mcp]
+submodule = "extensions/lyrashield-mcp"
+version = "0.1.0"
+
 [mach]
 submodule = "extensions/mach"
 version = "0.4.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2759,7 +2759,7 @@ version = "0.0.4"
 
 [lyrashield-mcp]
 submodule = "extensions/lyrashield-mcp"
-version = "0.1.0"
+version = "0.1.1"
 
 [mach]
 submodule = "extensions/mach"


### PR DESCRIPTION
## Summary

Add the LyraShield AI MCP Zed extension as a submodule at `extensions/lyrashield-mcp` and register it in `extensions.toml`.

- Extension ID: `lyrashield-mcp`; display name: `LyraShield AI MCP`.
- Uses `zed::npm_install_package` and `zed::node_binary_path`; it does not use `npx`.
- Declares only the least-privilege `npm:install` capability for `@lyrashield/mcp`; the requested `process:exec` capability has been removed.
- Supports OAuth-first setup through the existing user-only LyraShield credential store, with an explicit API-key fallback for CI or non-OAuth environments.

## Source

`https://github.com/ecryptoguru/lyrashield-zed-extension` at `0ccbad33d9e1da7b9eb6f794c4b6f1d373f403ae` (version `0.1.1`).

## Validation

- `pnpm build` passed.
- `pnpm test` passed (115 tests).
- `pnpm sort-extensions` passed.
- The Zed package CI is running against this updated submodule revision.