### PR TITLE
Update dprint to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1274,7 +1274,7 @@ version = "0.1.0"
 
 [dprint]
 submodule = "extensions/dprint"
-version = "0.0.1"
+version = "0.1.0"
 
 [dracula]
 submodule = "extensions/dracula"


### PR DESCRIPTION
## Summary

- update the dprint submodule to `45ad23561514769c9f96b00485582fc8ec90294f`
- bump the registry version from `0.0.1` to `0.1.0`
- replace the published v0.0.1 fallback that resolves `./node_modules/.bin/dprint` inside the extension work directory
- use v0.1.0 binary resolution through extension settings, the worktree, `PATH`, and automatic installation

Related: panikkastudio/dprint-zed#4 and panikkastudio/dprint-zed#5

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.