### PR TITLE
Add Template Toolkit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4934,6 +4934,10 @@
 	path = extensions/templ
 	url = https://github.com/makifdb/zed-templ.git
 
+[submodule "extensions/template-toolkit"]
+	path = extensions/template-toolkit
+	url = https://github.com/RuvimSypa/template-toolkit-zed.git
+
 [submodule "extensions/templeos-theme"]
 	path = extensions/templeos-theme
 	url = https://github.com/b6k-dev/zed-templeos-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5030,6 +5030,10 @@ path = "zed"
 submodule = "extensions/templ"
 version = "0.0.11"
 
+[template-toolkit]
+submodule = "extensions/template-toolkit"
+version = "0.1.0"
+
 [templeos-theme]
 submodule = "extensions/templeos-theme"
 version = "1.0.0"


### PR DESCRIPTION
Syntax support for Template Toolkit 2 (TT2) templates: the directives, plus the HTML, CSS and JavaScript around them, injected as one combined document so an attribute split across a tag stays markup. Blocks nest, so IF/FOREACH/BLOCK … END fold, indent and match; BLOCK and MACRO definitions appear in the outline. RAWPERL bodies are highlighted as Perl.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
