### PR TITLE
Add Stylus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4598,6 +4598,10 @@
 	path = extensions/stylelint
 	url = https://github.com/florian-sanders/zed-stylelint.git
 
+[submodule "extensions/stylus"]
+	path = extensions/stylus
+	url = https://github.com/WMikhail/stylus-tooling.git
+
 [submodule "extensions/styx"]
 	path = extensions/styx
 	url = https://github.com/bearcove/styx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4679,6 +4679,11 @@ version = "0.0.1"
 submodule = "extensions/stylelint"
 version = "3.0.0"
 
+[stylus]
+submodule = "extensions/stylus"
+path = "editors/zed"
+version = "0.6.0"
+
 [styx]
 submodule = "extensions/styx"
 path = "editors/zed-styx"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Stylus language support with a maintained Tree-sitter grammar, syntax highlighting, snippets, and a language server.

The extension installs the public `stylus-lsp@0.6.0` package and supports plain Stylus files as well as Stylus regions in Vue, Svelte, and Astro. The extension and language server are covered by Linux, macOS, Windows, WASM, grammar, fixture, capture, and performance checks.

Validation completed before submission:

- built the Zed adapter for `wasm32-wasip2`
- installed `stylus-lsp@0.6.0` from a clean npm cache and completed an LSP initialize handshake
- ran the extensions repository TypeScript build and all 115 tests

Related: #7029 proposes a different implementation for the same extension ID. This implementation was developed independently; linking both submissions so maintainers can compare them and choose the direction that best fits the catalog.
