### PR TITLE
Add autolog extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -314,6 +314,10 @@
 	path = extensions/autohotkey
 	url = https://github.com/alfredomtx/tree-sitter-autohotkey.git
 
+[submodule "extensions/autolog"]
+	path = extensions/autolog
+	url = https://github.com/Aft1n/zed-autolog.git
+
 [submodule "extensions/autumnal-marscape"]
 	path = extensions/autumnal-marscape
 	url = https://github.com/lilyyy411/autumnal-marscape-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -322,6 +322,10 @@ version = "0.2.2"
 submodule = "extensions/autohotkey"
 version = "2.0.1"
 
+[autolog]
+submodule = "extensions/autolog"
+version = "0.1.0"
+
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the **AutoLog** extension: press `ctrl+alt+l` (Zed task driven) to insert a labeled `console.log` with enclosing function name, `file:line`, and the value under the cursor. JS/TS/JSX/TSX use oxc-parser for AST-accurate statements; 15+ languages via heuristics. The extension ships snippet fallbacks (`clog`, `cerr`, `cwarn`, `ctable`).

## Notes for reviewers

- The log-insertion engine is a Zed task + script (Zed's extension API has no editor commands), so the repo also contains `tasks/`, `scripts/`, and a `keymap.json` that users merge into `~/.config/zed` per the README. The extension itself provides the snippet fallbacks.
- ID `autolog` is free in the registry (no `zed`/`extension` substring).
- MIT licensed at repo root. Version `0.1.0` matches `extension.toml`.

Repo: https://github.com/Aft1n/zed-autolog