### PR TITLE
Add artisan-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -218,6 +218,10 @@
 	path = extensions/ars-goetia-theme
 	url = https://github.com/rvdeguzman/ars-goetia-zed.git
 
+[submodule "extensions/artisan-theme"]
+	path = extensions/artisan-theme
+	url = https://github.com/VheissuLabs/artisan-theme.git
+
 [submodule "extensions/arturo"]
 	path = extensions/arturo
 	url = https://codeberg.org/DaZhi-the-Revelator/zed-arturo.git
@@ -5641,6 +5645,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/artisan-theme"]
-	path = extensions/artisan-theme
-	url = https://github.com/VheissuLabs/artisan-theme.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5641,3 +5641,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/artisan-theme"]
+	path = extensions/artisan-theme
+	url = https://github.com/VheissuLabs/artisan-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -223,6 +223,11 @@ version = "0.3.0"
 submodule = "extensions/ars-goetia-theme"
 version = "0.0.1"
 
+[artisan-theme]
+submodule = "extensions/artisan-theme"
+path = "zed"
+version = "0.2.0"
+
 [arturo]
 submodule = "extensions/arturo"
 version = "1.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -226,7 +226,7 @@ version = "0.0.1"
 [artisan-theme]
 submodule = "extensions/artisan-theme"
 path = "zed"
-version = "0.2.0"
+version = "0.3.0"
 
 [arturo]
 submodule = "extensions/arturo"

--- a/extensions.toml
+++ b/extensions.toml
@@ -226,7 +226,7 @@ version = "0.0.1"
 [artisan-theme]
 submodule = "extensions/artisan-theme"
 path = "zed"
-version = "0.3.0"
+version = "0.4.0"
 
 [arturo]
 submodule = "extensions/arturo"


### PR DESCRIPTION
Adds **Artisan Theme**, a light theme inspired by Laravel's branding.

- Repository: https://github.com/VheissuLabs/artisan-theme
- License: MIT
- Single light theme; the extension lives in the `zed/` subdirectory, so the entry uses `path = "zed"`.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.