### PR TITLE
Add georgy-themes-zed extension.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5705,3 +5705,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/georgy-themes-zed"]
+	path = extensions/georgy-themes-zed
+	url = https://github.com/GeorgyDesign/georgy-themes-zed.git


### PR DESCRIPTION
## Summary
Adds the `georgy-themes-zed` extension featuring a dark-only theme family for Zed:
- Georgy Dark
- Georgy Black
- Georgy Black Dim

## Note
My first ever PR. Hopefully, people will like this theme :D

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
