### PR TITLE
Update coverage-lsp to v1.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -905,7 +905,7 @@ version = "0.0.1"
 
 [coverage-lsp]
 submodule = "extensions/coverage-lsp"
-version = "1.0.1"
+version = "1.0.3"
 path = "zed-coverage-lsp"
 
 [cpp2]


### PR DESCRIPTION
 - Add "Python" in supported languages (fixes: https://github.com/fargies/coverage-lsp/issues/1)
 - Fix lsp binary update sequence
 - LSP binary has been released in v1.1.2 (to fix https://github.com/fargies/coverage-lsp/issues/3)

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
