### PR TITLE
Add code-translate extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -782,8 +782,8 @@
 	path = extensions/code-stats
 	url = https://github.com/maxdeviant/zed-code-stats.git
 
-[submodule "extensions/code-translate"]
-	path = extensions/code-translate
+[submodule "extensions/code-translate-lsp"]
+	path = extensions/code-translate-lsp
 	url = https://github.com/nazzeDe/code-translate.git
 
 [submodule "extensions/codebabel-ztheme-dark"]

--- a/.gitmodules
+++ b/.gitmodules
@@ -782,6 +782,10 @@
 	path = extensions/code-stats
 	url = https://github.com/maxdeviant/zed-code-stats.git
 
+[submodule "extensions/code-translate"]
+	path = extensions/code-translate
+	url = https://github.com/nazzeDe/code-translate.git
+
 [submodule "extensions/codebabel-ztheme-dark"]
 	path = extensions/codebabel-ztheme-dark
 	url = https://github.com/codebabel-appbag/codebabel-ztheme-dark

--- a/extensions.toml
+++ b/extensions.toml
@@ -795,6 +795,11 @@ version = "0.0.5"
 submodule = "extensions/code-stats"
 version = "0.3.0"
 
+[code-translate]
+submodule = "extensions/code-translate"
+path = "extensions/code-translate"
+version = "0.1.0"
+
 [codebabel-ztheme-dark]
 submodule = "extensions/codebabel-ztheme-dark"
 version = "0.0.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -795,8 +795,8 @@ version = "0.0.5"
 submodule = "extensions/code-stats"
 version = "0.3.0"
 
-[code-translate]
-submodule = "extensions/code-translate"
+[code-translate-lsp]
+submodule = "extensions/code-translate-lsp"
 path = "extensions/code-translate"
 version = "0.1.0"
 


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

Adds **code-translate** (v0.1.0): offline Chinese translations for English identifiers in Hover.

- Repository: https://github.com/nazzeDe/code-translate
- License: MIT (`LICENSE` at the extension path)
- Extension path in monorepo: `extensions/code-translate`

## What it provides

- A small native language server (`code-translate-lsp`) that resolves the identifier under the cursor and shows dictionary hits in Hover
- Works alongside existing language servers
- Supported languages: Rust, Python, Go, JavaScript, TypeScript, Markdown
- Fully offline: no online translation; source code does not leave the machine

## How the language server is obtained

Per the publishing prerequisites, the language server is **not** shipped inside the extension package. The extension downloads the matching release binary from GitHub Releases:

https://github.com/nazzeDe/code-translate/releases/tag/v0.1.0

Supported targets:

- `x86_64-unknown-linux-musl`
- `aarch64-unknown-linux-musl`
- `x86_64-apple-darwin`
- `aarch64-apple-darwin`
- `x86_64-pc-windows-msvc`
- `aarch64-pc-windows-msvc`

## Validation

- Installed and tested locally as a Zed **dev extension**
- Workspace checks: `cargo fmt`, `clippy`, `cargo test --workspace`, `wasm32-wasip2` check
- Release assets for `v0.1.0` are published and match the extension version
- `pnpm sort-extensions` run; `extensions.toml` / `.gitmodules` sorted
- Submodule uses HTTPS and points to a commit on `main` (not detached)

## Attribution

Dictionary shards are taken from [w88975/code-translate-vscode](https://github.com/w88975/code-translate-vscode) (MIT).