### PR TITLE
Add vs-2017-dark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5414,6 +5414,10 @@
 	path = extensions/vrl
 	url = https://github.com/belltoy/zed-vrl.git
 
+[submodule "extensions/vs-2017-dark-theme"]
+	path = extensions/vs-2017-dark-theme
+	url = https://github.com/exelsior87/zed-vs-2017-dark-theme.git
+
 [submodule "extensions/vscode-2026-theme"]
 	path = extensions/vscode-2026-theme
 	url = https://github.com/eugenebokhan/zed-vs-code-2026-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5519,6 +5519,10 @@ version = "0.1.1"
 submodule = "extensions/vrl"
 version = "0.1.1"
 
+[vs-2017-dark-theme]
+submodule = "extensions/vs-2017-dark-theme"
+version = "0.1.0"
+
 [vscode-2026-theme]
 submodule = "extensions/vscode-2026-theme"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the VS 2017 Dark theme for Zed.