### PR TITLE
feat: add intellij-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/intellij-lsp"]
+	path = extensions/intellij-lsp
+	url = https://github.com/zcg/intellij-lsp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1,4 +1,4 @@
-[0-protan-prism-theme]
+﻿[0-protan-prism-theme]
 submodule = "extensions/0-protan-prism-theme"
 version = "0.1.0"
 
@@ -2300,6 +2300,10 @@ version = "0.0.1"
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"
+
+[intellij-lsp]
+submodule = "extensions/intellij-lsp"
+version = "0.3.0"
 
 [intellij-newui-theme]
 submodule = "extensions/intellij-newui-theme"
@@ -5851,3 +5855,4 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+


### PR DESCRIPTION
Add the IntelliJ LSP extension (IntelliJ IDEA's LSP server for Java & Kotlin in Zed — completion, navigation, refactorings, inspections, quick-fixes, and the full IntelliJ debugger for Maven, Gradle and Bazel projects).