### PR TITLE
Add Kiro Default Themes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2442,6 +2442,10 @@
 	path = extensions/kiro
 	url = https://github.com/Takk8IS/kiro-theme-for-zed.git
 
+[submodule "extensions/kiro-theme"]
+	path = extensions/kiro-theme
+	url = https://github.com/MrPancakes39/kiro-zed-theme.git
+
 [submodule "extensions/kiselevka"]
 	path = extensions/kiselevka
 	url = https://github.com/kdubrovsky/kiselevka.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2491,6 +2491,10 @@ version = "0.0.1"
 submodule = "extensions/kiro"
 version = "1.0.0"
 
+[kiro-theme]
+submodule = "extensions/kiro-theme"
+version = "0.1.0"
+
 [kiselevka]
 submodule = "extensions/kiselevka"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
- [x] Extension has been tested locally. Testing was noted [here](https://github.com/MrPancakes39/kiro-zed-theme/blob/main/test/CHECKLIST.md). 

---

This adds an exact port of [Kiro](https://kiro.dev/)'s built-in default themes to Zed.

I'm aware of the [`kiro`](https://github.com/Takk8IS/kiro-theme-for-zed) extension existence, but I have some concerns:

- It hasn't been updated in a year so maybe it's dead?
- It's a recreation instead of a port (so I feel like goals are not aligned)
- It only recreates the dark theme.

This extension is derived directly from my Kiro IDE's installed `dark_default.json` and `light_default.json` definitions.

A comparison between the marketplace & this new theme can be found [here](https://github.com/MrPancakes39/kiro-zed-theme#theme-comparison). This theme aims to have better contrast and clarity.

AI Description Below

---

It provides:

- Kiro Dark and Kiro Light
- Directly mapped original palettes and transparency values
- Zed UI, editor, diagnostics, Git, terminal, and collaboration colors
- TextMate-to-Tree-sitter syntax capture mappings
- Validation against Zed's v0.2.0 theme schema