### PR TITLE
Add encrypted-armor extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5641,3 +5641,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/encrypted-armor"]
+	path = extensions/encrypted-armor
+	url = https://github.com/jiajunma/zed-crypt.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1428,6 +1428,11 @@ version = "0.20.2"
 submodule = "extensions/emoji-completions"
 version = "1.1.1"
 
+[encrypted-armor]
+submodule = "extensions/encrypted-armor"
+path = "extension"
+version = "0.1.0"
+
 [env]
 submodule = "extensions/env"
 version = "0.0.2"


### PR DESCRIPTION
Adds the **encrypted-armor** extension: transparent editing of ASCII-armored gpg/age encrypted files (`.asc`, `.age`, armored `.gpg`/`.pgp`).

Repo: https://github.com/jiajunma/zed-crypt (extension lives in `extension/`, MIT)

**How it works**: registers an "Encrypted Armor" language and a language server that decrypts the file from disk on open and swaps the buffer to plaintext via `workspace/applyEdit`; the language's external formatter re-encrypts on save so only ciphertext is ever written. A formatter failure aborts the save, so plaintext cannot leak to disk. Details and security model in the [README](https://github.com/jiajunma/zed-crypt#extension-mode).

**Language server**: not shipped in the extension — resolved from the user's PATH first, else downloaded from the repo's GitHub releases (prebuilt for macOS arm64/x64 and Linux musl arm64/x64), per the publishing guidelines.

**Tested**: end-to-end in Zed 1.14.2 on macOS (open → decrypt → edit → save → verified only armored ciphertext on disk, recipients preserved).