### PR TITLE
Add Phoenix Pulse theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3702,6 +3702,10 @@
 	path = extensions/phine-theme
 	url = https://github.com/phisch/phine-zed.git
 
+[submodule "extensions/phoenix-pulse-theme"]
+	path = extensions/phoenix-pulse-theme
+	url = https://github.com/phoenix-pulse/zed-themes.git
+
 [submodule "extensions/phosphor-icons-theme"]
 	path = extensions/phosphor-icons-theme
 	url = https://github.com/theoluciano/phosphor-icons-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3763,6 +3763,10 @@ version = "1.0.0"
 submodule = "extensions/phine-theme"
 version = "0.0.1"
 
+[phoenix-pulse-theme]
+submodule = "extensions/phoenix-pulse-theme"
+version = "0.1.0"
+
 [phosphor-icons-theme]
 submodule = "extensions/phosphor-icons-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- add the Phoenix Pulse Themes extension
- include the EX and ERL theme families
- provide dark and light variants for both families

## Validation

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests passed)
