### PR TITLE
Update tsar to v0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5116,7 +5116,7 @@
 
 [submodule "extensions/tsar"]
 	path = extensions/tsar
-	url = https://github.com/x032205/tsar-zed-theme.git
+	url = https://github.com/x032205/argent-zed-theme.git
 
 [submodule "extensions/tsarcasm"]
 	path = extensions/tsarcasm

--- a/extensions.toml
+++ b/extensions.toml
@@ -5218,7 +5218,7 @@ version = "0.1.1"
 
 [tsar]
 submodule = "extensions/tsar"
-version = "0.0.2"
+version = "0.1.0"
 
 [tsarcasm]
 submodule = "extensions/tsarcasm"


### PR DESCRIPTION
Bumps tsar to v0.1.0.

The extension now ships two themes: Argent, a desaturated variant, and TSAR, which keeps its original colors. TSAR also picks up the syntax captures it was missing, so enums and variables no longer fall back to plain white, and its ANSI black and white are no longer swapped.

The repo was renamed from tsar-zed-theme to argent-zed-theme, so the submodule URL changes as well. The extension id is unchanged.