### PR TITLE
Add typoscript extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5174,6 +5174,10 @@
 	path = extensions/typos
 	url = https://github.com/BaptisteRoseau/zed-typos.git
 
+[submodule "extensions/typoscript"]
+	path = extensions/typoscript
+	url = https://github.com/onza/typo3-typoscript.git
+
 [submodule "extensions/typst"]
 	path = extensions/typst
 	url = https://github.com/WeetHet/typst.zed.git
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/typoscript"]
-	path = extensions/typoscript
-	url = https://github.com/onza/typo3-typoscript.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/typoscript"]
+	path = extensions/typoscript
+	url = https://github.com/onza/typo3-typoscript.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -282,7 +282,7 @@ version = "0.1.0"
 
 [astro]
 submodule = "extensions/astro"
-version = "0.2.1"
+version = "0.2.0"
 
 [atlas-ragnarok-theme]
 submodule = "extensions/atlas-ragnarok-theme"
@@ -657,7 +657,7 @@ version = "1.0.0"
 
 [cargo-appraiser]
 submodule = "extensions/cargo-appraiser"
-version = "0.2.1"
+version = "0.2.0"
 
 [cargo-tom]
 submodule = "extensions/cargo-tom"
@@ -886,7 +886,7 @@ version = "0.0.1"
 
 [coi]
 submodule = "extensions/coi"
-version = "0.2.1"
+version = "0.2.0"
 
 [color-highlight]
 submodule = "extensions/color-highlight"
@@ -961,7 +961,7 @@ version = "3.0.0"
 
 [crates-lsp]
 submodule = "extensions/crates-lsp"
-version = "0.2.1"
+version = "0.2.0"
 
 [crimson-theme]
 submodule = "extensions/crimson-theme"
@@ -1063,7 +1063,7 @@ version = "0.0.2"
 
 [cylc]
 submodule = "extensions/cylc"
-version = "0.2.1"
+version = "0.2.0"
 
 [cypher]
 submodule = "extensions/cypher"
@@ -1071,7 +1071,7 @@ version = "0.0.1"
 
 [cython]
 submodule = "extensions/cython"
-version = "0.2.1"
+version = "0.2.0"
 
 [d]
 submodule = "extensions/d"
@@ -1319,7 +1319,7 @@ version = "0.0.4"
 
 [earo-theme]
 submodule = "extensions/earo-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [earthfile]
 submodule = "extensions/earthfile"
@@ -1383,7 +1383,7 @@ version = "0.1.1"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
-version = "0.2.1"
+version = "0.2.0"
 
 [ejs]
 submodule = "extensions/ejs"
@@ -1496,7 +1496,7 @@ version = "0.0.1"
 
 [everforest]
 submodule = "extensions/everforest"
-version = "0.2.1"
+version = "0.2.0"
 
 [everforest-blurred]
 submodule = "extensions/everforest-blurred"
@@ -1551,7 +1551,7 @@ version = "0.1.1"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
-version = "0.2.1"
+version = "0.2.0"
 
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"
@@ -1623,7 +1623,7 @@ version = "0.5.1"
 
 [flat-themes]
 submodule = "extensions/flat-themes"
-version = "0.2.1"
+version = "0.2.0"
 
 [flatbuffers]
 submodule = "extensions/flatbuffers"
@@ -1664,7 +1664,7 @@ version = "1.0.0"
 
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
-version = "0.2.1"
+version = "0.2.0"
 
 [flynt-theme]
 submodule = "extensions/flynt-theme"
@@ -1700,7 +1700,7 @@ version = "0.0.3"
 
 [fountain]
 submodule = "extensions/fountain"
-version = "0.2.1"
+version = "0.2.0"
 
 [fozzy]
 submodule = "extensions/fozzy"
@@ -1770,7 +1770,7 @@ version = "0.1.1"
 
 [gatito-theme]
 submodule = "extensions/gatito-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [gato-theme]
 submodule = "extensions/gato-theme"
@@ -1799,7 +1799,7 @@ version = "0.1.0"
 
 [geno]
 submodule = "extensions/geno"
-version = "0.2.1"
+version = "0.2.0"
 
 [gentle-dark]
 submodule = "extensions/gentle-dark"
@@ -1916,7 +1916,7 @@ version = "1.3.0"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
-version = "0.2.1"
+version = "0.2.0"
 
 [gosum]
 submodule = "extensions/gosum"
@@ -1952,7 +1952,7 @@ version = "0.0.3"
 
 [gren]
 submodule = "extensions/gren"
