### PR TITLE
Add napi-vm language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3238,6 +3238,10 @@
 	path = extensions/napalm
 	url = https://github.com/napalmpapalam/napalm-theme-zed.git
 
+[submodule "extensions/napi-vm"]
+	path = extensions/napi-vm
+	url = https://github.com/nglmercer/napi-vm.git
+
 [submodule "extensions/nautilus"]
 	path = extensions/nautilus
 	url = https://github.com/ndr-lmnc/zed-nautilus

--- a/extensions.toml
+++ b/extensions.toml
@@ -3297,6 +3297,11 @@ version = "0.1.0"
 submodule = "extensions/napalm"
 version = "0.1.0"
 
+[napi-vm]
+submodule = "extensions/napi-vm"
+path = "zed-extension"
+version = "0.1.2"
+
 [nautilus]
 submodule = "extensions/nautilus"
 version = "0.1.0"


### PR DESCRIPTION
## Extension

Adds `napi-vm` language intelligence for JavaScript projects using the napi-vm runtime.

## Language server

The extension uses a standalone native Rust language server (`napi-vm-lsp`).

The server is downloaded from GitHub releases (`nglmercer/napi-vm`) or resolved from:
1. Explicit Zed LSP configuration
2. `NAPI_VM_LSP_PATH`
3. `$PATH`

No Node.js or consumer `node_modules` dependency is required.

## Platforms

- Linux x86_64 / arm64 (glibc / musl)
- macOS Apple Silicon / Intel
- Windows x86_64 / arm64

## Testing

Tested using Zed's Dev Extension mode with hover, completion, diagnostics, runtime metadata discovery, and automated binary downloads.