### PR TITLE
Update deps-language-server to v0.1.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1200,7 +1200,7 @@ version = "1.10.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"
-version = "0.1.7"
+version = "0.1.8"
 
 [deputy]
 submodule = "extensions/deputy"


### PR DESCRIPTION
## Summary
- Syncs with deps-lsp `0.11`: adds vulnerability diagnostics, release-freshness signal, code lens, and quick-fix code actions
- Adds Deno/JSR and Python (PyPI) ecosystem coverage
- Bumps the version in `extensions.toml` from 0.1.7 to 0.1.8