### PR TITLE
Add Skopio language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4382,8 +4382,8 @@
 	path = extensions/skill-language-server
 	url = https://github.com/CyrusNuevoDia/skill-language-server.git
 
-[submodule "extensions/skopio"]
-	path = extensions/skopio
+[submodule "extensions/skopio-activity-tracker"]
+	path = extensions/skopio-activity-tracker
 	url = https://github.com/Skopio-app/skopio-zed.git
 
 [submodule "extensions/skript"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4382,6 +4382,10 @@
 	path = extensions/skill-language-server
 	url = https://github.com/CyrusNuevoDia/skill-language-server.git
 
+[submodule "extensions/skopio"]
+	path = extensions/skopio
+	url = https://github.com/Skopio-app/skopio-zed.git
+
 [submodule "extensions/skript"]
 	path = extensions/skript
 	url = https://github.com/DaisyCatTs/SkriptZed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4457,9 +4457,9 @@ submodule = "extensions/skill-language-server"
 path = "ext/zed"
 version = "0.0.1"
 
-[skopio]
-submodule = "extensions/skopio"
-version = "0.1.1"
+[skopio-activity-tracker]
+submodule = "extensions/skopio-activity-tracker"
+version = "0.1.2"
 
 [skript]
 submodule = "extensions/skript"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4457,6 +4457,10 @@ submodule = "extensions/skill-language-server"
 path = "ext/zed"
 version = "0.0.1"
 
+[skopio]
+submodule = "extensions/skopio"
+version = "0.1.1"
+
 [skript]
 submodule = "extensions/skript"
 path = "extension"


### PR DESCRIPTION
## Description

Adds Skopio, a macOS coding-activity tracking extension for Zed.

Skopio tracks coding sessions across supported languages and displays the
results in the local [Skopio desktop app](https://github.com/Skopio-app/skopio/blob/main/apps/desktop/README.md).

## Data collected

For each coding session, the extension records:

- Absolute file and project paths
- Current Git branch, when available
- Session start and end timestamps
- Session duration
- App, activity category, entity type, and source metadata

Source-code contents are not stored or sent to Skopio Desktop.

## Requirements

- macOS on Apple Silicon or Intel
- Skopio Desktop installed and running when events are synchronized
- No separate online account is required

Events are buffered locally if Skopio Desktop is unavailable.

## Implementation

The extension downloads `skopio-ls` and `skopio-cli` at runtime. Neither binary
is bundled in the extension. CLI archives are checksum-verified before
extraction.

## Testing

- Installed successfully as a Zed dev extension
- Verified compilation for `wasm32-wasip2`
- Confirmed coding events appear correctly in Skopio Desktop
- Confirmed activity across multiple languages

This supersedes #5047 and addresses the missing `extensions.toml` entry,
publishing prerequisites, installation problems, and requested explanation of
the extension's user benefit and requirements.
