### PR TITLE
Update short-giraffe-theme to v2.5.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4592,7 +4592,7 @@ version = "0.0.2"
 
 [short-giraffe-theme]
 submodule = "extensions/short-giraffe-theme"
-version = "2.2.1"
+version = "2.5.0"
 
 [sieve]
 submodule = "extensions/sieve"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4592,7 +4592,8 @@ version = "0.0.2"
 
 [short-giraffe-theme]
 submodule = "extensions/short-giraffe-theme"
-version = "2.5.0"
+path = "zed"
+version = "2.5.1"
 
 [sieve]
 submodule = "extensions/sieve"


### PR DESCRIPTION
- [x] I read the [contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the update steps.

Bump `short-giraffe-theme` from 2.2.1 to 2.5.1.

I pinned `extensions/short-giraffe-theme` to `03b81b8` (`v2.5.1` on [kumamaki/Short-Giraffe](https://github.com/kumamaki/Short-Giraffe)). `extensions.toml` now has `path = "zed"` and `version = "2.5.1"`, matching `zed/extension.toml` at that commit.

Zed packages every JSON under `themes/`. The Oh My Pi file in the old root `themes/` folder made CI fail (`missing field author`). The package now lives in `zed/` so the gallery only sees Zed files.

This release also restacks the Zed chrome: three navy planes, white hairlines, coral washes. Syntax colors stay the same.