### PR TITLE
Update devicetree to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1222,7 +1222,7 @@ version = "2.0.1"
 
 [devicetree]
 submodule = "extensions/devicetree"
-version = "0.0.1"
+version = "0.2.0"
 
 [dhall]
 submodule = "extensions/dhall"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This PR bumps the devicetree extension to the v0.2.0
New version brings new LSP
https://github.com/kylebonnici/dts-lsp
Originally proposed in the PR #6055 

Initial idea was to keep two LSP servers, because new LSP requires configuration. During the development I found that it's easier to have one preconfigured. Extension ships default configuration to the LSP, that is simple enough to have a good workflow on the Linux Kernel tree. Configuration can be overridden with project settings.
Also the extension now ships snippets for the project settings to have a simple configuration for Kernel or Zephyr based projects.