### PR TITLE
Add Live Reload Server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2634,6 +2634,10 @@
 	path = extensions/little-league-theme
 	url = https://github.com/ilikescience/little-league.git
 
+[submodule "extensions/live-reload-server"]
+	path = extensions/live-reload-server
+	url = https://github.com/jedbillyb/zed-live-reload-server.git
+
 [submodule "extensions/live-server"]
 	path = extensions/live-server
 	url = https://github.com/frederik-uni/zed-live-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2689,6 +2689,10 @@ submodule = "extensions/little-league-theme"
 path = "targets/zed"
 version = "1.5.1"
 
+[live-reload-server]
+submodule = "extensions/live-reload-server"
+version = "0.4.6"
+
 [live-server]
 submodule = "extensions/live-server"
 version = "0.3.1"


### PR DESCRIPTION
Adds **Live Reload Server** (`live-reload-server`), a local development server
that reloads the browser as you edit. CSS and images swap in place, everything
else reloads and keeps its scroll position.

- Repository: https://github.com/jedbillyb/zed-live-reload-server
- Licence: MIT
- Version: 0.4.6

The extension is a thin shim that declares a language server; the native binary
is downloaded from the repository's releases, with builds for macOS, Linux and
Windows on x86_64 and aarch64. Nothing is bundled in the extension itself.

### On the existing `live-server` extension

The prerequisites ask that duplicate functionality be raised with the existing
extension first, so I want to be upfront that `live-server` already covers this
ground, and why I am submitting a separate extension rather than a fix.

`frederik-uni/zed-live-server` has not had a commit since 22 January 2026, seven
months ago, and has 14 open issues. Several describe the problems this addresses,
and none of them has a maintainer reply:

- [#33](https://github.com/frederik-uni/zed-live-server/issues/33): no way to
  start or stop the server
- [#35](https://github.com/frederik-uni/zed-live-server/issues/35): code actions
  not appearing, with three people commenting since May
- [#37](https://github.com/frederik-uni/zed-live-server/issues/37): serves the
  wrong root, with a user diagnosing it down to the line
- [#36](https://github.com/frederik-uni/zed-live-server/issues/36): always
  reloads the page from the top

The differences are not a bug fix or two. That extension's slash commands print a
hardcoded string and do nothing, its reported port is the literal `57391`
regardless of what it bound, its documented `lazy`, `public` and `start_port`
settings are never wired up, and it starts on opening an HTML file with no way to
stop it. This is an independent implementation in Rust that starts and stops on
demand, applies a full set of settings live, watches the filesystem so changes
from other tools reload the page, hot swaps CSS and images, restores scroll
position, and supports ranged requests.

### Checklist

- [x] Extension ID is unique and contains neither `zed` nor `extension`
- [x] Manifest fields complete, including `repository`
- [x] MIT `LICENSE` at the extension root
- [x] The language server is downloaded, not shipped in the extension
- [x] Submodule added over HTTPS, on a branch
- [x] `pnpm sort-extensions` run
- [x] Tested locally as a dev extension
