### PR TITLE
Add CodeQL extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -850,6 +850,10 @@
 	path = extensions/codeowners
 	url = https://github.com/lukasmalkmus/codeowners-zed.git
 
+[submodule "extensions/codeql"]
+	path = extensions/codeql
+	url = https://github.com/Fruit-Guardians/codeql-zed.git
+
 [submodule "extensions/codesandbox-theme"]
 	path = extensions/codesandbox-theme
 	url = https://github.com/MartinRybergLaude/zed-theme-codesandbox.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -868,6 +868,10 @@ version = "0.0.1"
 submodule = "extensions/codeowners"
 version = "0.1.0"
 
+[codeql]
+submodule = "extensions/codeql"
+version = "0.1.1"
+
 [codesandbox-theme]
 submodule = "extensions/codesandbox-theme"
 version = "0.0.6"


### PR DESCRIPTION
## Summary

Adds the CodeQL language extension as a single HTTPS submodule at version 0.1.1.

- Supports .ql and .qll files with Tree-sitter highlighting, brackets, indentation, outline, and text objects.
- Uses the official CodeQL CLI language server and does not bundle the CLI.
- Supports PATH discovery plus binary.path, binary.arguments, and env configuration.
- Includes clear diagnostics for missing, invalid, or non-executable CodeQL CLI configuration.
- The extension repository is MIT-licensed and includes user-facing installation documentation and a screenshot.

Validation completed:

- Official extensions repository: pnpm sort-extensions, 115 tests, and TypeScript build pass.
- Extension repository: cargo fmt, tests, clippy, WASM release build, resource validation, and CodeQL LSP smoke tests pass.
- GitHub Actions Linux/Windows and CodeQL CLI 2.26.1/2.26.3 matrix passes: https://github.com/Fruit-Guardians/codeql-zed/actions/runs/32734738233
- The submodule points to main commit 31105ac347ba128d6baee357056e90a1a509fcf1.

Manual testing was completed in Zed on macOS. Windows CI smoke coverage passes; real Windows GUI validation remains for the maintainer review.

- [x] I've read the contribution guidelines and followed the relevant guidance for adding or updating my extension.