### PR TITLE
Add Silex language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4482,6 +4482,10 @@
 	path = extensions/sieve
 	url = https://github.com/aRustyDev/zed-sieve.git
 
+[submodule "extensions/silex"]
+	path = extensions/silex
+	url = https://github.com/Matanek/Silex-Extension-Zed.git
+
 [submodule "extensions/silverstripe"]
 	path = extensions/silverstripe
 	url = https://github.com/nicolas-cusan/zed-silverstripe.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4562,7 +4562,7 @@ version = "0.1.7"
 
 [silex]
 submodule = "extensions/silex"
-version = "0.48.0"
+version = "0.49.0"
 
 [silverstripe]
 submodule = "extensions/silverstripe"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4560,6 +4560,10 @@ version = "2.2.1"
 submodule = "extensions/sieve"
 version = "0.1.7"
 
+[silex]
+submodule = "extensions/silex"
+version = "0.48.0"
+
 [silverstripe]
 submodule = "extensions/silverstripe"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4562,7 +4562,7 @@ version = "0.1.7"
 
 [silex]
 submodule = "extensions/silex"
-version = "0.49.0"
+version = "0.51.0"
 
 [silverstripe]
 submodule = "extensions/silverstripe"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

Adds the Silex language extension at version `0.49.0` to the Zed extension registry.

The extension provides:

- Tree-sitter syntax highlighting for `.sx` files;
- indentation, outline and bracket queries;
- diagnostics, completion and definition navigation through the `silex lsp` command.

The language server is distributed with Silex and is discovered from the user's `PATH`; it is not bundled with the extension.

## Validation

- installed and exercised locally as a Zed development extension;
- 72 Tree-sitter corpus tests passed;
- 39 syntax-highlighting assertions passed;
- extension adapter compiled successfully for `wasm32-wasip2`;
- registry TypeScript build passed;
- registry test suite passed: 115 tests.

Repository: https://github.com/Matanek/Silex-Extension-Zed
Language: https://silex-lang.org