### PR TITLE
Add suannhai-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4758,6 +4758,10 @@
 	path = extensions/styx
 	url = https://github.com/bearcove/styx.git
 
+[submodule "extensions/suannhai-theme"]
+	path = extensions/suannhai-theme
+	url = https://github.com/WeiTing1991/suannhai-theme.git
+
 [submodule "extensions/sublime-mariana-theme"]
 	path = extensions/sublime-mariana-theme
 	url = https://github.com/hnatiukr/zed-mariana-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4846,6 +4846,11 @@ submodule = "extensions/styx"
 path = "editors/zed-styx"
 version = "0.1.0"
 
+[suannhai-theme]
+submodule = "extensions/suannhai-theme"
+path = "suannhai-zed"
+version = "0.1.0"
+
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
 version = "1.1.4"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4849,7 +4849,7 @@ version = "0.1.0"
 [suannhai-theme]
 submodule = "extensions/suannhai-theme"
 path = "suannhai-zed"
-version = "0.1.0"
+version = "0.2.0"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"


### PR DESCRIPTION
- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## What

Adds **Suannhai** , a theme collection featuring 8 traditional color palettes inspired by Formosa and Nippon — 5 dark, 3 light.

- Repository: https://github.com/WeiTing1991/suannhai-theme (MIT)

## Screenshots
### Dark
  ![lam-ni](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/lam-ni.png)
  ![jiufen](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/jiufen.png)
  ![koiai](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/koiai.png)
  ![rouiro](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/rouiro.png)
  ![sumi](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/sumi.png)

### Light
  ![hue-poo](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/hue-poo.png)
  ![shironeri](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/shironeri.png)
  ![torinoko](https://raw.githubusercontent.com/WeiTing1991/suannhai-theme/main/assets/torinoko.png)

## Checklist
  - [x] Extension ID `suannhai-theme` follows the `-theme` suffix convention and contains no `zed`/`extension`
  - [x] Submodule added at `extensions/suannhai-theme` with an HTTPS URL
  - [x] `extensions.toml` version `0.1.0` matches `extension.toml`
  - [x] Extension list sorted (`src/sort-extensions.js`)
  - [x] MIT `LICENSE` at the repository root
  - [x] Theme-only extension, tested locally as a dev extension