### PR TITLE
Add ParadoxCode EU4 language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3750,6 +3750,10 @@
 	path = extensions/papyrus
 	url = https://github.com/monster-cookie/zed-papyrus.git
 
+[submodule "extensions/paradoxcode"]
+	path = extensions/paradoxcode
+	url = https://github.com/danxiaogu520/ParadoxCode.git
+
 [submodule "extensions/paraiso"]
 	path = extensions/paraiso
 	url = https://github.com/treffynnon/zed-Paraiso.git
@@ -5749,6 +5753,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/paradoxcode"]
-	path = extensions/paradoxcode
-	url = https://github.com/danxiaogu520/ParadoxCode.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/paradoxcode"]
+	path = extensions/paradoxcode
+	url = https://github.com/danxiaogu520/ParadoxCode.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3814,6 +3814,11 @@ version = "0.2.0"
 submodule = "extensions/papyrus"
 version = "0.1.0"
 
+[paradoxcode]
+submodule = "extensions/paradoxcode"
+path = "editors/zed"
+version = "0.1.0"
+
 [paraiso]
 submodule = "extensions/paraiso"
 version = "1.0.2"


### PR DESCRIPTION
## Summary

- add the ParadoxCode EU4 language tooling extension to the Zed registry
- pin the registry entry to the v0.1.0 release
- use the existing editors/zed manifest and submodule layout

## Verification

- ParadoxCode v0.1.0 release quality gates passed
- Zed extension manifest/build checks passed
- submodule resolves to tag v0.1.0

This extension provides Paradox script/localisation language support and launches the bundled pdx-ls server.