### PR TITLE
Update kokedera-theme to v2.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2567,7 +2567,7 @@ version = "0.0.1"
 
 [kokedera-theme]
 submodule = "extensions/kokedera-theme"
-version = "1.0.2"
+version = "2.0.0"
 
 [kotlin]
 submodule = "extensions/kotlin"


### PR DESCRIPTION
Expands the Kokedera theme from a single dark theme into a family of nine variants sharing one palette system:

| Theme | |
|---|---|
| Kokedera Morning | light — washi paper and raked gravel |
| Kokedera Dusk | the original dark theme |
| Kokedera Night | near-black, high contrast |
| Kokedera Spring | young greens, cherry-blossom accent |
| Kokedera Summer | deep, saturated green |
| Kokedera Autumn | maple red and amber |
| Kokedera Winter | light — snow grey and pine |
| Kokedera Rain | cooled toward teal |
| Kokedera Mist | desaturated, low contrast |

All nine were checked for WCAG contrast against their editor background (syntax >= 4.3:1, comments >= 3:1) and for colour separation between syntax roles.

Note: the existing theme is renamed from `Kokedera` to `Kokedera Dusk`, so current users will need to re-select it. Hence the major version bump.

https://github.com/lastdescent/kokedera-theme-extension-zed