### PR TITLE
Add mcpgawk extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/mcpgawk"]
+	path = extensions/mcpgawk
+	url = https://github.com/gawk-dev/mcpgawk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3062,6 +3062,9 @@
 	path = extensions/mcp-server-zuraffa
 	url = https://github.com/arrrrny/zuraffa-zed.git
 
+[submodule "extensions/mcpgawk"]
+	path = extensions/mcpgawk
+	url = https://github.com/gawk-dev/mcpgawk.git
 [submodule "extensions/mdias-oled-theme"]
 	path = extensions/mdias-oled-theme
 	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git
@@ -5757,6 +5760,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/mcpgawk"]
-	path = extensions/mcpgawk
-	url = https://github.com/gawk-dev/mcpgawk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3065,6 +3065,7 @@
 [submodule "extensions/mcpgawk"]
 	path = extensions/mcpgawk
 	url = https://github.com/gawk-dev/mcpgawk.git
+
 [submodule "extensions/mdias-oled-theme"]
 	path = extensions/mdias-oled-theme
 	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3121,6 +3121,11 @@ version = "0.0.1"
 submodule = "extensions/mcp-server-zuraffa"
 version = "5.6.1"
 
+[mcpgawk]
+submodule = "extensions/mcpgawk"
+path = "extensions/zed"
+version = "0.1.32"
+
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"
 version = "0.1.0"


### PR DESCRIPTION
This adds the **mcpgawk** extension, which registers mcpgawk as a context server so Zed's agent can see every MCP server you have configured and what each one can reach — scanned locally, nothing uploaded.

- Repo: https://github.com/gawk-dev/mcpgawk (extension in `extensions/zed`)
- Version: 0.1.32
- License: Apache-2.0

I have tested that this extension builds and works as expected.