### PR TITLE
Add cron-sense language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -930,6 +930,10 @@
 	path = extensions/crimson-theme
 	url = https://github.com/kaem-e/zed-crimson-theme.git
 
+[submodule "extensions/cron-sense-lsp"]
+	path = extensions/cron-sense-lsp
+	url = https://github.com/zxcodes/cron-sense.git
+
 [submodule "extensions/crystal"]
 	path = extensions/crystal
 	url = https://github.com/crystal-lang-tools/zed-crystal.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -950,6 +950,10 @@ version = "0.2.0"
 submodule = "extensions/crimson-theme"
 version = "0.0.4"
 
+[cron-sense-lsp]
+submodule = "extensions/cron-sense-lsp"
+version = "0.3.0"
+
 [crystal]
 submodule = "extensions/crystal"
 version = "0.0.4"


### PR DESCRIPTION
## Extension

Adds **[cron-sense-lsp](https://github.com/zxcodes/cron-sense)** — hover tooltips and a code action that translate cron-like schedules into human-readable English.

| Field | Value |
| --- | --- |
| Extension ID | `cron-sense-lsp` |
| Version | `0.3.0` |
| Repository | https://github.com/zxcodes/cron-sense |
| License | MIT |
| Language server (npm) | [`cron-sense-lsp@0.3.0`](https://www.npmjs.com/package/cron-sense-lsp) |

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the [publishing prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites)
- [x] Tested locally as a **dev extension** in Zed
- [x] `extensions.toml` / `.gitmodules` updated and sorted (`pnpm sort-extensions`)
- [x] Extension ID follows naming rules (no `zed` / `extension` in id or name; purpose-oriented `*-lsp` suffix, same pattern as `import-cost-lsp`)
- [x] Accepted license (`LICENSE` MIT at repo root)
- [x] **Language server is not shipped inside the extension package** — installed at runtime via a single `zed::npm_install_package("cron-sense-lsp", …)` call; npm pulls all dependencies
- [x] Submodule uses HTTPS URL and is pinned to commit on `main` (`v0.3.0` / `a4b1536`)

## Review feedback addressed

Previous submissions: #6920, #6934 (closed).

| Feedback | Fix |
| --- | --- |
| Update extension ID per prerequisites | Permanent ID is now `cron-sense-lsp` (was `cron-sense`) |
| Publish language server to npm instead of installing deps one-by-one | Public package [`cron-sense-lsp`](https://www.npmjs.com/package/cron-sense-lsp); extension installs that package only (mirrors `import-cost-lsp` / `sftp-file-sync`) |

## Features

- Hover explanations for cron expressions (`cronstrue`)
- Code action to insert the explanation as a trailing comment (idempotent; no stacked duplicates)

## Testing (dev extension)

- Hover on standard 5-field crons and macros (`@daily`, etc.)
- Code action insert and re-run (replaces comment; no stacked duplicates)
- Works in JSON / YAML / Shell Script contexts
- Server smoke test: `cd server && npm test`

## Notes

- Independent from-scratch implementation (not a fork of the VS Code source).
- Concept/UX inspired by [tumido/cron-explained](https://github.com/tumido/cron-explained) (credited in README and NOTICE).