### PR TITLE
Add Sonoma theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4666,6 +4666,10 @@
 	path = extensions/sonokai
 	url = https://github.com/ciathefed/zed-sonokai.git
 
+[submodule "extensions/sonoma-theme"]
+	path = extensions/sonoma-theme
+	url = https://github.com/yu-yaba/zed-sonoma-theme.git
+
 [submodule "extensions/sora-theme"]
 	path = extensions/sora-theme
 	url = https://github.com/Aejkatappaja/sora

--- a/extensions.toml
+++ b/extensions.toml
@@ -4752,6 +4752,10 @@ version = "0.1.3"
 submodule = "extensions/sonokai"
 version = "0.0.7"
 
+[sonoma-theme]
+submodule = "extensions/sonoma-theme"
+version = "0.1.0"
+
 [sora-theme]
 submodule = "extensions/sora-theme"
 path = "extras/zed"


### PR DESCRIPTION
## Summary
- Add the public Sonoma Theme extension as a submodule.
- Register version 0.1.0 in the Zed Extension Registry.

## Theme
Sonoma provides two Catppuccin-inspired blurred, blue-accent themes:
- Catppuccin Latte (Blue Blur+)
- Catppuccin Mocha (Blue Blur+)

## Validation
- Confirmed the extension manifest and theme JSON parse successfully.
- Ran the Registry sorting tool.
- Ran the Registry test suite: 115 tests passed.