-version = "0.2.1"
+version = "0.2.0"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
@@ -1996,7 +1996,7 @@ version = "0.0.1"
 
 [gruvbox-crisp-themes]
 submodule = "extensions/gruvbox-crisp-themes"
-version = "0.2.1"
+version = "0.2.0"
 
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"
@@ -2057,7 +2057,7 @@ version = "0.5.0"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.2.1"
+version = "0.2.0"
 
 [hare]
 submodule = "extensions/hare"
@@ -2126,7 +2126,7 @@ version = "1.0.0"
 
 [hivacruz-theme]
 submodule = "extensions/hivacruz-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [hl7v2]
 submodule = "extensions/hl7v2"
@@ -2142,7 +2142,7 @@ version = "0.0.1"
 
 [hocon]
 submodule = "extensions/hocon"
-version = "0.2.1"
+version = "0.2.0"
 
 [hoon]
 submodule = "extensions/hoon"
@@ -2336,7 +2336,7 @@ version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [isle]
 submodule = "extensions/isle"
@@ -2478,7 +2478,7 @@ version = "0.1.10"
 
 [just]
 submodule = "extensions/just"
-version = "0.2.1"
+version = "0.2.0"
 
 [k8s-crd-lsp]
 submodule = "extensions/k8s-crd-lsp"
@@ -2631,7 +2631,7 @@ version = "1.0.1"
 
 [ledger]
 submodule = "extensions/ledger"
-version = "0.2.1"
+version = "0.2.0"
 
 [legendary-dark-theme]
 submodule = "extensions/legendary-dark-theme"
@@ -2707,7 +2707,7 @@ version = "0.0.4"
 
 [livetennis-mcp]
 submodule = "extensions/livetennis-mcp"
-version = "0.2.1"
+version = "0.2.0"
 
 [llvm-ir]
 submodule = "extensions/llvm-ir"
@@ -2841,7 +2841,7 @@ version = "0.1.2"
 
 [mantle-theme]
 submodule = "extensions/mantle-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [manuscript-theme]
 submodule = "extensions/manuscript-theme"
@@ -2921,7 +2921,7 @@ version = "0.1.1"
 
 [mau]
 submodule = "extensions/mau"
-version = "0.2.1"
+version = "0.2.0"
 
 [maya]
 submodule = "extensions/maya"
@@ -2950,15 +2950,15 @@ version = "0.0.2"
 
 [mcp-server-atexplore]
 submodule = "extensions/mcp-server-atexplore"
-version = "0.2.1"
+version = "0.2.0"
 
 [mcp-server-atproto-docs]
 submodule = "extensions/mcp-server-atproto-docs"
-version = "0.2.1"
+version = "0.2.0"
 
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"
-version = "0.2.1"
+version = "0.2.0"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
@@ -2986,7 +2986,7 @@ version = "0.1.0"
 
 [mcp-server-figma]
 submodule = "extensions/mcp-server-figma"
-version = "0.2.1"
+version = "0.2.0"
 
 [mcp-server-firecrawl]
 submodule = "extensions/mcp-server-firecrawl"
@@ -3062,7 +3062,7 @@ version = "0.0.1"
 
 [mcp-server-relytone]
 submodule = "extensions/mcp-server-relytone"
-version = "0.2.1"
+version = "0.2.0"
 
 [mcp-server-repomix]
 submodule = "extensions/mcp-server-repomix"
@@ -3152,11 +3152,11 @@ version = "0.1.21"
 
 [metascript]
 submodule = "extensions/metascript"
-version = "0.2.1"
+version = "0.2.0"
 
 [microscript]
 submodule = "extensions/microscript"
-version = "0.2.1"
+version = "0.2.0"
 
 [midnight-marina]
 submodule = "extensions/midnight-marina"
@@ -3196,7 +3196,7 @@ version = "0.0.1"
 
 [mjml]
 submodule = "extensions/mjml"
-version = "0.2.1"
+version = "0.2.0"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
@@ -3277,7 +3277,7 @@ version = "0.0.4"
 
 [monosami]
 submodule = "extensions/monosami"
-version = "0.2.1"
+version = "0.2.0"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
@@ -3289,7 +3289,7 @@ version = "0.2.1"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.2.1"
+version = "0.2.0"
 
 [moonlight]
 submodule = "extensions/moonlight"
@@ -3313,7 +3313,7 @@ version = "0.0.2"
 
 [mpls]
 submodule = "extensions/mpls"
