### PR TITLE
Add jinja2-sls extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2378,6 +2378,10 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
+[submodule "extensions/jinja2-sls"]
+	path = extensions/jinja2-sls
+	url = https://github.com/culler127/jinja2-sls.git
+
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2427,6 +2427,10 @@ version = "1.2.1"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
+[jinja2-sls]
+submodule = "extensions/jinja2-sls"
+version = "0.1.0"
+
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

- Adds [`jinja2-sls`](https://github.com/culler127/jinja2-sls) (`Jinja2 SLS Template Support` v0.1.0): a tree-sitter port of [Better Jinja 0.20.0](https://github.com/samuelcolvin/jinjahtml-vscode) plus Salt `.sls`.
- This is not a duplicate of the published [`jinja2`](https://github.com/ArcherHume/jinja2-support) or [`html-jinja`](https://github.com/JaagupAverin/html-jinja) extensions. Those only cover HTML plus `.jinja` / `.jinja2` / `.j2`. `jinja2` has not been updated since October 2024 (LICENSE PR and issues unanswered), so this is a separate extension rather than a fork. README tells users to disable one of the overlapping Jinja extensions if both are installed; `.sls` does not conflict.
- Host highlighting is bundled: Zed built-in grammars (YAML, Python, CSS, …) are injected where they exist; everything else is a hidden `jinja-host-*` language so users do not need extra marketplace language extensions. Hidden language names are unique; grammar keys match upstream Tree-sitter C symbols (`html`, `xml`, `php`, …).

## Test plan

- [x] Installed via **Install Dev Extension** on the extension repo (`culler127/jinja2-sls` @ `v0.1.0` / `f7ee3c1`)
- [x] First compile succeeded (Jinja + 15 bundled host WASM grammars)
- [x] Highlighting confirmed on `.sls`, `.yaml.j2`, `.html.j2`, `.xml.j2`, and bare `.j2` (Jinja delimiters **and** host tokens)
- [x] MIT `LICENSE` at repo root
- [ ] Reviewer: `pnpm sort-extensions` already run; submodule URL is HTTPS