### PR TITLE
Add WaveSpeed MCP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/wavespeed-mcp"]
+	path = extensions/wavespeed-mcp
+	url = https://github.com/WaveSpeedAI/wavespeed-mcp-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5510,6 +5510,10 @@
 	path = extensions/wat
 	url = https://github.com/g-plane/zed-wasm.git
 
+[submodule "extensions/wavespeed-mcp"]
+	path = extensions/wavespeed-mcp
+	url = https://github.com/WaveSpeedAI/wavespeed-mcp-zed.git
+
 [submodule "extensions/wc-language-server"]
 	path = extensions/wc-language-server
 	url = https://github.com/wc-toolkit/wc-language-server.git
@@ -5749,6 +5753,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/wavespeed-mcp"]
-	path = extensions/wavespeed-mcp
-	url = https://github.com/WaveSpeedAI/wavespeed-mcp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5615,6 +5615,10 @@ version = "0.17.0"
 submodule = "extensions/wat"
 version = "0.2.3"
 
+[wavespeed-mcp]
+submodule = "extensions/wavespeed-mcp"
+version = "0.1.0"
+
 [wc-language-server]
 submodule = "extensions/wc-language-server"
 path = "packages/zed"


### PR DESCRIPTION
Adds the **WaveSpeed MCP** context-server extension (id `wavespeed-mcp`, v0.1.0).

Extension repo: https://github.com/WaveSpeedAI/wavespeed-mcp-zed (MIT)

It wraps [WaveSpeed AI](https://wavespeed.ai)'s official MCP server (`npx -y @wavespeed/mcp`, published in the MCP Registry as `ai.wavespeed/mcp`), giving Zed's assistant access to the live wavespeed.ai model catalog — image, video, audio, and 3D generation — with catalog search, per-model schema introspection, and price quotes. Configuration takes the user's own `WAVESPEED_API_KEY`.

- [x] Submodule added at `extensions/wavespeed-mcp`
- [x] Entry inserted alphabetically in `extensions.toml`