### PR TITLE
Update S-DarkTheme to v2.0.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4467,7 +4467,7 @@ version = "0.1.0"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
-version = "2.0.3"
+version = "2.0.4"
 
 [sagemath]
 submodule = "extensions/sagemath"


### PR DESCRIPTION
Release notes:

https://github.com/SinaMombeiny/S-DarkTheme.zed/releases/tag/v2.0.4


<!-- Please confirm the checklist below, then remove this comment. -->

> - [X] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

> Closing this in favor of #7302 which includes additional changes (v2.0.5).