### PR TITLE
Add Ayatsumugi extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -326,6 +326,10 @@
 	path = extensions/axolosin
 	url = https://github.com/LightTreasure/axolosin-theme.git
 
+[submodule "extensions/ayatsumugi"]
+	path = extensions/ayatsumugi
+	url = https://github.com/nkwork9999/ayatsumugi-zed.git
+
 [submodule "extensions/ayla"]
 	path = extensions/ayla
 	url = https://github.com/z-sk1/zed-ayla

--- a/extensions.toml
+++ b/extensions.toml
@@ -334,6 +334,10 @@ version = "0.0.7"
 submodule = "extensions/axolosin"
 version = "1.2.0"
 
+[ayatsumugi]
+submodule = "extensions/ayatsumugi"
+version = "0.1.0"
+
 [ayla]
 submodule = "extensions/ayla"
 version = "0.0.1"


### PR DESCRIPTION
Adds the Ayatsumugi context-server extension for connecting Zed Agent Panel to the separately distributed Ayatsumugi inspection sidecar.\n\n- Extension ID: `ayatsumugi`\n- Version: `0.1.0`\n- License: Apache-2.0\n- Repository: https://github.com/nkwork9999/ayatsumugi-zed\n\nValidated with `cargo check --locked`, the repository sort script, and `git diff --check`.