### PR TITLE
Add hvp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2170,6 +2170,10 @@
 	path = extensions/hurl
 	url = https://github.com/tommy/zed-hurl
 
+[submodule "extensions/hvp"]
+	path = extensions/hvp
+	url = https://github.com/Zvord/zed-hvp.git
+
 [submodule "extensions/hyperlinks-lsp"]
 	path = extensions/hyperlinks-lsp
 	url = https://github.com/krawitzzZ/zed-hyperlinks.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2217,6 +2217,10 @@ version = "1.1.0"
 submodule = "extensions/hurl"
 version = "0.1.0"
 
+[hvp]
+submodule = "extensions/hvp"
+version = "0.1.0"
+
 [hyperlinks-lsp]
 submodule = "extensions/hyperlinks-lsp"
 version = "0.0.4"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Add an extension to work with HVP -- Hierarchical verification plan format used by Synopsys EDA tools. Useful for ASIC verification and design engineers working with Synopsys tools, since up to my knowledge there's no editor extension that can at least highlight the syntax of HVP.

So far the extension provides basic features:
- Syntax highlighting
- Symbols navigation (features and measures are treated as symbols)
- Autocompletion (keywords, snippets, built-in metric names)
- Diagnostics: mismatched/unclosed block keywords, missing semicolons, empty features, sourceless measures