### PR TITLE
Add koment extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2514,6 +2514,10 @@
 	path = extensions/kokedera-theme
 	url = https://github.com/7th-Layer/kokedera-theme-extension-zed.git
 
+[submodule "extensions/koment"]
+	path = extensions/koment
+	url = https://github.com/koment-dev/koment.git
+
 [submodule "extensions/kotlin"]
 	path = extensions/kotlin
 	url = https://github.com/zed-extensions/zed-kotlin.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2568,7 +2568,7 @@ version = "1.0.2"
 [koment]
 submodule = "extensions/koment"
 path = "integrations/editors/zed"
-version = "3.1.3"
+version = "3.1.5"
 
 [kotlin]
 submodule = "extensions/kotlin"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2565,6 +2565,11 @@ version = "0.0.1"
 submodule = "extensions/kokedera-theme"
 version = "1.0.2"
 
+[koment]
+submodule = "extensions/koment"
+path = "integrations/editors/zed"
+version = "3.1.1"
+
 [kotlin]
 submodule = "extensions/kotlin"
 version = "0.3.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2568,7 +2568,7 @@ version = "1.0.2"
 [koment]
 submodule = "extensions/koment"
 path = "integrations/editors/zed"
-version = "3.1.1"
+version = "3.1.3"
 
 [kotlin]
 submodule = "extensions/kotlin"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds koment 3.1.3 as a first-party Zed extension submodule. The extension lives at `integrations/editors/zed` in the koment repository; that directory is GPL-3.0-or-later while the rest of the repository remains AGPL-3.0-or-later.

Validation:

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` — 115 tests passed
- submodule commit `d74e468847ef136e738e101f5bd0738cb4bf9800` is the published `v3.1.3` commit and is reachable from `koment-dev/koment` main
- the extension crate passed formatting, Clippy, and WebAssembly build in the koment 3.1.3 release candidate CI