### PR TITLE
Update meson to v0.7.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3135,7 +3135,7 @@ version = "0.1.0"
 
 [meson]
 submodule = "extensions/meson"
-version = "0.6.0"
+version = "0.7.0"
 
 [metal]
 submodule = "extensions/metal"


### PR DESCRIPTION
The new version implements auto updating for the MesonLSP language server through Zed's `zed::latest_github_release`.

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
