### PR TITLE
Add iron-man theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/iron-man"]
+	path = extensions/iron-man
+	url = https://github.com/bkataru/iron-man-zed

--- a/.gitmodules
+++ b/.gitmodules
@@ -2286,6 +2286,10 @@
 	path = extensions/irodori-theme
 	url = https://github.com/agrahamlincoln/irodori.git
 
+[submodule "extensions/iron-man"]
+	path = extensions/iron-man
+	url = https://github.com/bkataru/iron-man-zed
+
 [submodule "extensions/islands-theme"]
 	path = extensions/islands-theme
 	url = https://github.com/himattm/zed-islands-theme
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/iron-man"]
-	path = extensions/iron-man
-	url = https://github.com/bkataru/iron-man-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -2297,6 +2297,10 @@ version = "0.0.2"
 submodule = "extensions/inko"
 version = "0.0.1"
 
+[iron-man]
+submodule = "extensions/iron-man"
+version = "2.0.0"
+
 [inlang-language-server]
 submodule = "extensions/inlang-language-server"
 version = "0.0.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2297,10 +2297,6 @@ version = "0.0.2"
 submodule = "extensions/inko"
 version = "0.0.1"
 
-[iron-man]
-submodule = "extensions/iron-man"
-version = "2.0.0"
-
 [inlang-language-server]
 submodule = "extensions/inlang-language-server"
 version = "0.0.1"
@@ -2337,6 +2333,10 @@ version = "0.1.0"
 [irodori-theme]
 submodule = "extensions/irodori-theme"
 version = "1.0.0"
+
+[iron-man]
+submodule = "extensions/iron-man"
+version = "2.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"


### PR DESCRIPTION
## Extension

- **ID:** `iron-man`
- **Name:** Iron Man
- **Version:** 2.0.0
- **Type:** Theme extension (dark + light variants, pure themes — no wasm)
- **Repository:** https://github.com/bkataru/iron-man-zed
- **License:** MIT

## Checklist

- [x] Extension repo includes an accepted license (MIT)
- [x] Tested locally as a dev extension — both variants ("Iron Man Dark", "Iron Man Light") load and register in Zed 1.15.1
- [x] 128×128 `icon.png` at repo root
- [x] `extension.toml` manifest with `themes` key, `schema_version = 1`
- [x] Entry added to `extensions.toml` in alphabetical order
- [x] Added as a git submodule pointing at the extension repository

## Notes

Iron Man is a Tony Stark inspired color scheme: arc-reactor golds, repulsor blues, and deep crimson reds on near-black chrome. The dark variant uses a three-lane syntax hierarchy (repulsor blue for types, arc gold for values, bright gold for functions) with red reserved for keywords; the light variant darkens the same palette for white backgrounds. Terminal ANSI ladders are monotonic per channel.