### PR TITLE
Add Hologram extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2102,6 +2102,10 @@
 	path = extensions/hocon
 	url = https://github.com/tomatitito/hocon-zed-extension.git
 
+[submodule "extensions/hologram"]
+	path = extensions/hologram
+	url = https://github.com/nagieeb0/hologram-zed.git
+
 [submodule "extensions/hoon"]
 	path = extensions/hoon
 	url = https://github.com/TisaneFruitRouge/hoon-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2144,6 +2144,10 @@ version = "0.0.1"
 submodule = "extensions/hocon"
 version = "0.2.0"
 
+[hologram]
+submodule = "extensions/hologram"
+version = "0.1.0"
+
 [hoon]
 submodule = "extensions/hoon"
 version = "0.1.0"


### PR DESCRIPTION
Adds [`hologram`](https://github.com/nagieeb0/hologram-zed) — support for the HOLO template language of the [Hologram](https://hologram.page) Elixir framework (`.holo` files).

It ships [`tree-sitter-holo`](https://github.com/nagieeb0/tree-sitter-holo), a new grammar in its own repository, and covers tags, components (`<Layout.Default>`), event bindings (`$click`), `{…}` expressions injected as Elixir, the `{%if}` / `{%for}` / `{%raw}` block tags, `<style>` → CSS, `<script>` → JavaScript, and `\{ \} \# \$` escapes. It is a feature port of the official [VS Code extension](https://github.com/bartblast/hologram_vscode) and mirrors its scopes.

Checklist:

- Extension ID `hologram` is unique and contains neither `zed` nor `extension`
- Apache-2.0 `LICENSE` at the extension root (matching the upstream VS Code extension it is ported from)
- Grammar lives in a separate public repository, pinned by commit
- Submodule uses an HTTPS URL and points at a commit on `main`
- `pnpm sort-extensions` run; `extensions.toml` and `.gitmodules` sorted
- Installed and tested locally as a dev extension on Zed 1.16.1
- No functionality overlap with an existing extension — nothing currently supports HOLO
- No language server is bundled; the extension contains no Rust/WASM code, only `extension.toml` and tree-sitter queries

One thing to flag: the repository contains `scripts/patch-elixir-sigil.sh`, a manual helper that appends a `~HOLO` sigil injection to the installed Elixir extension's query file, since an extension cannot inject into a language it does not own. It is never run by the extension itself and touches nothing at load time. I have opened https://github.com/zed-extensions/elixir/pull/136 to move that rule upstream, which makes the script obsolete. Happy to drop it from the repository now if you would rather it not ship at all.