-version = "0.2.1"
+version = "0.2.0"
 
 [msun-dark]
 submodule = "extensions/msun-dark"
@@ -3381,7 +3381,7 @@ version = "0.0.1"
 
 [neon-verdigris-theme]
 submodule = "extensions/neon-verdigris-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [neosolarized]
 submodule = "extensions/neosolarized"
@@ -3445,7 +3445,7 @@ version = "1.0.0"
 
 [nim]
 submodule = "extensions/nim"
-version = "0.2.1"
+version = "0.2.0"
 
 [ninja]
 submodule = "extensions/ninja"
@@ -3530,7 +3530,7 @@ version = "1.0.6"
 
 [nsis]
 submodule = "extensions/nsis"
-version = "0.2.1"
+version = "0.2.0"
 
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
@@ -3703,7 +3703,7 @@ version = "0.0.1"
 
 [openfga]
 submodule = "extensions/openfga"
-version = "0.2.1"
+version = "0.2.0"
 
 [openscad]
 submodule = "extensions/openscad"
@@ -3743,7 +3743,7 @@ version = "0.1.0"
 
 [oscura]
 submodule = "extensions/oscura"
-version = "0.2.1"
+version = "0.2.0"
 
 [oso]
 submodule = "extensions/oso"
@@ -3812,7 +3812,7 @@ version = "1.0.0"
 
 [papercolor]
 submodule = "extensions/papercolor"
-version = "0.2.1"
+version = "0.2.0"
 
 [papyrus]
 submodule = "extensions/papyrus"
@@ -3849,7 +3849,7 @@ version = "1.3.0"
 
 [pbxproj]
 submodule = "extensions/pbxproj"
-version = "0.2.1"
+version = "0.2.0"
 
 [pearish-theme]
 submodule = "extensions/pearish-theme"
@@ -3885,7 +3885,7 @@ version = "0.0.4"
 
 [perplexity]
 submodule = "extensions/perplexity"
-version = "0.2.1"
+version = "0.2.0"
 
 [pest]
 submodule = "extensions/pest"
@@ -3960,7 +3960,7 @@ version = "0.1.0"
 
 [pink-candy-theme]
 submodule = "extensions/pink-candy-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"
@@ -4052,7 +4052,7 @@ version = "1.0.3"
 
 [poryscript]
 submodule = "extensions/poryscript"
-version = "0.2.1"
+version = "0.2.0"
 
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
@@ -4064,7 +4064,7 @@ version = "0.1.0"
 
 [postman-context-server]
 submodule = "extensions/postman-context-server"
-version = "0.2.1"
+version = "0.2.0"
 
 [powershell]
 submodule = "extensions/powershell"
@@ -4084,7 +4084,7 @@ version = "0.1.9"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"
-version = "0.2.1"
+version = "0.2.0"
 
 [probe-rs]
 submodule = "extensions/probe-rs"
@@ -4117,7 +4117,7 @@ version = "0.0.3"
 
 [puppet]
 submodule = "extensions/puppet"
-version = "0.2.1"
+version = "0.2.0"
 
 [puppydog-theme]
 submodule = "extensions/puppydog-theme"
@@ -4218,11 +4218,11 @@ version = "0.2.2"
 
 [quint]
 submodule = "extensions/quint"
-version = "0.2.1"
+version = "0.2.0"
 
 [qwark-theme]
 submodule = "extensions/qwark-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [r]
 submodule = "extensions/r"
@@ -4292,11 +4292,11 @@ version = "0.1.4"
 
 [red]
 submodule = "extensions/red"
-version = "0.2.1"
+version = "0.2.0"
 
 [redscript]
 submodule = "extensions/redscript"
-version = "0.2.1"
+version = "0.2.0"
 
 [regedit]
 submodule = "extensions/regedit"
@@ -4320,7 +4320,7 @@ version = "0.0.5"
 
 [remedy-theme]
 submodule = "extensions/remedy-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [remix-min-darker-theme]
 submodule = "extensions/remix-min-darker-theme"
@@ -4382,7 +4382,7 @@ version = "0.1.0"
 
 [roc]
 submodule = "extensions/roc"
-version = "0.2.1"
+version = "0.2.0"
 
 [rockide-language-server]
 submodule = "extensions/rockide-language-server"
@@ -4471,7 +4471,7 @@ version = "2.0.3"
 
 [sagemath]
 submodule = "extensions/sagemath"
-version = "0.2.1"
+version = "0.2.0"
 
 [salesforce]
 submodule = "extensions/salesforce"
