### PR TITLE
Add Fatou language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1522,6 +1522,10 @@
 	path = extensions/fastapi-snippets
 	url = https://github.com/NarmadaWeb/fastapi-snippets-zed.git
 
+[submodule "extensions/fatou-language-server"]
+	path = extensions/fatou-language-server
+	url = https://github.com/jolars/fatou.git
+
 [submodule "extensions/fedaykin-themes"]
 	path = extensions/fedaykin-themes
 	url = https://github.com/btriapitsyn/zed-fedaykin-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1553,6 +1553,11 @@ version = "0.1.1"
 submodule = "extensions/fastapi-snippets"
 version = "0.2.0"
 
+[fatou-language-server]
+submodule = "extensions/fatou-language-server"
+path = "editors/zed"
+version = "0.1.0"
+
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"
 version = "1.0.0"


### PR DESCRIPTION
This PR adds support for a language server extension for Fatou (https://fatou.dev), which is a language server, formatter, and linter for Julia.

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
