### PR TITLE
Add Native SDK extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3334,6 +3334,10 @@
 	path = extensions/napalm
 	url = https://github.com/napalmpapalam/napalm-theme-zed.git
 
+[submodule "extensions/native-sdk"]
+	path = extensions/native-sdk
+	url = https://github.com/alvgaona/zed-native-sdk.git
+
 [submodule "extensions/nautilus"]
 	path = extensions/nautilus
 	url = https://github.com/ndr-lmnc/zed-nautilus

--- a/.gitmodules
+++ b/.gitmodules
@@ -3166,6 +3166,10 @@
 	path = extensions/napalm
 	url = https://github.com/napalmpapalam/napalm-theme-zed.git
 
+[submodule "extensions/native-sdk"]
+	path = extensions/native-sdk
+	url = https://github.com/alvgaona/zed-native-sdk.git
+
 [submodule "extensions/nautilus"]
 	path = extensions/nautilus
 	url = https://github.com/ndr-lmnc/zed-nautilus

--- a/extensions.toml
+++ b/extensions.toml
@@ -3399,6 +3399,10 @@ version = "0.1.0"
 submodule = "extensions/napalm"
 version = "0.1.0"
 
+[native-sdk]
+submodule = "extensions/native-sdk"
+version = "0.1.0"
+
 [nautilus]
 submodule = "extensions/nautilus"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3223,6 +3223,10 @@ version = "0.1.0"
 submodule = "extensions/napalm"
 version = "0.1.0"
 
+[native-sdk]
+submodule = "extensions/native-sdk"
+version = "0.1.0"
+
 [nautilus]
 submodule = "extensions/nautilus"
 version = "0.1.0"


### PR DESCRIPTION
Adds `native-sdk`, language support for [Native SDK](https://native-sdk.dev/) `.native` markup.

Native SDK is Vercel Labs' toolkit for building native desktop apps: views are declarative markup in `.native` files, logic is TypeScript or Zig, and its own engine renders to real OS windows. There is no editor support for the markup today.

**Repository:** https://github.com/alvgaona/zed-native-sdk (MIT).
**Grammar:** https://github.com/alvgaona/tree-sitter-native (MIT). Written for this and usable outside Zed

What the extension provides:

- Highlighting, brackets, indents and an outline of the templates in a view, from the Tree-sitter grammar.
- Diagnostics, hover and completion by running `native markup lsp`, a subcommand of the SDK's own CLI.

The language server is **not** shipped with the extension. It is resolved at runtime from the worktree's `node_modules/.bin/native` or from `PATH`, and when neither exists the extension reports that diagnostics are off and highlighting still works.

Tested locally as a dev extension against a real Native SDK app, with highlighting, outline, hover, completion and live diagnostics all confirmed working. The grammar parses 113 markup samples extracted from the SDK's own test suite plus the app's views with no errors.
