### PR TITLE
Update 8008-theme to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -16,7 +16,7 @@ version = "0.1.3"
 
 [8008-theme]
 submodule = "extensions/8008-theme"
-version = "0.0.2"
+version = "0.0.3"
 
 [a-distant-hope-theme]
 submodule = "extensions/a-distant-hope-theme"


### PR DESCRIPTION
Updates 8008 Theme to 0.0.3.

Reworked the 8008 Dark palette: unified blue-grey surface ramp, pink accent identity, green diff indicators, full terminal ANSI palette, and contrast fixes for comments and line numbers.

Removes the 8008 Mixed variant.