### PR TITLE
Add Local Keep AI extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4833,3 +4833,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/local-keep-ai"]
+	path = extensions/local-keep-ai
+	url = https://github.com/laynef/localkeep-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2252,6 +2252,10 @@ version = "0.0.4"
 submodule = "extensions/llvm-ir"
 version = "0.1.1"
 
+[local-keep-ai]
+submodule = "extensions/local-keep-ai"
+version = "1.0.0"
+
 [log]
 submodule = "extensions/log"
 version = "0.0.7"


### PR DESCRIPTION
Adds the Local Keep AI extension (`local-keep-ai`, v1.1.0) as a git submodule, with a sorted `extensions.toml` entry.

Local Keep AI is a local-first AI coding assistant (1,000+ free models, no API key needed for local models). The extension provides a **context server**: it launches `lk mcp` from the Local Keep AI CLI (`pip install local-keep-ai-cli`), exposing `ask` and `list_models` tools to Zed's Agent Panel over MCP. The extension ships only extension code — the CLI is resolved from the user's PATH at runtime (with a `path` setting override), never bundled or downloaded.

The extension repository is MIT licensed and the pinned submodule commit is the head of its `main` branch.

Supersedes #7167. Changes since: the manifest follows the current schema (top-level keys), the extension was rewritten from the deprecated slash command API to a context server, and the CLA has been signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)