### PR TITLE
Add Luna theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/luna-theme"]
+	path = extensions/luna-theme
+	url = https://github.com/miropls/zed-luna.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2782,6 +2782,10 @@ version = "0.0.2"
 submodule = "extensions/lumina-theme"
 version = "0.1.1"
 
+[luna-theme]
+submodule = "extensions/luna-theme"
+version = "1.0.0"
+
 [lusch-theme]
 submodule = "extensions/lusch-theme"
 version = "0.6.1"


### PR DESCRIPTION
This PR adds the [Luna.nvim theme](https://github.com/wtfox/luna.nvim) ported for Zed. It contains both an opaque and a transparent variant, tested locally using as a dev extension.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
