### PR TITLE
Update tsrx to v0.0.87

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5136,7 +5136,7 @@
 
 [submodule "extensions/tsrx"]
 	path = extensions/tsrx
-	url = https://github.com/Ripple-TS/ripple.git
+	url = https://github.com/tsrx-org/tsrx.git
 
 [submodule "extensions/turbo-log-snippets"]
 	path = extensions/turbo-log-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -5240,7 +5240,7 @@ version = "1.1.0"
 [tsrx]
 submodule = "extensions/tsrx"
 path = "packages/zed-plugin"
-version = "0.0.86"
+version = "0.0.87"
 
 [turbo-log-snippets]
 submodule = "extensions/turbo-log-snippets"


### PR DESCRIPTION
## Summary

The Zed plugin has moved to a new organization and repository because Ripple and target-neutral TSRX have been split into separate organizations and repositories.

This updates the existing `tsrx` Zed extension to v0.0.87 and:

- changes its submodule source from `Ripple-TS/ripple` to `tsrx-org/tsrx`;
- points the gitlink to the TSRX release commit containing `packages/zed-plugin`;
- keeps the existing extension ID and registry key, `tsrx`;
- uses the rebranded TSRX grammar and `@tsrx/language-server@0.3.125`.

Ripple remains a supported TSRX compiler target in its separate repository: https://github.com/Ripple-TS/ripple

New TSRX source: https://github.com/tsrx-org/tsrx

## Validation

- Installed locally as a Zed development extension
- Built successfully for `wasm32-wasip1`
- `tsrx` grammar compiled and loaded
- `@tsrx/language-server@0.3.125` installed and started with `--stdio`
- Registry sorting script completed without further changes
- Local manifest, upstream registry version, and gitlink all use v0.0.87