### PR TITLE
Add October CMS extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3510,6 +3510,10 @@
 	path = extensions/oceans-of-andromeda-theme
 	url = https://github.com/jdonlucas/zed-oceans-of-andromeda
 
+[submodule "extensions/october"]
+	path = extensions/october
+	url = https://github.com/artistro08/zed-october.git
+
 [submodule "extensions/odin"]
 	path = extensions/odin
 	url = https://github.com/zed-extensions/odin

--- a/extensions.toml
+++ b/extensions.toml
@@ -3570,6 +3570,10 @@ version = "1.1.0"
 submodule = "extensions/oceans-of-andromeda-theme"
 version = "1.0.1"
 
+[october]
+submodule = "extensions/october"
+version = "0.1.0"
+
 [odin]
 submodule = "extensions/odin"
 version = "0.3.15"


### PR DESCRIPTION
## Description

Adds the October CMS extension: syntax highlighting and language servers for October CMS templates (`.htm` files with PHP/Twig/INI sections).

Repo: https://github.com/artistro08/zed-october

## Checklist

- [x] Repository is public on GitHub, uses HTTPS URL in `extension.toml`
- [x] `extension.toml` includes `id`, `name`, `version`, `schema_version`, `authors`, `description`, `repository`
- [x] Extension id (`october`) doesn't contain "zed"/"extension"
- [x] MIT LICENSE included at repo root
- [x] No bundled language servers — downloads/resolves them at runtime
- [x] `version` in `extensions.toml` matches the extension's `extension.toml`
- [x] Submodule added under `extensions/october`, entries alphabetized in `.gitmodules` and `extensions.toml` (matched by hand — `pnpm sort-extensions` couldn't run, deps not installed locally)