### PR TITLE
Add omp-agent extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3534,6 +3534,10 @@
 	path = extensions/omnetpp
 	url = https://github.com/omnetpp/omnetpp-zed.git
 
+[submodule "extensions/omp-agent"]
+	path = extensions/omp-agent
+	url = https://github.com/lurendie/omp-acp.git
+
 [submodule "extensions/one-black-theme"]
 	path = extensions/one-black-theme
 	url = https://github.com/serhiiboreiko/one-black-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3595,6 +3595,10 @@ version = "1.5.5"
 submodule = "extensions/omnetpp"
 version = "0.0.5"
 
+[omp-agent]
+submodule = "extensions/omp-agent"
+version = "0.1.0"
+
 [one-black-theme]
 submodule = "extensions/one-black-theme"
 version = "0.0.4"


### PR DESCRIPTION
Adds the [omp-agent](https://github.com/lurendie/omp-acp) extension: Oh My Pi (omp) integration for Zed.

- Registers the `omp` MCP context server: a zero-dependency Node bridge (`bridge/server.cjs`) hosting a persistent `omp --mode rpc` child per project, exposing `omp_run` / `omp_continue` / `omp_status` / `omp_models` / `omp_sessions` / `omp_abort` MCP tools (plus `omp-run` / `omp-continue` prompt templates) to the built-in Zed Agent.
- Companion `scripts/install.ps1` registers `omp acp` as an ACP external agent under `agent_servers.omp` and copies the bridge to `~/.omp/zed/bridge.cjs` (the WASM extension launches it via a `node -e` loader since the sandbox cannot resolve `$HOME`).
- Tested: `test/bridge-smoke.cjs` end-to-end against a real omp 17.2.4 (handshake, tools, delegated run, image attachment, session continue); ACP initialize handshake verified (`omp acp` speaks ACP v1).
- No bundled language servers/binaries; MIT licensed.
