### PR TITLE
Update livetennis-mcp to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2703,7 +2703,7 @@ version = "0.0.4"
 
 [livetennis-mcp]
 submodule = "extensions/livetennis-mcp"
-version = "0.1.0"
+version = "0.2.0"
 
 [llvm-ir]
 submodule = "extensions/llvm-ir"


### PR DESCRIPTION
Updates the `livetennis-mcp` extension (Live Tennis MCP Server) from 0.1.0 to 0.2.0.

This bumps the version in `extensions.toml` and advances the submodule pointer to the repo's `v0.2.0` tag.

Changes in 0.2.0: docs synced to livetennisapi-mcp 1.4.0 (24 tools), Node 20 minimum, quota table, and truthcheck CI. I maintain the extension (original submission #6945) and have tested it locally as a dev extension.

Repository: https://github.com/livetennisapi/zed-livetennis-mcp (tag v0.2.0)