### PR TITLE
Update comphy-crisp-themes to v1.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -871,7 +871,7 @@ version = "1.0.4"
 
 [comphy-crisp-themes]
 submodule = "extensions/comphy-crisp-themes"
-version = "1.0.1"
+version = "1.1.0"
 
 [compline]
 submodule = "extensions/compline"


### PR DESCRIPTION
Bumps `comphy-crisp-themes` to v1.1.0, which adds a second theme family, **CoMPhy Gruvbox Plum** (near-black surfaces, CoMPhy brand-purple accent, Gruvbox/Dracula syntax hues). Submodule pointer updated to the v1.1.0 tag of the extension repository.