### PR TITLE
Add neuromancer-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3338,6 +3338,10 @@
 	path = extensions/netlinx
 	url = https://github.com/Norgate-AV/zed-netlinx.git
 
+[submodule "extensions/neuromancer-theme"]
+	path = extensions/neuromancer-theme
+	url = https://github.com/SirSouza/neuromancer-theme.git
+
 [submodule "extensions/neutral-theme"]
 	path = extensions/neutral-theme
 	url = https://github.com/dustinbturner/neutral-theme.git


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Neuromancer — a dual theme (dark/light) with a soft pink light mode and 
deep charcoal dark mode, featuring vibrant syntax highlights in pink, 
green, blue, and orange.