### PR TITLE
Add io3-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5741,3 +5741,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/io3-theme"]
+	path = extensions/io3-theme
+	url = https://github.com/brynnjustherenow/io3-zedtheme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2265,6 +2265,10 @@ version = "0.1.2"
 submodule = "extensions/import-cost-lsp"
 version = "0.0.3"
 
+[io3-theme]
+submodule = "extensions/io3-theme"
+version = "0.1.0"
+
 [inbedby7pm-theme]
 submodule = "extensions/inbedby7pm-theme"
 version = "0.1.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2267,7 +2267,7 @@ version = "0.0.3"
 
 [io3-theme]
 submodule = "extensions/io3-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [inbedby7pm-theme]
 submodule = "extensions/inbedby7pm-theme"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
### Description

Adds **io3**, a modern light/dark theme family with a subtle frosted-glass background and readability-first syntax colors.

- **Light & dark variants** — `io3 Light` / `io3 Dark`, follows system appearance
- **Frosted glass background** — nearly-opaque window with system blur: solid overall, just a hint of transparency
- **Readability-first palette** — dark tuned from Tokyo Night, light from One Light; saturated types, dimmed italic parameters, dedicated color for Rust macros
- **Complete coverage** — syntax, UI chrome, Git status colors, diagnostics, terminal ANSI 16 colors, multiplayer cursors; opaque popovers for readability

### Preview

| Dark | Light |
|:---:|:---:|
| ![io3 Dark](https://raw.githubusercontent.com/brynnjustherenow/io3-zedtheme/main/screenshots/dark.png) | ![io3 Light](https://raw.githubusercontent.com/brynnjustherenow/io3-zedtheme/main/screenshots/light.png) |

### Notes

- Repository: https://github.com/brynnjustherenow/io3-zedtheme
- MIT licensed, `extension.toml` with `schema_version = 1`, theme JSON follows schema v0.2.0
- Tested locally as a dev extension (Install Dev Extension) in both light and dark modes