### PR TITLE
Add Local Keep AI extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2890,6 +2890,10 @@
 	path = extensions/mcp-server-kubernetes
 	url = https://github.com/ferra-io/zed-mcp-server-kubernetes.git
 
+[submodule "extensions/mcp-server-local-keep-ai"]
+	path = extensions/mcp-server-local-keep-ai
+	url = https://github.com/laynef/localkeep-zed.git
+
 [submodule "extensions/mcp-server-markitdown"]
 	path = extensions/mcp-server-markitdown
 	url = https://github.com/G36maid/zed-mcp-server-markitdown

--- a/extensions.toml
+++ b/extensions.toml
@@ -2945,6 +2945,10 @@ version = "0.1.2"
 submodule = "extensions/mcp-server-kubernetes"
 version = "0.1.0"
 
+[mcp-server-local-keep-ai]
+submodule = "extensions/mcp-server-local-keep-ai"
+version = "1.2.2"
+
 [mcp-server-markitdown]
 submodule = "extensions/mcp-server-markitdown"
 version = "0.0.1"


### PR DESCRIPTION
Adds the Local Keep AI extension (`mcp-server-local-keep-ai`, v1.2.2) as a git submodule, with sorted `extensions.toml` and `.gitmodules` entries (`pnpm sort-extensions`).

The extension provides a **context server** for the Agent Panel: it launches `lk mcp` from the Local Keep AI CLI, exposing `ask` and `list_models` tools over MCP. Per the publishing prerequisites for MCP server extensions, the server is **not** bundled — the user's per-server `command` settings (path, arguments, env) are honored when set, otherwise `lk` resolves from the user's environment, and a descriptive error plus `ContextServerConfiguration` installation instructions cover the not-installed case. The extension defines no settings of its own and reads no environment outside what Zed provides.

**Testing on the exact submitted commit**, replicating this repo's CI workflow locally (linux/amd64, Node 24, pnpm 9, Rust 1.90 / `wasm32-wasip2`, pinned `zed-extension` CLI `2a00db06`), with the diff base set to current `main`:
- `pnpm install`, `pnpm build`, `pnpm test` — all pass.
- `pnpm package-extensions` — detects one changed extension, packages it; manifest reports `"provides":["context-servers"]`, `wasm_api_version: 0.7.0`.
- Runtime: full MCP session against the published CLI (v1.21.46 on PyPI) — initialize/protocol negotiation, `tools/list`, and real `tools/call` round-trips for both tools.

The extension repository is MIT licensed (LICENSE at the root), the submodule uses an HTTPS URL, and the pinned commit is the head of its `main` branch. The id follows the `mcp-server-*` convention used by MCP server extensions in this registry. CLA is signed.

Supersedes #7167/#7169 (originally submitted against the deprecated slash command API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)