### PR TITLE
Add 0 Protan Prism theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "extensions/0-protan-prism-theme"]
+	path = extensions/0-protan-prism-theme
+	url = https://github.com/0rtbo/0-protan-prism-theme.git
+
 [submodule "extensions/0x96f"]
 	path = extensions/0x96f
 	url = https://github.com/0x96f-org/0x96f-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,3 +1,7 @@
+[0-protan-prism-theme]
+submodule = "extensions/0-protan-prism-theme"
+version = "0.1.0"
+
 [0x96f]
 submodule = "extensions/0x96f"
 version = "1.3.6"


### PR DESCRIPTION
## Summary

Adds **0 Protan Prism**, a dark and light theme family designed for strong protan color vision. The theme uses blue/yellow structure, deliberate lightness differences, code context, and restrained font weight instead of relying on red/green separation.

Repository: https://github.com/0rtbo/0-protan-prism-theme

## Validation

- Installed the repository with `zed: install dev extension` and verified that both `0 Protan Prism` and `0 Protan Prism Light` load successfully.
- Validated `themes/0.json` against Zed's theme schema v0.2.0.
- Ran the theme generator's marketplace consistency and contrast checks.
- Ran the registry TypeScript build and all 115 tests.
- Packaged the extension successfully with the Zed extension CLI; the package manifest reports version `0.1.0` and `provides: ["themes"]`.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
