### PR TITLE
Update roc to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4378,7 +4378,7 @@ version = "0.1.0"
 
 [roc]
 submodule = "extensions/roc"
-version = "0.1.2"
+version = "0.2.0"
 
 [rockide-language-server]
 submodule = "extensions/rockide-language-server"


### PR DESCRIPTION
Updates the [Roc](https://github.com/h2000/zed-roc) extension to v0.2.0.

Changes since v0.1.2:

- Updated the `tree-sitter-roc` grammar to `2760de95` for modern Roc syntax coverage
- Regenerated `highlights.scm` from the grammar, and updated `brackets.scm`, `indents.scm`, `outline.scm`, and `textobjects.scm` to match
- Reduced `injections.scm` to comment injection only, as the previous function-call injection queries referenced node names that no longer exist in the grammar
- Added a trailing space to the line comment prefixes

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
