### PR TITLE
Add intellij-high-contrast-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2254,6 +2254,10 @@
 	path = extensions/inlang-language-server
 	url = https://github.com/NEKOYASAN/inlang-zed
 
+[submodule "extensions/intellij-high-contrast-theme"]
+	path = extensions/intellij-high-contrast-theme
+	url = https://github.com/igorlealantunes/intellij-high-contrast-zed.git
+
 [submodule "extensions/intellij-light-theme"]
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2301,6 +2301,10 @@ version = "0.0.1"
 submodule = "extensions/inlang-language-server"
 version = "0.0.1"
 
+[intellij-high-contrast-theme]
+submodule = "extensions/intellij-high-contrast-theme"
+version = "0.1.0"
+
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"


### PR DESCRIPTION
A port of the **High Contrast** accessibility theme bundled with JetBrains IDEs.

- Repository: https://github.com/igorlealantunes/intellij-high-contrast-zed
- Submodule pinned at `97454e5`
- License: MIT

### On the existing `jb-high-contrast-theme` entry

The prerequisites ask that I try contributing to an existing extension before publishing similar functionality, so to be upfront about it: this began as a fork of [`cringoleg/jetbrains-high-contrast-zed`](https://github.com/cringoleg/jetbrains-high-contrast-zed), which is already in the registry as `jb-high-contrast-theme`.

I did contribute first — [cringoleg/jetbrains-high-contrast-zed#1](https://github.com/cringoleg/jetbrains-high-contrast-zed/pull/1) is open and still awaiting review. The context for publishing separately anyway:

**The published entry has never rendered syntax highlighting.** It is pinned at `5fa25f9`, where `syntax` sits alongside `style` rather than inside it. `ThemeContent` accepts only `name`, `appearance` and `style`, so the stray object is dropped and the theme loads with zero syntax styles — every buffer paints in `editor.foreground` while the UI colors look correct, which is why it is easy to miss.

```
themes[0] keys:            ['name', 'appearance', 'style', 'syntax']
'syntax' in style:         False      <- Zed reads nothing
top-level syntax entries:  44         <- ignored
```

The upstream repository fixed the nesting in `e13c089` but left `version` at `0.1.0`, so this registry has had no reason to re-pull. Last commit there was in April.

This submission is not a straight copy: the ID and display name are distinct so it neither collides with `jb-high-contrast-theme` nor shows a duplicate label in the theme picker, six syntax tokens were added where the inherited parent was the wrong color (`tree-sitter-php` maps `true`/`false`/`null` to `constant.builtin` rather than `boolean`, for instance), and there is a CI check that fails the build if a theme ships with an empty `style.syntax`.

Happy to close this if you would rather I keep waiting on the upstream PR, or if you would prefer to re-point `jb-high-contrast-theme` once it merges.

### Checklist

- [x] Tested in Zed at the submitted submodule commit
- [x] MIT license included, upstream and JetBrains attribution recorded in the README
- [x] `extensions.toml` and `.gitmodules` left in sorted order
- [x] Adds exactly one extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLHPEmYmuCQXBqJjvfiHtg
