### PR TITLE
Update hubbamax-theme to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2199,7 +2199,7 @@ version = "0.0.1"
 
 [hubbamax-theme]
 submodule = "extensions/hubbamax-theme"
-version = "0.2.1"
+version = "0.3.0"
 
 [hubl]
 submodule = "extensions/hubl"


### PR DESCRIPTION
Updates `hubbamax-theme` from 0.2.1 to 0.3.0.

This release restores the upstream Hubbamax `#1c1c1c` editor background and refines the Zed UI with clearer surface hierarchy, tabs, panels, interaction states, and semantic accents while preserving the syntax palette.

Validation:
- `npm run sort-extensions`
- `npm run build`
- `npm test` (115 tests passed)