### PR TITLE
Add Markdown Image Path Completion language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3054,6 +3054,10 @@
 	path = extensions/mcp-server-zuraffa
 	url = https://github.com/arrrrny/zuraffa-zed.git
 
+[submodule "extensions/md-image-path-lsp"]
+	path = extensions/md-image-path-lsp
+	url = https://github.com/yuzukq/md-image-path-lsp.git
+
 [submodule "extensions/mdias-oled-theme"]
 	path = extensions/mdias-oled-theme
 	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3113,6 +3113,11 @@ version = "0.0.1"
 submodule = "extensions/mcp-server-zuraffa"
 version = "5.6.1"
 
+[md-image-path-lsp]
+submodule = "extensions/md-image-path-lsp"
+path = "clients/zed"
+version = "0.1.0"
+
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3116,7 +3116,7 @@ version = "5.6.1"
 [md-image-path-lsp]
 submodule = "extensions/md-image-path-lsp"
 path = "clients/zed"
-version = "0.1.0"
+version = "0.1.1"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
## Extension

Adds **[md-image-path-lsp](https://github.com/yuzukq/md-image-path-lsp)** — a Language Server that completes relative paths to image files inside Markdown `![alt](...)` links.

| Field | Value |
| --- | --- |
| Extension ID | `md-image-path-lsp` |
| Version | `0.1.0` |
| Repository | https://github.com/yuzukq/md-image-path-lsp |
| License | MIT |
| Language server (npm) | [`md-image-path-lsp@0.2.0`](https://www.npmjs.com/package/md-image-path-lsp) |

## Why not covered by an existing extension

Zed's default `markdown-language-server` (a standalone build of `vscode-markdown-languageserver`) provides completion for regular links, but not for image links specifically — `![alt](` does not trigger any path suggestions in practice. This extension only handles image links, so it can run alongside `markdown-language-server` without overlap.

## Behavior

- Only triggers completion inside `![alt](...)`, not regular `[text](...)` links.
- If the workspace has a `public/` directory (Next.js / Vite static asset convention), paths are resolved relative to it (e.g. `/images/logo.png`).
- Otherwise, paths are resolved relative to the currently edited Markdown file (e.g. `../assets/logo.png`), matching how plain Markdown files are normally viewed (GitHub, static file viewers, etc.).
- Newly added/removed image files are picked up without restarting the server (`fs.watch`-based).

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and the [publishing prerequisites](https://zed.dev/docs/extensions/developing-extensions#extension-publishing-prerequisites)
- [x] Tested locally as a **dev extension** in Zed
- [x] `extensions.toml` / `.gitmodules` updated and sorted (`pnpm sort-extensions`)
- [x] Extension ID/name follow naming rules (no `zed`/`extension` in id or name)
- [x] Accepted license (`LICENSE` MIT at `clients/zed`, the extension's own directory)
- [x] **Language server is not shipped inside the extension package** — installed at runtime via `zed::npm_install_package("md-image-path-lsp", …)`
- [x] Submodule uses HTTPS URL and is pinned to a commit on `main` (not detached)