### PR TITLE
Add Surface extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4826,6 +4826,10 @@
 	path = extensions/supertheme4
 	url = https://github.com/superkacper4/supertheme4
 
+[submodule "extensions/surface"]
+	path = extensions/surface
+	url = https://github.com/ebool/zed-surface
+
 [submodule "extensions/surpassone-theme"]
 	path = extensions/surpassone-theme
 	url = https://github.com/aitit-inc/zed-surpassone-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.6"
+version = "0.0.7"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.3"
+version = "0.0.4"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.4"
+version = "0.0.5"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4917,6 +4917,10 @@ version = "0.0.1"
 submodule = "extensions/supertheme4"
 version = "0.0.3"
 
+[surface]
+submodule = "extensions/surface"
+version = "0.0.2"
+
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"
 version = "0.3.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.5"
+version = "0.0.6"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.2"
+version = "0.0.3"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4919,7 +4919,7 @@ version = "0.0.3"
 
 [surface]
 submodule = "extensions/surface"
-version = "0.0.7"
+version = "0.0.8"
 
 [surpassone-theme]
 submodule = "extensions/surpassone-theme"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Surface template language support with syntax highlighting, Elixir expression injection, brackets, indentation, outline support, and go-to-definition navigation.

Tested as a Zed dev extension on macOS. The extension test suite, grammar corpus/query verification, Rust WASM release build, and registry test suite all pass.