### PR TITLE
Add One Monokai theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3622,6 +3622,10 @@
 	path = extensions/one-hunter
 	url = https://github.com/teziovsky/zed-one-hunter-theme.git
 
+[submodule "extensions/one-monokai-theme"]
+	path = extensions/one-monokai-theme
+	url = https://github.com/Sothcheat/one-monokai-theme.git
+
 [submodule "extensions/onurb"]
 	path = extensions/onurb
 	url = https://github.com/brunoocrv/onurb-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -3685,6 +3685,10 @@ version = "0.1.0"
 submodule = "extensions/one-hunter"
 version = "0.0.4"
 
+[one-monokai-theme]
+submodule = "extensions/one-monokai-theme"
+version = "0.1.0"
+
 [onurb]
 submodule = "extensions/onurb"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **One Monokai** (`one-monokai-theme`), a dark theme pairing One Dark's UI palette with Monokai's syntax assignments.

Repository: https://github.com/Sothcheat/one-monokai-theme

### Provenance and license

This is an unofficial port of [azemoh/vscode-one-monokai](https://github.com/azemoh/vscode-one-monokai) by Joshua Azemoh, which is MIT licensed. The extension's `LICENSE` retains the original copyright and permission notice alongside the port's, and the README credits the original author and states that the port is unaffiliated and unendorsed.

### Notes

- Each color is derived from the TextMate scope the original theme assigns, mapped onto the tree-sitter capture Zed emits for that token, rather than eyeballed from screenshots.
- Syntax coverage spans the grammars bundled with Zed and the nvim-treesitter capture vocabulary that language extensions use, so Java, C#, Dart, Kotlin, Rust and friends are colored rather than falling through to the default foreground.
- The theme validates against `https://zed.dev/schema/themes/v0.2.0.json`.
- Tested in Zed at the submitted submodule commit (`9e7959b`), which is on `main`.