### PR TITLE
Add swagger-viewer extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4846,6 +4846,10 @@
 	path = extensions/svelte-snippets
 	url = https://github.com/bobbymannino/svelte-snippets-for-zed.git
 
+[submodule "extensions/swagger-viewer"]
+	path = extensions/swagger-viewer
+	url = https://github.com/Ihsan-null/zed-swagger-viewer.git
+
 [submodule "extensions/sway"]
 	path = extensions/sway
 	url = https://github.com/FuelLabs/sway-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4938,6 +4938,11 @@ version = "0.1.1"
 submodule = "extensions/svelte-snippets"
 version = "0.1.0"
 
+[swagger-viewer]
+submodule = "extensions/swagger-viewer"
+path = "extension"
+version = "0.1.0"
+
 [sway]
 submodule = "extensions/sway"
 version = "0.1.0"


### PR DESCRIPTION
### Description
Adds the `swagger-viewer` extension for Swagger/OpenAPI live preview and tooling in Zed.

- **Repository**: https://github.com/Ihsan-null/zed-swagger-viewer
- **Features**: Live preview (Swagger UI, Redoc, Stoplight Elements) with SSE hot-reloading and `/swagger` assistant slash command.
