### PR TITLE
Add Unyly Gateway MCP server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5553,3 +5553,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcp-server-unyly"]
+	path = extensions/mcp-server-unyly
+	url = https://github.com/FasadSalatov/zed-mcp-server-unyly

--- a/.gitmodules
+++ b/.gitmodules
@@ -2922,6 +2922,10 @@
 	path = extensions/mcp-server-threadbridge
 	url = https://github.com/dereklei12/zed-mcp-server-threadbridge.git
 
+[submodule "extensions/mcp-server-unyly"]
+	path = extensions/mcp-server-unyly
+	url = https://github.com/FasadSalatov/zed-mcp-server-unyly
+
 [submodule "extensions/mcp-server-webflow"]
 	path = extensions/mcp-server-webflow
 	url = https://github.com/LoamStudios/zed-mcp-server-webflow.git
@@ -5553,6 +5557,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/mcp-server-unyly"]
-	path = extensions/mcp-server-unyly
-	url = https://github.com/FasadSalatov/zed-mcp-server-unyly

--- a/extensions.toml
+++ b/extensions.toml
@@ -2975,6 +2975,10 @@ version = "0.0.2"
 submodule = "extensions/mcp-server-threadbridge"
 version = "0.2.1"
 
+[mcp-server-unyly]
+submodule = "extensions/mcp-server-unyly"
+version = "0.0.1"
+
 [mcp-server-webflow]
 submodule = "extensions/mcp-server-webflow"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **mcp-server-unyly** — a context server that connects Zed's Agent Panel to the [Unyly](https://unyly.org) catalog gateway.

**What it does:** instead of installing MCP servers one by one, the gateway (`gateway.unyly.org/mcp`, Streamable HTTP + OAuth 2.1) exposes an 80,000+ server catalog through three meta-tools: `search_mcps` (semantic search by task), `list_mcp_tools`, `use_mcp_tool` (dispatches the call on the fly). The extension bridges the remote server through `mcp-remote`, which handles the browser OAuth flow on first use.

**Extension repo:** https://github.com/FasadSalatov/zed-mcp-server-unyly (Apache-2.0)

I run the Unyly project. The gateway endpoint is free for client integrations; the same endpoint is already listed on Smithery, Glama and the Official MCP Registry.
