### PR TITLE
Add the Symfony LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4862,6 +4862,10 @@
 	path = extensions/symbols
 	url = https://github.com/sebastiandotdev/zed-symbols.git
 
+[submodule "extensions/symfony-language-tools"]
+	path = extensions/symfony-language-tools
+	url = https://github.com/symfony/language-tools.git
+
 [submodule "extensions/symposium"]
 	path = extensions/symposium
 	url = https://github.com/symposium-dev/symposium.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4953,6 +4953,11 @@ version = "0.4.11"
 submodule = "extensions/symbols"
 version = "1.2.0"
 
+[symfony-language-tools]
+submodule = "extensions/symfony-language-tools"
+path = "editor/zed"
+version = "0.1.0"
+
 [symposium]
 submodule = "extensions/symposium"
 path = "zed-extension/prod"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [X] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This LSP server covers Symfony, Twig, and Doctrine from the official Symfony team. It doesn't replace a PHP LSP server.
