### PR TITLE
Add deepseek-visionary context server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1102,6 +1102,10 @@
 	path = extensions/deep-slate-theme
 	url = https://github.com/Roter-S/deep-slate-theme.git
 
+[submodule "extensions/deepseek-visionary"]
+	path = extensions/deepseek-visionary
+	url = https://github.com/xlight/deepseek-visionary.git
+
 [submodule "extensions/defold"]
 	path = extensions/defold
 	url = https://github.com/whiterabbit1983/zed-defold

--- a/extensions.toml
+++ b/extensions.toml
@@ -1124,7 +1124,7 @@ version = "0.1.1"
 [deepseek-visionary]
 submodule = "extensions/deepseek-visionary"
 path = "crates/visionary-zed-ext"
-version = "0.2.1"
+version = "0.2.2"
 
 [defold]
 submodule = "extensions/defold"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1121,6 +1121,11 @@ version = "0.1.0"
 submodule = "extensions/deep-slate-theme"
 version = "0.1.1"
 
+[deepseek-visionary]
+submodule = "extensions/deepseek-visionary"
+path = "crates/visionary-zed-ext"
+version = "0.2.1"
+
 [defold]
 submodule = "extensions/defold"
 version = "0.1.4"


### PR DESCRIPTION
## Summary

Adds the **DeepSeek Visionary** context server extension, which exposes DeepSeek's web vision model as an MCP server with 4 tools:

- `deepseek_vision` — image recognition
- `deepseek_vision_login` — browser auto-login
- `deepseek_vision_status` — token/credential status
- `deepseek_vision_logout` — logout

## Architecture

The extension is a thin WASM shell (`crates/visionary-zed-ext`). In compliance with the guideline that MCP servers must not be bundled into the extension, the native `visionary-server` binary is **downloaded from GitHub Releases** at runtime via `latest_github_release` + `download_file` (matching asset `visionary-server-<arch>-<os>[.exe]` per platform, `DownloadedFileType::Uncompressed`), cached under the extension directory.

## Testing

- Tested locally as a dev extension (`Extensions` → `Install Dev Extension`): installs, downloads the binary, and the 4 tools are listed via the MCP `tools/list` handshake.
- Asset naming matches the released binaries for all 5 platforms (macOS x86_64/aarch64, Linux x86_64/aarch64, Windows x86_64).

## License

MIT (`crates/visionary-zed-ext/LICENSE`). Extension ID `deepseek-visionary` is unique and contains no `zed`/`extension` wording.