@@ -4556,7 +4556,7 @@ version = "0.0.1"
 
 [setinox-theme]
 submodule = "extensions/setinox-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [severance-theme]
 submodule = "extensions/severance-theme"
@@ -4568,7 +4568,7 @@ version = "0.1.0"
 
 [shader-ls]
 submodule = "extensions/shader-ls"
-version = "0.2.1"
+version = "0.2.0"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
@@ -4678,7 +4678,7 @@ version = "0.0.1"
 
 [sml]
 submodule = "extensions/sml"
-version = "0.2.1"
+version = "0.2.0"
 
 [smooth]
 submodule = "extensions/smooth"
@@ -4734,7 +4734,7 @@ version = "0.1.0"
 
 [solidity]
 submodule = "extensions/solidity"
-version = "0.2.1"
+version = "0.2.0"
 
 [solitude-theme]
 submodule = "extensions/solitude-theme"
@@ -4796,7 +4796,7 @@ version = "0.1.2"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"
-version = "0.2.1"
+version = "0.2.0"
 
 [sqlmesh]
 submodule = "extensions/sqlmesh"
@@ -4824,11 +4824,11 @@ version = "0.4.1"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
-version = "0.2.1"
+version = "0.2.0"
 
 [stimulus]
 submodule = "extensions/stimulus"
-version = "0.2.1"
+version = "0.2.0"
 
 [stix-theme]
 submodule = "extensions/stix-theme"
@@ -4862,7 +4862,7 @@ version = "0.1.0"
 [suannhai-theme]
 submodule = "extensions/suannhai-theme"
 path = "suannhai-zed"
-version = "0.2.1"
+version = "0.2.0"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
@@ -4986,7 +4986,7 @@ version = "0.1.1"
 
 [synthwave84]
 submodule = "extensions/synthwave84"
-version = "0.2.1"
+version = "0.2.0"
 
 [sysml-v2]
 submodule = "extensions/sysml-v2"
@@ -5127,7 +5127,7 @@ version = "0.0.2"
 
 [tla-plus]
 submodule = "extensions/tla-plus"
-version = "0.2.1"
+version = "0.2.0"
 
 [tlapalli-theme]
 submodule = "extensions/tlapalli-theme"
@@ -5199,7 +5199,7 @@ version = "0.3.1"
 
 [tonel-smalltalk]
 submodule = "extensions/tonel-smalltalk"
-version = "0.2.1"
+version = "0.2.0"
 
 [toon]
 submodule = "extensions/toon"
@@ -5300,7 +5300,7 @@ version = "0.0.2"
 
 [ultimate-dark-neo]
 submodule = "extensions/ultimate-dark-neo"
-version = "0.2.1"
+version = "0.2.0"
 
 [ultralytics-snippets]
 submodule = "extensions/ultralytics-snippets"
@@ -5308,7 +5308,7 @@ version = "0.0.2"
 
 [ultraviolet-theme]
 submodule = "extensions/ultraviolet-theme"
-version = "0.2.1"
+version = "0.2.0"
 
 [umbra-theme]
 submodule = "extensions/umbra-theme"
@@ -5372,7 +5372,7 @@ version = "0.1.0"
 
 [utl]
 submodule = "extensions/utl"
-version = "0.2.1"
+version = "0.2.0"
 
 [v]
 submodule = "extensions/v"
@@ -5396,7 +5396,7 @@ version = "0.1.1"
 
 [vala]
 submodule = "extensions/vala"
-version = "0.2.1"
+version = "0.2.0"
 
 [vale]
 submodule = "extensions/vale"
@@ -5663,7 +5663,7 @@ version = "0.0.1"
 
 [windows-batch]
 submodule = "extensions/windows-batch"
-version = "0.2.1"
+version = "0.2.0"
 
 [wit]
 submodule = "extensions/wit"
@@ -5787,7 +5787,7 @@ version = "1.2.2"
 
 [zedokai-darkest-machine]
 submodule = "extensions/zedokai-darkest-machine"
-version = "0.2.1"
+version = "0.2.0"
 
 [zedrack-theme]
 submodule = "extensions/zedrack-theme"
@@ -5863,4 +5863,4 @@ version = "0.0.1"
 
 [zwirn]
 submodule = "extensions/zwirn"
-version = "0.2.1"
+version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -282,7 +282,7 @@ version = "0.1.0"
 
 [astro]
 submodule = "extensions/astro"
