### PR TITLE
Update markdown-snippets to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2744,7 +2744,7 @@ version = "0.0.5"
 
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
-version = "0.0.8"
+version = "0.1.0"
 
 [markdownlint]
 submodule = "extensions/markdownlint"


### PR DESCRIPTION
Release notes:

https://github.com/bobbymannino/markdown-snippets-for-zed/releases/tag/v0.1.0