### PR TITLE
Update svelte-snippets to v0.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4935,7 +4935,7 @@ version = "0.1.1"
 
 [svelte-snippets]
 submodule = "extensions/svelte-snippets"
-version = "0.0.9"
+version = "0.1.0"
 
 [sway]
 submodule = "extensions/sway"


### PR DESCRIPTION
Release notes:

https://github.com/bobbymannino/svelte-snippets-for-zed/releases/tag/v0.1.0