### PR TITLE
Update Carve to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -657,7 +657,7 @@ version = "0.4.1"
 
 [carve]
 submodule = "extensions/carve"
-version = "0.1.0"
+version = "0.1.1"
 
 [cassette-futurism-theme]
 submodule = "extensions/cassette-futurism-theme"


### PR DESCRIPTION
Updates the Carve extension registry entry and submodule to the released v0.1.1.

The release updates the Tree-sitter grammar and keeps the extension metadata in sync with the published source release.