### PR TITLE
Add eskip language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1414,6 +1414,10 @@
 	path = extensions/erlang-qol-snippets
 	url = https://github.com/ACodingDay/erlang-qol-snippets.git
 
+[submodule "extensions/eskip"]
+	path = extensions/eskip
+	url = https://github.com/carloluis/zed-eskip
+
 [submodule "extensions/esmerald-theme"]
 	path = extensions/esmerald-theme
 	url = https://github.com/esthorace/esmerald-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -1439,6 +1439,10 @@ version = "0.3.0"
 submodule = "extensions/erlang-qol-snippets"
 version = "0.1.0"
 
+[eskip]
+submodule = "extensions/eskip"
+version = "0.0.1"
+
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
 version = "0.1.2"


### PR DESCRIPTION
## Add `eskip` language extension

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding my extension.
- [x] Extension: carloluis/zed-eskip#1
- [x] Grammar Repo: https://github.com/carloluis/tree-sitter-eskip

Adds support for [eskip](https://pkg.go.dev/github.com/zalando/skipper/eskip) — the routing configuration language used by [Skipper](https://github.com/zalando/skipper). 
See docs: <https://opensource.zalando.com/skipper/data-clients/eskip-file/>
Tested https://github.com/carloluis/zed-eskip#installing-locally-dev-extension

<img width="1243" height="568" alt="Image Zed Screenshot" src="https://github.com/user-attachments/assets/7abfbcdb-20c1-4b87-ac76-bce6668ba0f1" />