### PR TITLE
Add Arcturus extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -210,6 +210,10 @@
 	path = extensions/arctikai-theme
 	url = https://github.com/hexqnt/arctikai-zed.git
 
+[submodule "extensions/arcturus"]
+	path = extensions/arcturus
+	url = https://github.com/ByteProject/zed-arcturus.git
+
 [submodule "extensions/arduino"]
 	path = extensions/arduino
 	url = https://github.com/mambucodev/zed-arduino.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -215,6 +215,10 @@ version = "1.0.0"
 submodule = "extensions/arctikai-theme"
 version = "0.1.0"
 
+[arcturus]
+submodule = "extensions/arcturus"
+version = "1.0.0"
+
 [arduino]
 submodule = "extensions/arduino"
 version = "0.1.0"


### PR DESCRIPTION
Syntax highlighting for the Arcturus programming language (Infocom Z-machine): .storyarc games, .granule library extensions, and .prelude library sources, plus an outline of rooms, things, kinds, blocks, and topics. Arcturus lives at https://github.com/ByteProject/Arcturus.


- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
