### PR TITLE
Add markdown-render extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2810,6 +2810,10 @@
 	path = extensions/markdown-oxide
 	url = https://github.com/Feel-ix-343/markdown-oxide-zed.git
 
+[submodule "extensions/markdown-render"]
+	path = extensions/markdown-render
+	url = https://github.com/ParamThakkar123/zed-markdown-render.git
+
 [submodule "extensions/markdown-snippets"]
 	path = extensions/markdown-snippets
 	url = https://github.com/bobbymannino/markdown-snippets-for-zed.git
@@ -5749,6 +5753,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/markdown-render"]
-	path = extensions/markdown-render
-	url = https://github.com/ParamThakkar123/zed-markdown-render.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/markdown-render"]
+	path = extensions/markdown-render
+	url = https://github.com/ParamThakkar123/zed-markdown-render.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2867,6 +2867,10 @@ version = "1.0.0"
 submodule = "extensions/markdown-oxide"
 version = "0.0.5"
 
+[markdown-render]
+submodule = "extensions/markdown-render"
+version = "0.1.0"
+
 [markdown-snippets]
 submodule = "extensions/markdown-snippets"
 version = "0.1.0"


### PR DESCRIPTION
Adds the `markdown-render` extension.

- Registers `extensions/markdown-render` as a submodule pointing at https://github.com/ParamThakkar123/zed-markdown-render.git
- Adds the `[markdown-render]` entry to `extensions.toml` at version `0.1.0`