### PR TITLE
Add weir v0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5534,6 +5534,10 @@
 	path = extensions/webstorm-darker-theme
 	url = https://github.com/jxshwa/webstorm-darker-theme.git
 
+[submodule "extensions/weir"]
+	path = extensions/weir
+	url = https://github.com/weir-shell/weir
+
 [submodule "extensions/wgsl"]
 	path = extensions/wgsl
 	url = https://github.com/luan/zed-wgsl.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5641,6 +5641,11 @@ version = "0.0.2"
 submodule = "extensions/webstorm-darker-theme"
 version = "0.0.1"
 
+[weir]
+submodule = "extensions/weir"
+path = "editors/zed"
+version = "0.1.0"
+
 [wgsl]
 submodule = "extensions/wgsl"
 version = "0.0.1"


### PR DESCRIPTION
Language support for weir (https://weir.sh): tree-sitter highlighting + `weir lsp`. The extension lives at `editors/zed` in the weir repo (subdirectory via `path`).