-version = "0.2.0"
+version = "0.2.1"
 
 [atlas-ragnarok-theme]
 submodule = "extensions/atlas-ragnarok-theme"
@@ -657,7 +657,7 @@ version = "1.0.0"
 
 [cargo-appraiser]
 submodule = "extensions/cargo-appraiser"
-version = "0.2.0"
+version = "0.2.1"
 
 [cargo-tom]
 submodule = "extensions/cargo-tom"
@@ -886,7 +886,7 @@ version = "0.0.1"
 
 [coi]
 submodule = "extensions/coi"
-version = "0.2.0"
+version = "0.2.1"
 
 [color-highlight]
 submodule = "extensions/color-highlight"
@@ -961,7 +961,7 @@ version = "3.0.0"
 
 [crates-lsp]
 submodule = "extensions/crates-lsp"
-version = "0.2.0"
+version = "0.2.1"
 
 [crimson-theme]
 submodule = "extensions/crimson-theme"
@@ -1063,7 +1063,7 @@ version = "0.0.2"
 
 [cylc]
 submodule = "extensions/cylc"
-version = "0.2.0"
+version = "0.2.1"
 
 [cypher]
 submodule = "extensions/cypher"
@@ -1071,7 +1071,7 @@ version = "0.0.1"
 
 [cython]
 submodule = "extensions/cython"
-version = "0.2.0"
+version = "0.2.1"
 
 [d]
 submodule = "extensions/d"
@@ -1319,7 +1319,7 @@ version = "0.0.4"
 
 [earo-theme]
 submodule = "extensions/earo-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [earthfile]
 submodule = "extensions/earthfile"
@@ -1383,7 +1383,7 @@ version = "0.1.1"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [ejs]
 submodule = "extensions/ejs"
@@ -1496,7 +1496,7 @@ version = "0.0.1"
 
 [everforest]
 submodule = "extensions/everforest"
-version = "0.2.0"
+version = "0.2.1"
 
 [everforest-blurred]
 submodule = "extensions/everforest-blurred"
@@ -1551,7 +1551,7 @@ version = "0.1.1"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"
@@ -1623,7 +1623,7 @@ version = "0.5.1"
 
 [flat-themes]
 submodule = "extensions/flat-themes"
-version = "0.2.0"
+version = "0.2.1"
 
 [flatbuffers]
 submodule = "extensions/flatbuffers"
@@ -1664,7 +1664,7 @@ version = "1.0.0"
 
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [flynt-theme]
 submodule = "extensions/flynt-theme"
@@ -1700,7 +1700,7 @@ version = "0.0.3"
 
 [fountain]
 submodule = "extensions/fountain"
-version = "0.2.0"
+version = "0.2.1"
 
 [fozzy]
 submodule = "extensions/fozzy"
@@ -1770,7 +1770,7 @@ version = "0.1.1"
 
 [gatito-theme]
 submodule = "extensions/gatito-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [gato-theme]
 submodule = "extensions/gato-theme"
@@ -1799,7 +1799,7 @@ version = "0.1.0"
 
 [geno]
 submodule = "extensions/geno"
-version = "0.2.0"
+version = "0.2.1"
 
 [gentle-dark]
 submodule = "extensions/gentle-dark"
@@ -1916,7 +1916,7 @@ version = "1.3.0"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
-version = "0.2.0"
+version = "0.2.1"
 
 [gosum]
 submodule = "extensions/gosum"
@@ -1952,7 +1952,7 @@ version = "0.0.3"
 
 [gren]
 submodule = "extensions/gren"
-version = "0.2.0"
+version = "0.2.1"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
@@ -1996,7 +1996,7 @@ version = "0.0.1"
 
 [gruvbox-crisp-themes]
 submodule = "extensions/gruvbox-crisp-themes"
-version = "0.2.0"
+version = "0.2.1"
 
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"
@@ -2057,7 +2057,7 @@ version = "0.5.0"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.2.0"
+version = "0.2.1"
 
 [hare]
 submodule = "extensions/hare"
@@ -2126,7 +2126,7 @@ version = "1.0.0"
 
 [hivacruz-theme]
 submodule = "extensions/hivacruz-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [hl7v2]
 submodule = "extensions/hl7v2"
@@ -2142,7 +2142,7 @@ version = "0.0.1"
 
 [hocon]
 submodule = "extensions/hocon"
-version = "0.2.0"
+version = "0.2.1"
 
 [hoon]
 submodule = "extensions/hoon"
