### PR TITLE
Add linear-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2582,6 +2582,10 @@
 	path = extensions/lilypond
 	url = https://github.com/nwhetsell/lilypond-zed-extension
 
+[submodule "extensions/linear-theme"]
+	path = extensions/linear-theme
+	url = https://github.com/adriandlam/zed-linear.git
+
 [submodule "extensions/lini"]
 	path = extensions/lini
 	url = https://github.com/monfa-red/lini

--- a/extensions.toml
+++ b/extensions.toml
@@ -2633,6 +2633,10 @@ version = "0.0.1"
 submodule = "extensions/lilypond"
 version = "0.1.0"
 
+[linear-theme]
+submodule = "extensions/linear-theme"
+version = "0.0.1"
+
 [lini]
 submodule = "extensions/lini"
 path = "editors/zed"


### PR DESCRIPTION
Adds **Linear Theme**, an unofficial light and dark theme providing `Linear Dark` and `Linear Light`, adapted from the Linear theme in the Codex app.

Repository: https://github.com/adriandlam/zed-linear

This resubmits #6730, which was closed for sitting as a draft. The extension has been reworked against the [publishing prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites) since then:

- Extension ID renamed `linear` → `linear-theme` to carry the `-theme` suffix, and the submodule now lives at `extensions/linear-theme`.
- `extension.toml` trimmed to only what the extension needs — dropped the empty `[lib]`, `[grammars]`, `[language_servers]`, `[context_servers]` and `[slash_commands]` tables along with the unused `languages`/`capabilities` keys and the redundant `themes` list.
- Author entry now includes an email address.
- Theme-only extension; no language, icon theme, or other features are bundled.
- MIT license at the repository root.
- Submodule uses an HTTPS URL and points at a commit on `main`.

On naming: the theme file is written from scratch against Zed's theme schema, with the palette adapted from the Linear theme in the Codex app. The manifest description and README both state that it is unofficial and unaffiliated, following the same convention as the existing `anysphere-theme` entry. Happy to rename if you'd prefer something less tied to the product name.

Checks run:

- `pnpm sort-extensions` — `extensions.toml` and `.gitmodules` entries are in sorted position.
- `pnpm test` — 115 passed.
- `themes/linear.json` validates against `https://zed.dev/schema/themes/v0.2.0.json`.
- Installed locally as a dev extension and both variants confirmed working in Zed.