### PR TITLE
Add deja

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1164,7 +1164,7 @@
 
 [submodule "extensions/deja-context-server"]
 	path = extensions/deja-context-server
-	url = https://github.com/vshulcz/zed-deja.git
+	url = https://github.com/vshulcz/deja-vu.git
 
 [submodule "extensions/demotape"]
 	path = extensions/demotape

--- a/.gitmodules
+++ b/.gitmodules
@@ -1162,6 +1162,10 @@
 	path = extensions/defold
 	url = https://github.com/whiterabbit1983/zed-defold
 
+[submodule "extensions/deja-context-server"]
+	path = extensions/deja-context-server
+	url = https://github.com/vshulcz/zed-deja.git
+
 [submodule "extensions/demotape"]
 	path = extensions/demotape
 	url = https://github.com/fnando/zed-demotape.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1185,6 +1185,10 @@ version = "0.0.1"
 submodule = "extensions/defold"
 version = "0.1.4"
 
+[deja-context-server]
+submodule = "extensions/deja-context-server"
+version = "0.1.0"
+
 [demotape]
 submodule = "extensions/demotape"
 version = "0.0.2"

--- a/extensions.toml
+++ b/extensions.toml
@@ -1187,6 +1187,7 @@ version = "0.1.4"
 
 [deja-context-server]
 submodule = "extensions/deja-context-server"
+path = "extensions/zed"
 version = "0.1.0"
 
 [demotape]


### PR DESCRIPTION
deja indexes the session files that coding agents already write to disk — Claude Code, Codex, Cursor, opencode and sixteen more — and answers from them. This extension serves that index to the agent panel as a context server, so a thread can search what was done before, including work from before deja was installed. The tools are `recall`, `recall_context`, `blame`, `fix`, `how` and `remember`.

Extension: https://github.com/vshulcz/deja-vu/tree/main/extensions/zed (MIT). It ships no language server, theme or slash command — one context server and its settings schema. It lives in the project's own repository, so the submodule carries a `path`.

Tested as a dev extension on macOS 26.3 arm64 against Zed's agent panel: the server shows as connected under MCP Servers and its tools are available in a thread.

One note from that testing, in case it is useful to reviewers: the binary is downloaded from the project's GitHub releases on first start, and on the first run that download outlasted the 60-second window for `initialize`, so the server was reported as timed out once. The extension now looks for an already-downloaded copy before making any network call, so only the very first start can hit it, and the installation instructions say so.