### PR TITLE
Update kokedera-icons to v2.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2564,7 +2564,7 @@
 
 [submodule "extensions/kokedera-icons"]
 	path = extensions/kokedera-icons
-	url = https://github.com/7th-Layer/kokedera-icons-extension-zed.git
+	url = https://github.com/lastdescent/kokedera-icons-extension-zed.git
 
 [submodule "extensions/kokedera-light-theme"]
 	path = extensions/kokedera-light-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -2619,7 +2619,7 @@ version = "0.0.1"
 
 [kokedera-icons]
 submodule = "extensions/kokedera-icons"
-version = "2.0.0"
+version = "2.0.1"
 
 [kokedera-light-theme]
 submodule = "extensions/kokedera-light-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2559,7 +2559,7 @@ version = "0.0.1"
 
 [kokedera-icons]
 submodule = "extensions/kokedera-icons"
-version = "1.1.0"
+version = "2.0.0"
 
 [kokedera-light-theme]
 submodule = "extensions/kokedera-light-theme"


### PR DESCRIPTION
Updates Kokedera Icons from v1.1.0 to v2.0.1, with nine icon sets matching Kokedera Theme: Morning, Dusk, Night, Spring, Summer, Autumn, Winter, Rain and Mist. Morning and Winter use the light appearance. Pairs with the theme variants added in #7290.

Version 2.0.1 also updates the display name to **Kokedera Icons**, refreshes the extension description and README, adds the shared golem logo to the README, and clarifies installation and local development instructions. The icon artwork and mappings are unchanged from v2.0.0.

- Sets the registry version to `2.0.1` and pins the submodule to [3cc045f](https://github.com/lastdescent/kokedera-icons-extension-zed/commit/3cc045f1d9ab92ec6019042f4c53b41d6e6c5df6).
- Updates the submodule URL to the repository's current owner, `lastdescent`.

**Compatibility:** The original `Kokedera Icons` icon theme is now named `Kokedera Icons Dusk`. Users upgrading from v1.x need to reselect their preferred variant.

**Validation:** All nine variants pass Zed's icon theme JSON schema; all 3,609 asset references resolve; all 1,359 SVG assets parse and render. Registry, manifest, version, license and submodule checks pass, as do `pnpm build`, all 115 tests and `pnpm sort-extensions`.
