### PR TITLE
Add Minimal Kiwi theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3114,6 +3114,10 @@
 	path = extensions/min-theme-plus
 	url = https://github.com/NiFate/zed-min-theme-plus.git
 
+[submodule "extensions/minimal-kiwi"]
+	path = extensions/minimal-kiwi
+	url = https://github.com/MrBStones/minimal-kiwi-theme.git
+
 [submodule "extensions/minizinc"]
 	path = extensions/minizinc
 	url = https://tangled.org/dekker.one/zed-minizinc

--- a/extensions.toml
+++ b/extensions.toml
@@ -3174,6 +3174,10 @@ version = "0.2.2"
 submodule = "extensions/min-theme-plus"
 version = "1.0.0"
 
+[minimal-kiwi]
+submodule = "extensions/minimal-kiwi"
+version = "0.1.0"
+
 [minizinc]
 submodule = "extensions/minizinc"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

### Summary
Adds the **Minimal Kiwi** theme extension (`minimal-kiwi`), adapting the VS Code Minimal Kiwi color theme for Zed.

- **Repository**: https://github.com/MrBStones/minimal-kiwi-theme
- **Extension ID**: `minimal-kiwi`
- **Version**: `0.1.0`
