### PR TITLE
Add Composer Support language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -902,6 +902,10 @@
 	path = extensions/compline
 	url = https://github.com/jblais493/compline.git
 
+[submodule "extensions/composer-support"]
+	path = extensions/composer-support
+	url = https://github.com/BastenIT/zed-composer-support.git
+
 [submodule "extensions/confluence-context-server"]
 	path = extensions/confluence-context-server
 	url = https://github.com/mouhamadalmounayar/confluence-context-server

--- a/.gitmodules
+++ b/.gitmodules
@@ -902,8 +902,8 @@
 	path = extensions/compline
 	url = https://github.com/jblais493/compline.git
 
-[submodule "extensions/composer-support"]
-	path = extensions/composer-support
+[submodule "extensions/composer-lsp"]
+	path = extensions/composer-lsp
 	url = https://github.com/BastenIT/zed-composer-support.git
 
 [submodule "extensions/confluence-context-server"]

--- a/extensions.toml
+++ b/extensions.toml
@@ -924,7 +924,7 @@ version = "0.1.0"
 
 [composer-support]
 submodule = "extensions/composer-support"
-version = "0.2.3"
+version = "0.2.4"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"

--- a/extensions.toml
+++ b/extensions.toml
@@ -924,7 +924,7 @@ version = "0.1.0"
 
 [composer-support]
 submodule = "extensions/composer-support"
-version = "0.2.2"
+version = "0.2.3"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"

--- a/extensions.toml
+++ b/extensions.toml
@@ -922,6 +922,10 @@ submodule = "extensions/compline"
 path = "zed"
 version = "0.1.0"
 
+[composer-support]
+submodule = "extensions/composer-support"
+version = "0.2.1"
+
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"
 version = "1.0.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -924,7 +924,7 @@ version = "0.1.0"
 
 [composer-support]
 submodule = "extensions/composer-support"
-version = "0.2.1"
+version = "0.2.2"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"

--- a/extensions.toml
+++ b/extensions.toml
@@ -922,9 +922,9 @@ submodule = "extensions/compline"
 path = "zed"
 version = "0.1.0"
 
-[composer-support]
-submodule = "extensions/composer-support"
-version = "0.2.4"
+[composer-lsp]
+submodule = "extensions/composer-lsp"
+version = "0.2.5"
 
 [confluence-context-server]
 submodule = "extensions/confluence-context-server"


### PR DESCRIPTION
Adds Composer Support for `composer.json` files.

Features:

- Packagist links for Composer dependencies
- Installed-version inlay hints
- Optional update availability checks
- Native Rust language server
- Native binaries for macOS, Linux, and Windows on Intel and ARM64

The extension has been tested locally in Zed on macOS (ARM).