### PR TITLE
Update stylelint to v3.1.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4852,7 +4852,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "3.0.0"
+version = "3.1.0"
 
 [styx]
 submodule = "extensions/styx"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Changes:

* **lsp:** Allow using local Stylelint language server binaries
  * The extension now prefers an explicitly configured binary or a `stylelint-language-server` executable found on the worktree `PATH` before falling back to the managed language server.
