### PR TITLE
Add Hearth theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2046,6 +2046,10 @@
 	path = extensions/hc-monokai-theme
 	url = https://github.com/p404/zed-hc-monokai.git
 
+[submodule "extensions/hearth-theme"]
+	path = extensions/hearth-theme
+	url = https://github.com/ryanfurrer/hearth-theme.git
+
 [submodule "extensions/hearthcode-theme"]
 	path = extensions/hearthcode-theme
 	url = https://github.com/hearth-code/hearthcode-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2087,6 +2087,11 @@ version = "0.1.0"
 submodule = "extensions/hc-monokai-theme"
 version = "0.0.1"
 
+[hearth-theme]
+submodule = "extensions/hearth-theme"
+path = "zed"
+version = "0.2.0"
+
 [hearthcode-theme]
 submodule = "extensions/hearthcode-theme"
 version = "3.7.7"


### PR DESCRIPTION
## Summary

- add Hearth as a theme extension
- publish all six light and dark variants from the repository's `zed/` directory at version `0.2.0`

## Testing

- installed and tested locally as a Zed dev extension
- validated `zed/themes/hearth.json` against Zed's theme schema v0.2.0
- ran `pnpm sort-extensions`
- ran `pnpm build`
- ran `pnpm test` (115 tests passed)

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.