### PR TITLE
Add VBScript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5749,3 +5749,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/vbscript"]
+	path = extensions/vbscript
+	url = https://github.com/indrayanto-suharko/zed-vbscript-extension-local.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5310,6 +5310,10 @@
 	path = extensions/vapor-theme
 	url = https://github.com/felipetesc/vapor-theme.git
 
+[submodule "extensions/vbscript"]
+	path = extensions/vbscript
+	url = https://github.com/indrayanto-suharko/zed-vbscript-extension-source.git
+
 [submodule "extensions/vcard"]
 	path = extensions/vcard
 	url = https://github.com/TitouanReal/zed-vcard.git
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/vbscript"]
-	path = extensions/vbscript
-	url = https://github.com/indrayanto-suharko/zed-vbscript-extension-source.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5751,4 +5751,4 @@
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
 [submodule "extensions/vbscript"]
 	path = extensions/vbscript
-	url = https://github.com/indrayanto-suharko/zed-vbscript-extension-local.git
+	url = https://github.com/indrayanto-suharko/zed-vbscript-extension-source.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5414,6 +5414,10 @@ version = "2.0.0"
 submodule = "extensions/vapor-theme"
 version = "0.0.2"
 
+[vbscript]
+submodule = "extensions/vbscript"
+version = "0.1.0"
+
 [vcard]
 submodule = "extensions/vcard"
 version = "0.3.0"
@@ -5474,10 +5478,6 @@ version = "1.0.0"
 [vibescript]
 submodule = "extensions/vibescript"
 version = "0.0.4"
-
-[vbscript]
-submodule = "extensions/vbscript"
-version = "0.1.0"
 
 [vibrant-abyss]
 submodule = "extensions/vibrant-abyss"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5467,6 +5467,10 @@ version = "1.0.0"
 submodule = "extensions/vibescript"
 version = "0.0.4"
 
+[vbscript]
+submodule = "extensions/vbscript"
+version = "0.1.0"
+
 [vibrant-abyss]
 submodule = "extensions/vibrant-abyss"
 version = "0.4.14"


### PR DESCRIPTION
## Summary

- Add VBScript language support to the Zed extensions registry
- Include Tree-sitter parsing, syntax highlighting, outline, folding, and indentation

The extension source is available at:

https://github.com/indrayanto-suharko/zed-vbscript-extension-source

Validation completed with:

- npm ci
- npm run generate
- npm test

All parser tests pass successfully.

The extension does not include a language server.
