### PR TITLE
Update TSRX to v0.0.85

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5122,7 +5122,7 @@ version = "1.1.0"
 [tsrx]
 submodule = "extensions/tsrx"
 path = "packages/zed-plugin"
-version = "0.0.84"
+version = "0.0.85"
 
 [turtle]
 submodule = "extensions/turtle"


### PR DESCRIPTION
## Summary

- update the TSRX extension registry entry from 0.0.84 to 0.0.85
- advance the Ripple submodule to the commit containing the matching Zed extension manifest
- update the bundled language server from 0.2.208 to 0.3.118

## Why

The registry still points at TSRX 0.0.84. Ripple main already contains 0.0.85, which updates the language tooling to the current TSRX packages and includes Octane compiler auto-detection for published packages.

## Validation

- pnpm sort-extensions
- pnpm build
- pnpm test (115 tests passed)
- cargo check --manifest-path extensions/tsrx/packages/zed-plugin/Cargo.toml --target wasm32-wasip2