### PR TITLE
Update npm-package-json-checker to v1.0.7

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3526,7 +3526,7 @@ version = "0.1.0"
 
 [npm-package-json-checker]
 submodule = "extensions/npm-package-json-checker"
-version = "1.0.6"
+version = "1.0.7"
 
 [nsis]
 submodule = "extensions/nsis"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Updates npm-package-json-checker from v1.0.6 to v1.0.7 and advances its submodule to the published v1.0.7 commit.

### What's new in v1.0.7

- Streams package and changelog results progressively, so updates appear as they are found instead of all at once.
- Adds optional inline loading hints and configurable changelog concurrency for clearer, faster feedback.
- Improves caching, stale-work cancellation, dependency freshness, and reproducible release verification.

Release: https://github.com/e-simpson/zed-npm-update-checker/releases/tag/v1.0.7

Verification:
- Tested locally in Zed as a dev extension
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests passed)