### PR TITLE
Update deps-language-server to v0.1.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1200,7 +1200,7 @@ version = "1.10.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"
-version = "0.1.6"
+version = "0.1.7"
 
 [deputy]
 submodule = "extensions/deputy"


### PR DESCRIPTION
## Summary
- Adds NuGet ecosystem support to the Deps extension: `.csproj` via the `C# Project File` language, and `.fsproj` / `.vbproj` / `Directory.Packages.props` via the `MSBuild File` language
- Bumps the version in `extensions.toml` from 0.1.6 to 0.1.7