### PR TITLE
Update Julia to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2383,7 +2383,7 @@ version = "0.1.0"
 
 [julia]
 submodule = "extensions/julia"
-version = "0.1.10"
+version = "0.2.0"
 
 [just]
 submodule = "extensions/just"


### PR DESCRIPTION
Migrate from LanguageServer.jl to JETLS.jl

This is a breaking change!  See the extension's [README](https://github.com/JuliaEditorSupport/zed-julia).

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
