### PR TITLE
Update apache-avro to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -172,7 +172,7 @@ version = "0.0.1"
 
 [apache-avro]
 submodule = "extensions/apache-avro"
-version = "0.1.0"
+version = "0.2.0"
 
 [apathy-theme]
 submodule = "extensions/apathy-theme"


### PR DESCRIPTION
Updates the apache-avro extension to [v0.2.0](https://github.com/victorhqc/zed-apache-avro/releases/tag/v0.2.0).

- Bumps the submodule to the v0.2.0 tag (bee171e).
- Bumps `version` in `extensions.toml` to 0.2.0, matching `extension.toml` at that commit.

This release updates the tree-sitter grammar to v0.2.0 (fully qualified names, multiple annotations per declaration, array/map default values) and fixes highlight captures that styled whole statements instead of the names inside them.