@@ -2336,7 +2336,7 @@ version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [isle]
 submodule = "extensions/isle"
@@ -2478,7 +2478,7 @@ version = "0.1.10"
 
 [just]
 submodule = "extensions/just"
-version = "0.2.0"
+version = "0.2.1"
 
 [k8s-crd-lsp]
 submodule = "extensions/k8s-crd-lsp"
@@ -2631,7 +2631,7 @@ version = "1.0.1"
 
 [ledger]
 submodule = "extensions/ledger"
-version = "0.2.0"
+version = "0.2.1"
 
 [legendary-dark-theme]
 submodule = "extensions/legendary-dark-theme"
@@ -2707,7 +2707,7 @@ version = "0.0.4"
 
 [livetennis-mcp]
 submodule = "extensions/livetennis-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [llvm-ir]
 submodule = "extensions/llvm-ir"
@@ -2841,7 +2841,7 @@ version = "0.1.2"
 
 [mantle-theme]
 submodule = "extensions/mantle-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [manuscript-theme]
 submodule = "extensions/manuscript-theme"
@@ -2921,7 +2921,7 @@ version = "0.1.1"
 
 [mau]
 submodule = "extensions/mau"
-version = "0.2.0"
+version = "0.2.1"
 
 [maya]
 submodule = "extensions/maya"
@@ -2950,15 +2950,15 @@ version = "0.0.2"
 
 [mcp-server-atexplore]
 submodule = "extensions/mcp-server-atexplore"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-atproto-docs]
 submodule = "extensions/mcp-server-atproto-docs"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
@@ -2986,7 +2986,7 @@ version = "0.1.0"
 
 [mcp-server-figma]
 submodule = "extensions/mcp-server-figma"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-firecrawl]
 submodule = "extensions/mcp-server-firecrawl"
@@ -3062,7 +3062,7 @@ version = "0.0.1"
 
 [mcp-server-relytone]
 submodule = "extensions/mcp-server-relytone"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-repomix]
 submodule = "extensions/mcp-server-repomix"
@@ -3152,11 +3152,11 @@ version = "0.1.21"
 
 [metascript]
 submodule = "extensions/metascript"
-version = "0.2.0"
+version = "0.2.1"
 
 [microscript]
 submodule = "extensions/microscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [midnight-marina]
 submodule = "extensions/midnight-marina"
@@ -3196,7 +3196,7 @@ version = "0.0.1"
 
 [mjml]
 submodule = "extensions/mjml"
-version = "0.2.0"
+version = "0.2.1"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
@@ -3277,7 +3277,7 @@ version = "0.0.4"
 
 [monosami]
 submodule = "extensions/monosami"
-version = "0.2.0"
+version = "0.2.1"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
@@ -3289,7 +3289,7 @@ version = "0.2.1"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.2.0"
+version = "0.2.1"
 
 [moonlight]
 submodule = "extensions/moonlight"
@@ -3313,7 +3313,7 @@ version = "0.0.2"
 
 [mpls]
 submodule = "extensions/mpls"
-version = "0.2.0"
+version = "0.2.1"
 
 [msun-dark]
 submodule = "extensions/msun-dark"
@@ -3381,7 +3381,7 @@ version = "0.0.1"
 
 [neon-verdigris-theme]
 submodule = "extensions/neon-verdigris-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [neosolarized]
 submodule = "extensions/neosolarized"
@@ -3445,7 +3445,7 @@ version = "1.0.0"
 
 [nim]
 submodule = "extensions/nim"
-version = "0.2.0"
+version = "0.2.1"
 
 [ninja]
 submodule = "extensions/ninja"
@@ -3530,7 +3530,7 @@ version = "1.0.6"
 
 [nsis]
 submodule = "extensions/nsis"
-version = "0.2.0"
+version = "0.2.1"
 
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
@@ -3703,7 +3703,7 @@ version = "0.0.1"
 
 [openfga]
 submodule = "extensions/openfga"
-version = "0.2.0"
+version = "0.2.1"
 
 [openscad]
 submodule = "extensions/openscad"
@@ -3743,7 +3743,7 @@ version = "0.1.0"
 
 [oscura]
 submodule = "extensions/oscura"
-version = "0.2.0"
+version = "0.2.1"
 
 [oso]
 submodule = "extensions/oso"
@@ -3812,7 +3812,7 @@ version = "1.0.0"
 
 [papercolor]
 submodule = "extensions/papercolor"
-version = "0.2.0"
+version = "0.2.1"
 
 [papyrus]
 submodule = "extensions/papyrus"
