### PR TITLE
Add Oceanic Rift theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3542,6 +3542,10 @@
 	path = extensions/oceanic-next
 	url = https://github.com/rkunev/oceanic-next.git
 
+[submodule "extensions/oceanic-rift-theme"]
+	path = extensions/oceanic-rift-theme
+	url = https://github.com/jeffschuil/oceanic-rift-zed.git
+
 [submodule "extensions/oceans-of-andromeda-theme"]
 	path = extensions/oceans-of-andromeda-theme
 	url = https://github.com/jdonlucas/zed-oceans-of-andromeda

--- a/extensions.toml
+++ b/extensions.toml
@@ -3604,6 +3604,10 @@ version = "0.0.1"
 submodule = "extensions/oceanic-next"
 version = "1.1.0"
 
+[oceanic-rift-theme]
+submodule = "extensions/oceanic-rift-theme"
+version = "0.1.0"
+
 [oceans-of-andromeda-theme]
 submodule = "extensions/oceans-of-andromeda-theme"
 version = "1.0.1"


### PR DESCRIPTION
Adds **Oceanic Rift**, a deep-ocean dark theme — calm blue surfaces with a warm, high-contrast syntax palette.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.