### PR TITLE
Add Ansible Vault extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -150,6 +150,10 @@
 	path = extensions/ansible
 	url = https://github.com/kartikvashistha/zed-ansible
 
+[submodule "extensions/ansible-vault"]
+	path = extensions/ansible-vault
+	url = https://github.com/gesundes/zed-ansible-vault.git
+
 [submodule "extensions/anthracite-theme"]
 	path = extensions/anthracite-theme
 	url = https://github.com/boycsuk/anthracite-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -154,6 +154,10 @@ version = "21.1.0"
 submodule = "extensions/ansible"
 version = "1.0.0"
 
+[ansible-vault]
+submodule = "extensions/ansible-vault"
+version = "0.2.1"
+
 [anthracite-theme]
 submodule = "extensions/anthracite-theme"
 version = "1.0.0"


### PR DESCRIPTION
## Extension

Adds **Ansible Vault** 0.2.1: code actions and inline diagnostics for encrypting/decrypting complete Ansible Vault files and YAML `!vault` values.

Repository: https://github.com/gesundes/zed-ansible-vault
Release: https://github.com/gesundes/zed-ansible-vault/releases/tag/v0.2.1

## Relationship to the existing Ansible extension

This is complementary to the catalog's existing **Ansible** extension. It does not provide or replace Ansible syntax highlighting or the Ansible language server; it attaches a companion LSP alongside Ansible/YAML solely for Vault operations and validation.

## Platforms and capability

The companion supports macOS and Linux on x86_64 and aarch64. Linux assets are static. The `download_file` capability is restricted to immutable, versioned release assets under `gesundes/zed-ansible-vault/releases/download/**`; the adapter pins release `v0.2.1`, downloads through staging, and verifies the adjacent SHA-256 checksum before activation.

## Verification

- official Zed extension packager passes in the extension repository CI
- catalog `pnpm sort-extensions`, TypeScript build, and 115 tests pass
- release binaries pass version, architecture, Linux static-linkage, and macOS deployment-target checks
- published checksums and GitHub artifact attestations verified independently
- extension tested locally as a Zed dev extension with file/value actions, diagnostics, password-file and masked-prompt flows

The catalog's Linux packaging job is expected to run the pinned `zed-extension` CLI; that Linux executable cannot be run directly in the local macOS checkout.
