### PR TITLE
Add xgo extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5538,6 +5538,10 @@
 	path = extensions/xdr-naive
 	url = https://github.com/algebnaly/xdr.zed.git
 
+[submodule "extensions/xgo"]
+	path = extensions/xgo
+	url = https://github.com/goplus/zed-xgo.git
+
 [submodule "extensions/xmake"]
 	path = extensions/xmake
 	url = https://github.com/xmake-io/xmake-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5640,6 +5640,10 @@ version = "2.0.1"
 submodule = "extensions/xdr-naive"
 version = "0.0.2"
 
+[xgo]
+submodule = "extensions/xgo"
+version = "0.1.8"
+
 [xmake]
 submodule = "extensions/xmake"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
- Add the XGo language extension (`id = xgo`) from https://github.com/goplus/zed-xgo
- Provides XGo grammar/language support and starts `xgols` on first open of an XGo file

## Notes
- Tested locally as a Dev Extension on Windows (Go + XGo on PATH).
- Does not ship a language-server binary. On first open it compiles `xgols` on the user's machine with `xgo install` (same model as the VS Code XGo extension).
- Requires [Go](https://go.dev/dl/) and [XGo](https://xgo.dev) on PATH; `xgols` itself is installed automatically.
- License: Apache-2.0 at the repo root.
- Manifest version: `0.1.8`