### PR TITLE
Add SPARQL extension (Qlue-ls language server)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4686,6 +4686,10 @@
 	path = extensions/spai-zero-theme
 	url = https://github.com/BasaiCorp/zed-spai-zero-theme.git
 
+[submodule "extensions/sparql"]
+	path = extensions/sparql
+	url = https://codeberg.org/lutzi/zparqled.git
+
 [submodule "extensions/spiceflow-theme"]
 	path = extensions/spiceflow-theme
 	url = https://github.com/remorses/spiceflow-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -4773,6 +4773,10 @@ version = "0.0.1"
 submodule = "extensions/spai-zero-theme"
 version = "0.2.1"
 
+[sparql]
+submodule = "extensions/sparql"
+version = "0.1.0"
+
 [spiceflow-theme]
 submodule = "extensions/spiceflow-theme"
 version = "0.0.0"


### PR DESCRIPTION
## Add SPARQL extension (Qlue-ls language server)

This extension adds SPARQL language support to Zed, powered by [Qlue-ls](https://github.com/IoannisNezis/Qlue-ls) - a SPARQL language server written in Rust.

### What it provides

- **Grammar**: [tree-sitter-sparql](https://github.com/GordianDziwis/tree-sitter-sparql) for syntax highlighting, brackets, indentation, and outline
- **Language server**: Qlue-ls (found via `PATH` or `~/.cargo/bin/qlue-ls`)
- **File types**: `.rq`, `.sparql`, `.sparu`

### Working features (standard LSP)

- Completion (variables + SPO with backend)
- Document and on-type formatting
- Diagnostics
- Hover
- Code actions
- Rename
- Find references
- Document highlight
- Configuration via `qlue-ls.toml`/`.yml` passed through `workspace/configuration`

### Not supported

Qlue-ls extends LSP with custom `qlueLs/*` methods (query execution, jump navigation, parse tree, runtime backend management). Zed's extension API does not support sending custom LSP requests/notifications, so these are not available.

### Prerequisites

Users install the language server separately:
cargo install qlue-ls

### Verification

Tested manually in Zed with `.rq` files - highlighting, completion, formatting, diagnostics, and hover all working.