### PR TITLE
Bump Soufflé to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4696,7 +4696,7 @@ version = "0.1.1"
 
 [souffle]
 submodule = "extensions/souffle"
-version = "0.1.0"
+version = "0.1.1"
 
 [sourcepawn]
 submodule = "extensions/sourcepawn"


### PR DESCRIPTION
Bumps the Soufflé extension to v0.1.1.

Fixes the language server failing to start with `operation not supported on this platform`; the jar path was resolved with `std::fs::canonicalize`, which is unsupported on WASI. It now joins onto `std::env::current_dir()`.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
