### PR TITLE
Update simple-light-theme to v0.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4438,7 +4438,8 @@ version = "0.0.1"
 
 [simple-light-theme]
 submodule = "extensions/simple-light-theme"
-version = "0.4.0"
+path = "zed"
+version = "0.5.0"
 
 [simula]
 submodule = "extensions/simula"


### PR DESCRIPTION
Updates `simple-light-theme` submodule to v0.5.0.

Also adds `path = "zed"`: the extension was moved into a `zed/` subdirectory of the repository, so `extension.toml` is no longer at the repo root.