### PR TITLE
Update zeraphim-theme to v0.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5434,6 +5434,10 @@
 	path = extensions/zenburn-transparent-theme
 	url = https://github.com/rockas-d/zenburn-transparent.git
 
+[submodule "extensions/zeraphim-theme"]
+	path = extensions/zeraphim-theme
+	url = https://github.com/Zeraphim/zed-theme.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5526,6 +5526,10 @@ version = "1.4.3"
 submodule = "extensions/zenburn-transparent-theme"
 version = "1.0.0"
 
+[zeraphim-theme]
+submodule = "extensions/zeraphim-theme"
+version = "0.1.0"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5528,7 +5528,7 @@ version = "1.0.0"
 
 [zeraphim-theme]
 submodule = "extensions/zeraphim-theme"
-version = "0.1.0"
+version = "0.1.1"
 
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"


### PR DESCRIPTION
## Summary

- Update zeraphim-theme version from 0.1.0 to 0.1.1
- Update the extension submodule pointer

## Testing

- Not run. This change only updates extension metadata and the submodule reference.