### PR TITLE
Add PPL language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3990,6 +3990,10 @@
 	path = extensions/powershell
 	url = https://github.com/zed-extensions/powershell
 
+[submodule "extensions/ppl"]
+	path = extensions/ppl
+	url = https://github.com/mkrueger/zed-ppl.git
+
 [submodule "extensions/praia"]
 	path = extensions/praia
 	url = https://github.com/praia-lang/praia-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -4060,7 +4060,7 @@ version = "0.4.3"
 
 [ppl]
 submodule = "extensions/ppl"
-version = "0.1.1"
+version = "0.1.4"
 
 [praia]
 submodule = "extensions/praia"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4058,6 +4058,10 @@ version = "0.2.0"
 submodule = "extensions/powershell"
 version = "0.4.3"
 
+[ppl]
+submodule = "extensions/ppl"
+version = "0.1.0"
+
 [praia]
 submodule = "extensions/praia"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4060,7 +4060,7 @@ version = "0.4.3"
 
 [ppl]
 submodule = "extensions/ppl"
-version = "0.1.0"
+version = "0.1.1"
 
 [praia]
 submodule = "extensions/praia"


### PR DESCRIPTION
Adds support for the PCBoard Programming Language (PPL).

- Repository: https://github.com/mkrueger/zed-ppl
- Extension version: `0.1.1`
- Grammar: `tree-sitter-ppl`, updated to IcyBoard revision `a24de3a5b248e7bd678e0fed02ab613d0e867292`
- Language server: `icyboard-ppl`, downloaded from the IcyBoard releases, with a binary on the `PATH` or a configured path taking precedence

Installed and used locally as a dev extension. The updated extension compiles with `cargo check` and packages successfully with the repository's pinned `zed-extension` CLI.