### PR TITLE
Add translate-dict-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5086,6 +5086,10 @@
 	path = extensions/tql
 	url = https://github.com/tenzir/zed-tql.git
 
+[submodule "extensions/translate-dict-lsp"]
+	path = extensions/translate-dict-lsp
+	url = https://github.com/Nahida-aa/translate-dict.git
+
 [submodule "extensions/tree-sitter-query"]
 	path = extensions/tree-sitter-query
 	url = https://github.com/vitallium/zed-tree-sitter-query.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5187,6 +5187,10 @@ version = "0.0.2"
 submodule = "extensions/tql"
 version = "0.4.2"
 
+[translate-dict-lsp]
+submodule = "extensions/translate-dict-lsp"
+version = "0.1.0"
+
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"
 version = "0.1.1"


### PR DESCRIPTION
Add translate-dict-lsp extension

Offline hover translation for code identifiers. Splits camelCase / snake_case / kebab-case, looks up a built-in 760k-word dictionary, and renders the meaning on hover (English → Chinese). Selecting Chinese text queries Chinese → English. Fully offline, no network required.

Submodule: [Nahida-aa/translate-dict @ e53fa9f](https://github.com/Nahida-aa/translate-dict/commit/e53fa9f)
license = "MIT"

Changes since the previous (closed) submission (#6902):
- Extension renamed `hover-dict` → `translate-dict-lsp`
- All log/error messages are in English
- The language server does not read the environment (`std::env::var`); the LS binary is downloaded at runtime via the extension shell

Dictionary data: derived from ECDICT (skywind3000) under CC BY-NC 4.0; extension code under MIT.
