### PR TITLE
Add solitude-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4642,6 +4642,10 @@
 	path = extensions/solidity
 	url = https://github.com/zarifpour/zed-solidity.git
 
+[submodule "extensions/solitude-theme"]
+	path = extensions/solitude-theme
+	url = https://github.com/SomeoneWithOptions/zed-solitude.git
+
 [submodule "extensions/soma"]
 	path = extensions/soma
 	url = https://github.com/SrGaabriel/zed-soma.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4727,6 +4727,10 @@ version = "0.1.0"
 submodule = "extensions/solidity"
 version = "0.2.0"
 
+[solitude-theme]
+submodule = "extensions/solitude-theme"
+version = "0.1.0"
+
 [soma]
 submodule = "extensions/soma"
 version = "0.6.0"


### PR DESCRIPTION
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## What

Adds **Solitude**, a dark theme ported from the [Omarchy](https://omarchy.org) desktop theme of the same name.

- UI chrome is taken verbatim from Omarchy's Solitude palette — `#101315` background, `#0c0e10` panels, `#798186` accent, `#de6145` cursor and match highlights
- Terminal ANSI colors are the Omarchy palette as-is, so Zed's built-in terminal matches Alacritty/Ghostty under the same desktop theme
- Solitude's own palette is near-greyscale, which is fine for a terminal and unreadable as syntax highlighting, so syntax colors are derived from [ashen.nvim](https://github.com/ficcdaf/ashen.nvim) (MIT), the Neovim colorscheme Omarchy pairs with Solitude
- Dark appearance only; 141 style keys, 46 syntax captures, 8 player colors
- Repository: https://github.com/SomeoneWithOptions/zed-solitude (MIT)

## Screenshots

Editor, project panel and gutter:

![Solitude — Rust](https://raw.githubusercontent.com/SomeoneWithOptions/zed-solitude/main/assets/screenshot-rust.png)

![Solitude — TypeScript](https://raw.githubusercontent.com/SomeoneWithOptions/zed-solitude/main/assets/screenshot-typescript.png)

Integrated terminal, showing the 16 ANSI colors:

![Solitude — terminal](https://raw.githubusercontent.com/SomeoneWithOptions/zed-solitude/main/assets/screenshot-term.png)

## Checklist

- [x] Extension ID `solitude-theme` follows the `-theme` suffix convention and contains no `zed`/`extension`
- [x] Submodule added at `extensions/solitude-theme` with an HTTPS URL
- [x] `extensions.toml` version `0.1.0` matches `extension.toml`
- [x] Extension list sorted (`src/sort-extensions.js`)
- [x] MIT `LICENSE` at the repository root
- [x] Theme-only extension, validated against `https://zed.dev/schema/themes/v0.2.0.json` and tested locally as a dev extension (screenshots above are that build)
