### PR TITLE
Add Inform 6 x PunyInform extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2178,6 +2178,10 @@
 	path = extensions/i18n-lens-language-server
 	url = https://github.com/yizixu/zed-i18n-lens.git
 
+[submodule "extensions/i6puny"]
+	path = extensions/i6puny
+	url = https://github.com/ByteProject/zed-i6puny.git
+
 [submodule "extensions/ibm-5151"]
 	path = extensions/ibm-5151
 	url = https://github.com/Takk8IS/ibm-5151-theme-for-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2225,6 +2225,10 @@ version = "0.0.5"
 submodule = "extensions/i18n-lens-language-server"
 version = "0.11.1"
 
+[i6puny]
+submodule = "extensions/i6puny"
+version = "1.0.0"
+
 [ibm-5151]
 submodule = "extensions/ibm-5151"
 version = "1.0.0"


### PR DESCRIPTION
Adds **Inform 6 x PunyInform**, syntax highlighting for Inform 6, the
classic interactive-fiction programming language, with first-class
support for the [PunyInform](https://github.com/johanberntsson/PunyInform)
library.

- Extension: https://github.com/ByteProject/zed-i6puny
- Grammar: https://github.com/ByteProject/tree-sitter-i6puny

### On the existing `inform6` extension

CONTRIBUTING asks that overlap be addressed rather than glossed over, so:
an `inform6` extension already exists, and this is not a fork or a
reskin of it. It is a different extension with a different scope, built
on a different Tree-sitter grammar.

The scope difference is PunyInform. PunyInform is an independently
written Inform 6 library with its own stdlib and parser, aimed at 8-bit
machines, and it is a meaningful part of the Inform 6 world. This
extension treats its author-facing surface as first-class alongside the
Inform 6 Standard Library: entry points and hooks, library routines,
globals, actions, the `OPTIONAL_*` / `MSG_*` configuration constant
families, and the shipped `ext_*` extensions.

The coverage difference is broader than vocabulary. This extension also
adds print rules (`print (the) obj`, `(address)`, and custom rules such
as `(OnOff) pump`), `Verb` grammar tables with the action after `->`,
dictionary words scoped distinctly from text strings, string escapes and
`@00` printing variables, `@opcode` assembly with branch labels, and
case-insensitive directives, which real sources rely on: the PunyInform
library itself writes `Endif`, `endif` and `EndIf`.

Contributing this upstream to the existing extension was considered. It
would not be a fix but a wholesale replacement of that extension's
grammar and queries with different ones, plus a change of scope it does
not claim, which seemed the wrong thing to push onto another author's
project.

### Verification

The grammar produces zero ERROR and zero MISSING nodes across the entire
PunyInform repository: 85 files, 73 `.inf` and 12 `.h`, comprising the
library (`puny.h`, `parser.h`, `grammar.h`, `messages.h`, `globals.h`,
`scope.h` and every `ext_*.h`), the how-to examples, the test suite and
the shipped games. All query files are checked with `tree-sitter query`
against the largest sources in that corpus.

Tested locally as a dev extension.

### File types

Only `.inf` is claimed by suffix. Inform 6 headers use `.h`, and rather
than contest C's built-in claim on a registration-order tiebreak, the
README documents the per-project `file_types` opt-in, which resolves in
the user-configured tier. No `.h` file changes language unless the user
asks for it.

### Prerequisites

- Public repository, MIT licence, `LICENSE` at the extension root
- No language server, debugger, or MCP server bundled; no theme bundled
- Repository contains only the extension: manifest, licence, readme and
  four query files
- Submodule pinned to a commit on `main`, added over HTTPS
- `pnpm sort-extensions` run; `pnpm test` passes (115 tests)
