### PR TITLE
Add Axel extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,6 +322,10 @@
 	path = extensions/awsum
 	url = https://github.com/awsum-lang/awsum-zed.git
 
+[submodule "extensions/axel"]
+	path = extensions/axel
+	url = https://github.com/struckchure/axel.git
+
 [submodule "extensions/axolosin"]
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -330,6 +330,11 @@ version = "0.0.1"
 submodule = "extensions/awsum"
 version = "0.0.7"
 
+[axel]
+submodule = "extensions/axel"
+path = "tools/zed"
+version = "0.0.12"
+
 [axolosin]
 submodule = "extensions/axolosin"
 version = "1.2.0"


### PR DESCRIPTION
Adds **Axel** — syntax highlighting and a language server for the two Axel languages:

- **Axel Schema** (`.asl`) — types, enums, links, constraints, indexes
- **Axel Query** (`.aql`) — `select` / `insert` / `update` / `delete`

Highlighting is backed by small Tree-sitter grammars that mirror the parsers in the Axel repo; the language server launches the `axel` CLI as `axel lsp` (diagnostics, hover, go-to-definition, completion, and document formatting). Extension source lives under `tools/zed` in the repo (`path = "tools/zed"`).

- Repository: https://github.com/struckchure/axel (MIT licensed)
- Grammars are committed with generated `src/` (ABI 14) and have passing corpus tests.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
