### PR TITLE
Update sora-theme to v0.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4746,7 +4746,7 @@ version = "0.0.7"
 [sora-theme]
 submodule = "extensions/sora-theme"
 path = "extras/zed"
-version = "0.1.1"
+version = "0.1.2"
 
 [sorbet]
 submodule = "extensions/sorbet"


### PR DESCRIPTION
Updating an extension I maintain.

Release notes: https://github.com/Aejkatappaja/sora/releases/tag/v1.8.0

The theme picks up a raised border colour, and a fix where the editor's invisible characters were rendered from the border token instead of the one that means invisibles, so they no longer disagree with the same theme's Neovim side.

Tested locally as a dev extension from `extras/zed`.