@@ -3849,7 +3849,7 @@ version = "1.3.0"
 
 [pbxproj]
 submodule = "extensions/pbxproj"
-version = "0.2.0"
+version = "0.2.1"
 
 [pearish-theme]
 submodule = "extensions/pearish-theme"
@@ -3885,7 +3885,7 @@ version = "0.0.4"
 
 [perplexity]
 submodule = "extensions/perplexity"
-version = "0.2.0"
+version = "0.2.1"
 
 [pest]
 submodule = "extensions/pest"
@@ -3960,7 +3960,7 @@ version = "0.1.0"
 
 [pink-candy-theme]
 submodule = "extensions/pink-candy-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"
@@ -4052,7 +4052,7 @@ version = "1.0.3"
 
 [poryscript]
 submodule = "extensions/poryscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
@@ -4064,7 +4064,7 @@ version = "0.1.0"
 
 [postman-context-server]
 submodule = "extensions/postman-context-server"
-version = "0.2.0"
+version = "0.2.1"
 
 [powershell]
 submodule = "extensions/powershell"
@@ -4084,7 +4084,7 @@ version = "0.1.9"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [probe-rs]
 submodule = "extensions/probe-rs"
@@ -4117,7 +4117,7 @@ version = "0.0.3"
 
 [puppet]
 submodule = "extensions/puppet"
-version = "0.2.0"
+version = "0.2.1"
 
 [puppydog-theme]
 submodule = "extensions/puppydog-theme"
@@ -4218,11 +4218,11 @@ version = "0.2.2"
 
 [quint]
 submodule = "extensions/quint"
-version = "0.2.0"
+version = "0.2.1"
 
 [qwark-theme]
 submodule = "extensions/qwark-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [r]
 submodule = "extensions/r"
@@ -4292,11 +4292,11 @@ version = "0.1.4"
 
 [red]
 submodule = "extensions/red"
-version = "0.2.0"
+version = "0.2.1"
 
 [redscript]
 submodule = "extensions/redscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [regedit]
 submodule = "extensions/regedit"
@@ -4320,7 +4320,7 @@ version = "0.0.5"
 
 [remedy-theme]
 submodule = "extensions/remedy-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [remix-min-darker-theme]
 submodule = "extensions/remix-min-darker-theme"
@@ -4382,7 +4382,7 @@ version = "0.1.0"
 
 [roc]
 submodule = "extensions/roc"
-version = "0.2.0"
+version = "0.2.1"
 
 [rockide-language-server]
 submodule = "extensions/rockide-language-server"
@@ -4471,7 +4471,7 @@ version = "2.0.3"
 
 [sagemath]
 submodule = "extensions/sagemath"
-version = "0.2.0"
+version = "0.2.1"
 
 [salesforce]
 submodule = "extensions/salesforce"
@@ -4556,7 +4556,7 @@ version = "0.0.1"
 
 [setinox-theme]
 submodule = "extensions/setinox-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [severance-theme]
 submodule = "extensions/severance-theme"
@@ -4568,7 +4568,7 @@ version = "0.1.0"
 
 [shader-ls]
 submodule = "extensions/shader-ls"
-version = "0.2.0"
+version = "0.2.1"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
@@ -4678,7 +4678,7 @@ version = "0.0.1"
 
 [sml]
 submodule = "extensions/sml"
-version = "0.2.0"
+version = "0.2.1"
 
 [smooth]
 submodule = "extensions/smooth"
@@ -4734,7 +4734,7 @@ version = "0.1.0"
 
 [solidity]
 submodule = "extensions/solidity"
-version = "0.2.0"
+version = "0.2.1"
 
 [solitude-theme]
 submodule = "extensions/solitude-theme"
@@ -4796,7 +4796,7 @@ version = "0.1.2"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [sqlmesh]
 submodule = "extensions/sqlmesh"
@@ -4824,11 +4824,11 @@ version = "0.4.1"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
-version = "0.2.0"
+version = "0.2.1"
 
 [stimulus]
 submodule = "extensions/stimulus"
-version = "0.2.0"
+version = "0.2.1"
 
 [stix-theme]
 submodule = "extensions/stix-theme"
@@ -4862,7 +4862,7 @@ version = "0.1.0"
 [suannhai-theme]
 submodule = "extensions/suannhai-theme"
 path = "suannhai-zed"
-version = "0.2.0"
+version = "0.2.1"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
@@ -4986,7 +4986,7 @@ version = "0.1.1"
 
 [synthwave84]
 submodule = "extensions/synthwave84"
