### PR TITLE
Update deps-language-server to v0.1.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1183,7 +1183,7 @@ version = "1.10.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"
-version = "0.1.5"
+version = "0.1.6"
 
 [deputy]
 submodule = "extensions/deputy"


### PR DESCRIPTION
## Summary
- Linux now always requests the statically-linked unknown-linux-musl deps-lsp asset instead of unknown-linux-gnu, since zed_extension_api has no way to detect the host libc at runtime and a static musl binary runs on both glibc and musl distros.
- Downloaded archives are now verified against the .sha256 sidecar published on the same GitHub release before extraction. The sidecar parser handles both plain sha256sum output and Windows CertUtil output.