### PR TITLE
Add omakase theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3566,6 +3566,10 @@
 	path = extensions/oldbook-theme
 	url = https://github.com/gko/oldbook-theme.git
 
+[submodule "extensions/omakase"]
+	path = extensions/omakase
+	url = https://github.com/byluisfer/Omakase.git
+
 [submodule "extensions/omnetpp"]
 	path = extensions/omnetpp
 	url = https://github.com/omnetpp/omnetpp-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3632,7 +3632,7 @@ version = "1.5.5"
 [omakase]
 submodule = "extensions/omakase"
 path = "packages/zed"
-version = "1.0.0"
+version = "1.1.0"
 
 [omnetpp]
 submodule = "extensions/omnetpp"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3629,6 +3629,11 @@ version = "0.0.1"
 submodule = "extensions/oldbook-theme"
 version = "1.5.5"
 
+[omakase]
+submodule = "extensions/omakase"
+path = "packages/zed"
+version = "1.0.0"
+
 [omnetpp]
 submodule = "extensions/omnetpp"
 version = "0.0.5"


### PR DESCRIPTION
## Summary

Adds the Omakase theme extension to the Zed Extensions registry.

- Extension ID: `omakase`
- Extension name: Omakase
- Theme: Omakase Kuroshio
- Repository: https://github.com/byluisfer/Omakase
- Extension path: `packages/zed`
- Version: `1.1.0`

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
