### PR TITLE
Add `.4dm` language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1558,6 +1558,10 @@
 	path = extensions/fountain
 	url = https://github.com/LaPingvino/zed-fountain
 
+[submodule "extensions/fourd"]
+    path = extensions/fourd
+    url = https://github.com/miyako/language-4dm-zed.git
+    
 [submodule "extensions/fozzy"]
 	path = extensions/fozzy
 	url = https://github.com/juxta-tad/fozzy-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1559,8 +1559,8 @@
 	url = https://github.com/LaPingvino/zed-fountain
 
 [submodule "extensions/fourd"]
-    path = extensions/fourd
-    url = https://github.com/miyako/language-4dm-zed.git
+	path = extensions/fourd
+	url = https://github.com/miyako/language-4dm-zed.git
     
 [submodule "extensions/fozzy"]
 	path = extensions/fozzy

--- a/extensions.toml
+++ b/extensions.toml
@@ -1585,6 +1585,10 @@ version = "0.0.3"
 submodule = "extensions/fountain"
 version = "0.2.0"
 
+[fourd]
+submodule = "extensions/fourd"
+version = "0.2.13"
+
 [fozzy]
 submodule = "extensions/fozzy"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

My earlier [PR](https://github.com/zed-industries/extensions/pull/6991) only added text entries in `.gitmodules` and `extensions.toml` referencing `extensions/fourd`, but never registered an actual git submodule, so the pointer described in those files had nothing behind it.

https://github.com/zed-industries/extensions/pull/6991/changes/2e7fa1000dccd58549fe0d7fd5cd4ac4774cc680

That's fixed now. `extensions/fourd` is registered as a proper submodule, mode `160000` gitlink, not a regular file:

```
$ git ls-files -s extensions/fourd
160000 383b4611e8fe805cff76311230834f2a16bcdac0 0	extensions/fourd
```

It's pinned to the tagged release, not an arbitrary commit:

```
$ cd extensions/fourd && git log -1 --oneline
383b4611 (HEAD, tag: v0.2.13) Update Cargo.lock
```

Let me know if anything else needs adjusting.