### PR TITLE
Add RustOwl extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4342,6 +4342,10 @@
 	path = extensions/rust-workflow-snippets
 	url = https://github.com/Teamofeyy/rust-snippets.git
 
+[submodule "extensions/rustowl"]
+	path = extensions/rustowl
+	url = https://github.com/rusty-auth/rustowl-zed.git
+
 [submodule "extensions/rux"]
 	path = extensions/rux
 	url = https://github.com/rux-lang/Zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4419,6 +4419,10 @@ version = "0.0.4"
 submodule = "extensions/rust-workflow-snippets"
 version = "0.1.0"
 
+[rustowl]
+submodule = "extensions/rustowl"
+version = "0.1.3"
+
 [rux]
 submodule = "extensions/rux"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

- add RustOwl, a compiler-grounded Rust ownership and async-state cockpit for Zed
- provide always-visible semantic underlines and inlay hints plus human-first layered hovers
- expose bounded, read-only ownership graphs to Zed's agent panel through an MCP context server
- pin the marketplace entry to RustOwl v0.1.3 (`704eb4afdc3927590e12519acc805ca4b2df22e1`)

## Validation

- installed and exercised as a Zed dev extension against a live Rust workspace
- packaged successfully with the exact Zed extension CLI pinned by this repository and Rust 1.90 / `wasm32-wasip2`
- `pnpm build` and all 115 registry tests pass
- the v0.1.3 release workflow builds, launches, verifies, and packages the native runtime for all six supported macOS, Linux, and Windows targets
- release archives contain checksums, CycloneDX SBOMs, MIT/MPL-2.0/Apache-2.0 licenses, and third-party notices

Repository: https://github.com/rusty-auth/rustowl-zed
Release verification: https://github.com/rusty-auth/rustowl-zed/actions/runs/31553610041
