### PR TITLE
Add JSON to CSV Converter extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2366,6 +2366,10 @@
 	path = extensions/jq
 	url = https://github.com/dangh/zed-jq.git
 
+[submodule "extensions/json-to-csv-converter"]
+	path = extensions/json-to-csv-converter
+	url = https://github.com/dancvv/json-to-csv-converter.git
+
 [submodule "extensions/json-tool-lsp"]
 	path = extensions/json-tool-lsp
 	url = https://github.com/xgfone/zed-json-tool.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2414,6 +2414,11 @@ version = "0.1.0"
 submodule = "extensions/jq"
 version = "0.0.2"
 
+[json-to-csv-converter]
+submodule = "extensions/json-to-csv-converter"
+path = "packages/zed"
+version = "0.3.0"
+
 [json-tool-lsp]
 submodule = "extensions/json-tool-lsp"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2417,7 +2417,7 @@ version = "0.0.2"
 [json-to-csv-converter]
 submodule = "extensions/json-to-csv-converter"
 path = "packages/zed"
-version = "0.3.0"
+version = "0.4.0"
 
 [json-tool-lsp]
 submodule = "extensions/json-tool-lsp"


### PR DESCRIPTION
## Summary

- Add `json-to-csv-converter` as a public HTTPS submodule.
- Point the registry entry at the Zed extension in `packages/zed`.
- Provide JSON to CSV, JSON to Excel, CSV to JSON, and CSV format detection as MCP tools.
- Support automatic delimiter, encoding, and header detection plus bounded-memory streaming, progress, row limits, and cancellation.
- Support optional Zed Task shortcuts that convert the active file without opening Agent Panel.

The companion `json-to-csv-converter-mcp` binary is installed from the public repository with Cargo. The extension checks `PATH` or an explicitly configured absolute `binary_path` and shows public installation instructions in Zed.

## Validation

- Installed and exercised locally as a Zed dev extension.
- `cargo test --workspace --locked` (22 tests passed)
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo check --manifest-path packages/zed/Cargo.toml --target wasm32-wasip2 --locked`
- Zed registry `pnpm sort-extensions`
- Zed registry `pnpm build`
- Zed registry `pnpm test` (115 tests passed)
- Zed registry license validator passed for `packages/zed/LICENSE` (MIT)
- Triggered the smart-convert shortcut in Zed and verified the generated CSV
