### PR TITLE
Add Pop-11 extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5741,3 +5741,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/pop11"]
+	path = extensions/pop11
+	url = https://github.com/IoTone/zed-pop11.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4038,6 +4038,10 @@ version = "0.6.1"
 submodule = "extensions/pop-theme"
 version = "0.1.0"
 
+[pop11]
+submodule = "extensions/pop11"
+version = "0.1.0"
+
 [popping-and-locking]
 submodule = "extensions/popping-and-locking"
 version = "1.0.3"


### PR DESCRIPTION
Adds **Pop-11**, the core language of the [Poplog](https://github.com/IoTone/poplog) environment (classic AI teaching/research language, University of Sussex, actively maintained forks) — tree-sitter highlighting via [IoTone/tree-sitter-pop11](https://github.com/IoTone/tree-sitter-pop11), outline symbols, brackets, and comment support for `.p`, `.ph`, and `.pop11`.

Extension repo: https://github.com/IoTone/zed-pop11 (MIT).

Note on `.p`: the extension claims it (Pop-11's primary extension); the README documents the `file_types` override for projects where `.p` means Pascal/Gnuplot/OpenEdge.

- [x] I have read and understand the [extension authoring guidelines](https://zed.dev/docs/extensions/developing-extensions)
- [x] The extension is MIT-licensed and I have the rights to submit it