### PR TITLE
Update sora-theme to v0.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4536,7 +4536,7 @@
 
 [submodule "extensions/sora-theme"]
 	path = extensions/sora-theme
-	url = https://github.com/Aejkatappaja/sora-theme
+	url = https://github.com/Aejkatappaja/sora
 
 [submodule "extensions/sorbet"]
 	path = extensions/sorbet

--- a/extensions.toml
+++ b/extensions.toml
@@ -4616,7 +4616,8 @@ version = "0.0.7"
 
 [sora-theme]
 submodule = "extensions/sora-theme"
-version = "0.1.0"
+path = "extras/zed"
+version = "0.1.1"
 
 [sorbet]
 submodule = "extensions/sorbet"


### PR DESCRIPTION
Relocating an extension I maintain. `sora-theme` moves from its standalone repository into the repository the theme is generated from.

- `.gitmodules`: submodule url `Aejkatappaja/sora-theme` → `Aejkatappaja/sora`
- `extensions.toml`: adds `path = "extras/zed"`, version `0.1.0` → `0.1.1`
- submodule pointer → [`a20f73e`](https://github.com/Aejkatappaja/sora/commit/a20f73e9e593d4b459e98704acaad7a422d5918b)

## Why

Sora is a Neovim colorscheme, and every surface it ships to (terminals, `bat`, `fzf`, `delta`, `yazi`, and now Zed) is rendered from one palette file, with a test that fails if a committed file differs from a fresh render. The Zed theme was the last one written by hand, which meant a palette change never reached it and nothing said so. It found seven colours that no longer existed anywhere else.

Moving the source here puts it under that guard.

## What this changes for users

Nothing. `themes/sora.json` at the new location is byte for byte identical to what is currently published, `id` stays `sora-theme`, and the theme name stays `Sora`, so existing `settings.json` entries keep working. The version bump is only there to trigger a rebuild from the new source.

`extras/zed/LICENSE` is present (MIT, same as the repository root).

Tested locally as a dev extension from the new path.