### PR TITLE
Add Local Keep AI extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4833,3 +4833,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/local-keep-ai"]
+	path = extensions/local-keep-ai
+	url = https://github.com/laynef/localkeep-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2252,6 +2252,10 @@ version = "0.0.4"
 submodule = "extensions/llvm-ir"
 version = "0.1.1"
 
+[local-keep-ai]
+submodule = "extensions/local-keep-ai"
+version = "1.0.0"
+
 [log]
 submodule = "extensions/log"
 version = "0.0.7"


### PR DESCRIPTION
Adds the Local Keep AI extension (`local-keep-ai`, v1.0.0) as a git submodule per CONTRIBUTING.md, with a sorted `extensions.toml` entry.

Local Keep AI provides slash commands (/lk, /lk-refactor, /lk-tests, /lk-run, /lk-commit, /lk-models) that drive the `lk` CLI (`pip install local-keep-ai-cli`) for local-first AI assistance. The extension repository is MIT licensed (LICENSE at the repo root), the submodule commit is on its `main` branch, and the extension ships only extension code — the CLI is resolved from the user's PATH at runtime, never bundled.

Supersedes #6170, which predated the license file and the submodule format; both are addressed here. CLA: being signed by @laynef.