### PR TITLE
Add Obsidian Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3182,6 +3182,10 @@
 	path = extensions/obsidian-sunset
 	url = https://github.com/lczerniawski/ObsidianSunset-Zed.git
 
+[submodule "extensions/obsidian-theme"]
+	path = extensions/obsidian-theme
+	url = https://github.com/SECT19N/zed-obsidian-theme.git
+
 [submodule "extensions/oc-2-theme"]
 	path = extensions/oc-2-theme
 	url = https://github.com/nstlgy/oc-2-theme
@@ -5197,6 +5201,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/zed-obsidian-theme"]
-	path = extensions/zed-obsidian-theme
-	url = https://github.com/SECT19N/zed-obsidian-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -5197,3 +5197,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/zed-obsidian-theme"]
+	path = extensions/zed-obsidian-theme
+	url = https://github.com/SECT19N/zed-obsidian-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -5191,6 +5191,10 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
+[zed-obsidian-theme]
+submodule = "extensions/zed-obsidian-theme"
+version = "1.0.0"
+
 [zedbox]
 submodule = "extensions/zedbox"
 version = "0.0.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5191,9 +5191,9 @@ version = "0.1.2"
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
 
-[zed-obsidian-theme]
-submodule = "extensions/zed-obsidian-theme"
-version = "1.0.0"
+[obsidian-theme]
+submodule = "extensions/obsidian-theme"
+version = "1.2.0"
 
 [zedbox]
 submodule = "extensions/zedbox"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3234,6 +3234,10 @@ version = "1.4.0"
 submodule = "extensions/obsidian-sunset"
 version = "1.1.0"
 
+[obsidian-theme]
+submodule = "extensions/obsidian-theme"
+version = "1.2.0"
+
 [oc-2-theme]
 submodule = "extensions/oc-2-theme"
 version = "0.0.1"
@@ -5190,10 +5194,6 @@ version = "0.1.2"
 [zed-legacy-themes]
 submodule = "extensions/zed-legacy-themes"
 version = "0.0.3"
-
-[obsidian-theme]
-submodule = "extensions/obsidian-theme"
-version = "1.2.0"
 
 [zedbox]
 submodule = "extensions/zedbox"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3586,7 +3586,7 @@ version = "1.1.0"
 
 [obsidian-theme]
 submodule = "extensions/obsidian-theme"
-version = "1.2.0"
+version = "1.2.1"
 
 [oc-2-theme]
 submodule = "extensions/oc-2-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3662,7 +3662,7 @@ version = "1.1.0"
 
 [obsidian-theme]
 submodule = "extensions/obsidian-theme"
-version = "1.2.1"
+version = "1.3.0"
 
 [oc-2-theme]
 submodule = "extensions/oc-2-theme"


### PR DESCRIPTION
 Zed theme inspired by the Obsidian Theme from Notepad++ (specifically Nickc01's VS Code version) and the Vercel Theme for Zed.

Repo: [SECT19N/zed-obsidian-theme](https://github.com/SECT19N/zed-obsidian-theme)
Tested as a dev extension since 1st of July. Bumped to version 1.3.0.
License: MIT

**v1.3.0** adds four variants alongside the original Dark and Light — six themes total:

| Theme | Notes |
|-------|-------|
| Obsidian Dark | original |
| Obsidian Dark Soft | same palette, lifted backgrounds and gentler foreground for lower contrast |
| Obsidian Purple | mauve accent in place of green; git/diagnostic colors stay semantic |
| Obsidian Purple Soft | purple, low-contrast |
| Obsidian Light | original |
| Obsidian Light Soft | warm paper instead of white, warm near-black text |

<details>
    <summary>Obsidian Dark:</summary>
    <img width="1920" height="1048" alt="obsidian-dark" src="https://github.com/user-attachments/assets/7eb7081a-73f5-48d8-8b5b-4fd79384a93f" />
</details>

<details>
    <summary>Obsidian Light:</summary>
    <img width="1920" height="1048" alt="obsidian-light" src="https://github.com/user-attachments/assets/149dac50-be5d-4008-b9aa-5abc8ccd4bb3" />
</details>

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.