### PR TITLE
Add firefox-quantum-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1506,6 +1506,10 @@
 	path = extensions/firebase-security-rules
 	url = https://github.com/ChemisTechlabs/zed-firebase-security-rules.git
 
+[submodule "extensions/firefox-quantum-theme"]
+	path = extensions/firefox-quantum-theme
+	url = https://github.com/devinaxo/zed-firefox-quantum-themes.git
+
 [submodule "extensions/firrtl-source-locator"]
 	path = extensions/firrtl-source-locator
 	url = https://github.com/MrAMS/zed-firrtl-source-locator.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1534,6 +1534,10 @@ version = "0.1.1"
 submodule = "extensions/firebase-security-rules"
 version = "0.1.1"
 
+[firefox-quantum-theme]
+submodule = "extensions/firefox-quantum-theme"
+version = "1.0.2"
+
 [firrtl-source-locator]
 submodule = "extensions/firrtl-source-locator"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

 Adds the Firefox Quantum color theme (v1.0.2) to the Zed extension registry.
  
  ### Summary
  
  • Extension ID: firefox-quantum-theme
  • Version: 1.0.2
  • Repository: https://github.com/devinaxo/zed-firefox-quantum-themes
  • License: MIT
  
  ### Included Variants (4 Themes)
  
  • Firefox Quantum Dark: A dark port of the Firefox DevTools palette (#14171a, editor #181d20) with the Firefox semanttic syntax highlighting with cyan accents.
  • Firefox Quantum Light: The matching light variant (#f7f7f7, editor #fcfcfc) with blue accents.