### PR TITLE
Add root package to pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 allowBuilds:
   core-js: true
   esbuild: true


### PR DESCRIPTION
## fix: add packages field to pnpm-workspace.yaml

pnpm install fails on pnpm v9 with:

```
ERROR  packages field missing or empty
```

This was introduced in #6415, which added `pnpm-workspace.yaml` without a packages field. pnpm v11 apparently relaxed that requirement, but v9 (and likely other pre-v11 versions) still enforce it.

This adds `packages: ["."]` so contributors running an older pnpm version can still install dependencies and run scripts like `sort-extensions` locally.

> [!NOTE]
> tested on pnpm v9.15.0. Unable to verify on v11 but the field is valid there too — a single root package workspace is well-supported.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
- [x] error discovered when running `pnpm sort-extensions` in #7155
     - <img width="389" height="83" alt="Screenshot 2026-08-10 at 02 33 36" src="https://github.com/user-attachments/assets/7abd75e6-473b-4e84-9735-980b308a8aac" />
