### PR TITLE
Add dep-beacon 1.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1170,6 +1170,10 @@
 	path = extensions/deno
 	url = https://github.com/zed-extensions/deno.git
 
+[submodule "extensions/dep-beacon"]
+	path = extensions/dep-beacon
+	url = https://github.com/santi020k/dep-beacon
+
 [submodule "extensions/dependi"]
 	path = extensions/dependi
 	url = https://github.com/mpiton/zed-dependi.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1193,6 +1193,11 @@ version = "0.0.2"
 submodule = "extensions/deno"
 version = "0.1.2"
 
+[dep-beacon]
+submodule = "extensions/dep-beacon"
+path = "extensions/dep-beacon"
+version = "1.1.0"
+
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"


### PR DESCRIPTION
Publishes dep-beacon 1.1.0.\n\nSource: https://github.com/santi020k/dep-beacon/tree/bd84886c987fccd7c1d87a194d6663efa2e77349/extensions/dep-beacon