-version = "0.2.0"
+version = "0.2.1"
 
 [sysml-v2]
 submodule = "extensions/sysml-v2"
@@ -5127,7 +5127,7 @@ version = "0.0.2"
 
 [tla-plus]
 submodule = "extensions/tla-plus"
-version = "0.2.0"
+version = "0.2.1"
 
 [tlapalli-theme]
 submodule = "extensions/tlapalli-theme"
@@ -5199,7 +5199,7 @@ version = "0.3.1"
 
 [tonel-smalltalk]
 submodule = "extensions/tonel-smalltalk"
-version = "0.2.0"
+version = "0.2.1"
 
 [toon]
 submodule = "extensions/toon"
@@ -5280,7 +5280,7 @@ version = "0.0.5"
 
 [typoscript]
 submodule = "extensions/typoscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [typst]
 submodule = "extensions/typst"
@@ -5300,7 +5300,7 @@ version = "0.0.2"
 
 [ultimate-dark-neo]
 submodule = "extensions/ultimate-dark-neo"
-version = "0.2.0"
+version = "0.2.1"
 
 [ultralytics-snippets]
 submodule = "extensions/ultralytics-snippets"
@@ -5308,7 +5308,7 @@ version = "0.0.2"
 
 [ultraviolet-theme]
 submodule = "extensions/ultraviolet-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [umbra-theme]
 submodule = "extensions/umbra-theme"
@@ -5372,7 +5372,7 @@ version = "0.1.0"
 
 [utl]
 submodule = "extensions/utl"
-version = "0.2.0"
+version = "0.2.1"
 
 [v]
 submodule = "extensions/v"
@@ -5396,7 +5396,7 @@ version = "0.1.1"
 
 [vala]
 submodule = "extensions/vala"
-version = "0.2.0"
+version = "0.2.1"
 
 [vale]
 submodule = "extensions/vale"
@@ -5663,7 +5663,7 @@ version = "0.0.1"
 
 [windows-batch]
 submodule = "extensions/windows-batch"
-version = "0.2.0"
+version = "0.2.1"
 
 [wit]
 submodule = "extensions/wit"
@@ -5787,7 +5787,7 @@ version = "1.2.2"
 
 [zedokai-darkest-machine]
 submodule = "extensions/zedokai-darkest-machine"
-version = "0.2.0"
+version = "0.2.1"
 
 [zedrack-theme]
 submodule = "extensions/zedrack-theme"
@@ -5863,4 +5863,4 @@ version = "0.0.1"
 
 [zwirn]
 submodule = "extensions/zwirn"
-version = "0.2.0"
+version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5280,7 +5280,7 @@ version = "0.0.5"
 
 [typoscript]
 submodule = "extensions/typoscript"
-version = "0.2.1"
+version = "0.2.2"
 
 [typst]
 submodule = "extensions/typst"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5278,6 +5278,10 @@ version = "0.0.1"
 submodule = "extensions/typos"
 version = "0.0.5"
 
+[typoscript]
+submodule = "extensions/typoscript"
+version = "0.2.0"
+
 [typst]
 submodule = "extensions/typst"
 version = "0.2.2"
@@ -5859,8 +5863,4 @@ version = "0.0.1"
 
 [zwirn]
 submodule = "extensions/zwirn"
-version = "0.2.0"
-
-[typoscript]
-submodule = "extensions/typoscript"
 version = "0.2.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5860,3 +5860,7 @@ version = "0.0.1"
 [zwirn]
 submodule = "extensions/zwirn"
 version = "0.2.0"
+
+[typoscript]
+submodule = "extensions/typoscript"
+version = "0.2.0"


### PR DESCRIPTION
### Summary
Adds syntax highlighting for **TYPO3 TypoScript** (`*.typoscript`) and **TSconfig** (`*.tsconfig`).

### What is this?
* **NOT TypeScript:** Despite the name, this has absolutely nothing to do with JavaScript.
* **It's a Config Language:** TYPO3 is a popular European CMS. TypoScript/TSconfig is its internal configuration syntax.
* **Syntax Style:** It looks and behaves like a mix of **TOML and Nginx configurations** (using blocks `{ }`, assignments `=`, and comments `#` or `//`).
* **One Grammar for Both:** Both file extensions use the exact same syntax logic, which is why they are bundled together in this Tree-sitter extension.

Extension: https://github.com/onza/typo3-typoscript
