### PR TITLE
Add TeXpand extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4934,6 +4934,10 @@
 	path = extensions/tex-japanese-formatter
 	url = https://github.com/keufcp/tex-japanese-formatter-for-zed
 
+[submodule "extensions/texpand"]
+	path = extensions/texpand
+	url = https://github.com/TheSkyentist/zed-texpand.git
+
 [submodule "extensions/texpresso"]
 	path = extensions/texpresso
 	url = https://github.com/lnay/zed-texpresso.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5028,6 +5028,10 @@ version = "0.0.3"
 submodule = "extensions/tex-japanese-formatter"
 version = "1.0.0"
 
+[texpand]
+submodule = "extensions/texpand"
+version = "0.1.0"
+
 [texpresso]
 submodule = "extensions/texpresso"
 version = "0.0.3"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **TeXpand** — TeX-style shortcuts for Unicode math symbols, expanded as you type.

```
\alpha        → α
f\lambda      → fλ          macros fuse onto surrounding text
\alpha\beta   → αβ          no space needed between macros
\bbR          → ℝ
```

- Repository: https://github.com/TheSkyentist/zed-texpand
- License: GPL-3.0
- Release: [v0.1.0](https://github.com/TheSkyentist/zed-texpand/releases/tag/v0.1.0), with `texpand-ls` binaries for macOS (aarch64, x86_64), Linux (aarch64, x86_64) and Windows (x86_64)
- 2553 symbols, generated from Julia's `latex_symbols.jl` (MIT, attribution preserved)

Tested locally as a dev extension across Python, Markdown and plain text.

## Why this is a separate extension rather than a change to `unicode`

CONTRIBUTING asks that overlapping functionality be contributed to an existing extension first, so I want to address that directly. The `unicode` extension also inserts Unicode math symbols, but the two overlap in purpose only — not in mechanism, and not in any code that could be shared.

**TeXpand uses `textDocument/onTypeFormatting`; `unicode` uses `textDocument/completion`.** That is not an implementation preference. Zed filters its completion popup using its own client-side `Buffer::surrounding_word` scan (`completion_query` in `crates/editor/src/completions.rs`), which only walks across characters sharing a "kind": alphanumerics, `_`, and whatever the language declares in `completion_query_characters`. That field is a per-language *grammar* setting declared in a language extension's `config.toml` — not a language-server setting, and not exposed in `settings.json`. No built-in language declares `\`, and a language-server extension cannot add one to a language it does not own.

The result is that a completion-based extension cannot support a backslash trigger at all: the moment `\` is typed, Zed's query computation drops it and everything before it, so a correct `λ` item returned for `\lambda` is filtered out before it can display. Mid-token fusion (`f\lambda` → `fλ`) is likewise unreachable, because the word scan stops at the `f`. On-type formatting never consults word boundaries — the server receives the raw position and the typed character and inspects real buffer text.

**Adding this capability to `unicode` is not a small change.** Its `unicode-ls` is 371 lines: a `clap` CLI, a snippet data table, and a `main()` that hands those snippets to [`simple-completion-language-server`](https://github.com/zed-industries/simple-completion-language-server). All LSP behaviour lives in that crate, whose server is 134 lines implementing `initialize` (advertising only `completion_provider`), `initialized`, `did_open`, `completion` and `completion_resolve`. It does not implement `on_type_formatting`. Adding it there would mean either extending a zed-industries crate whose scope is snippet completion and which has other consumers, or having `unicode` drop that dependency and write its own LSP server — which is what TeXpand already is.

Concretely, the projects share no code: TeXpand is ~1150 hand-written lines of document sync, UTF-16 position arithmetic and macro matching, none of which exists on the other side. The symbol data is not shareable either — `unicode` stores `Snippet { prefix, body }` records for a completion engine with a configurable word prefix, TeXpand a macro-name-keyed table roughly 8× larger from a different upstream source.

The user-facing behaviour differs accordingly: TeXpand replaces immediately with no popup to accept, uses backslash syntax rather than bare words, and disables itself in TeX-family files, where `\alpha` is already correct source. Merging the two would put two incompatible trigger syntaxes, two interaction models and a conflicting default for `.tex` files into one extension.

I have contributed to `zed-unicode` before ([PR #13](https://github.com/aripiprazole/zed-unicode/pull/13), merged) and am happy to reconsider if maintainers would prefer this upstream instead.