### PR TITLE
Add v2-blues-theme v0.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5280,7 +5280,7 @@
 
 [submodule "extensions/v2-blues-theme"]
 	path = extensions/v2-blues-theme
-	url = https://github.com/AmazingVanish/v2-blues-theme.git
+	url = https://github.com/V2-VanishsVault/v2-blues-theme.git
 
 [submodule "extensions/vacuum"]
 	path = extensions/vacuum

--- a/.gitmodules
+++ b/.gitmodules
@@ -5278,6 +5278,10 @@
 	path = extensions/v0-theme
 	url = https://github.com/biaqat/v0-theme-zed.git
 
+[submodule "extensions/v2-blues-theme"]
+	path = extensions/v2-blues-theme
+	url = https://github.com/AmazingVanish/v2-blues-theme.git
+
 [submodule "extensions/vacuum"]
 	path = extensions/vacuum
 	url = https://github.com/kovapatrik/zed-vacuum.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5382,6 +5382,10 @@ version = "0.0.1"
 submodule = "extensions/v0-theme"
 version = "0.6.0"
 
+[v2-blues-theme]
+submodule = "extensions/v2-blues-theme"
+version = "0.1.0"
+
 [vacuum]
 submodule = "extensions/vacuum"
 version = "0.1.1"


### PR DESCRIPTION
## Summary

Adds **V2 Blues**, a theme-only extension with two dark variants:

- **V2 Blues** — opaque glacial navy
- **V2 Blues (Blurred)** — same syntax with a glass editor

- Extension ID: `v2-blues-theme`
- Version: `0.1.0` (matches `extension.toml`)
- Repository: https://github.com/AmazingVanish/v2-blues-theme
- Submodule URL: HTTPS
- License: GPL-3.0 (accepted; palette credited to ARN-Skin Glacial Navy)

## Checklist

- [x] Theme-only extension; ID ends with `-theme`
- [x] Tested locally as a Zed **dev extension**
- [x] `LICENSE` present at the extension root
- [x] `pnpm sort-extensions` / `node src/sort-extensions.js` run

I can respond to review feedback within 3 weeks.