### PR TITLE
Add Yona extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5630,6 +5630,10 @@
 	path = extensions/yellowed
 	url = https://github.com/Gael-Lopes-Da-Silva/YellowedZed
 
+[submodule "extensions/yona"]
+	path = extensions/yona
+	url = https://github.com/yona-lang/zed-yona.git
+
 [submodule "extensions/your-name-theme"]
 	path = extensions/your-name-theme
 	url = https://github.com/TheAhumMaitra/Your-Name-Zed-theme.git
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/yona"]
-	path = extensions/yona
-	url = https://github.com/yona-lang/zed-yona.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/yona"]
+	path = extensions/yona
+	url = https://github.com/yona-lang/zed-yona.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5745,6 +5745,10 @@ version = "1.1.0"
 submodule = "extensions/yuck"
 version = "0.1.0"
 
+[yona]
+submodule = "extensions/yona"
+version = "0.1.6"
+
 [yue-theme]
 submodule = "extensions/yue-theme"
 version = "1.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -5737,6 +5737,10 @@ version = "0.0.9"
 submodule = "extensions/yellowed"
 version = "0.0.3"
 
+[yona]
+submodule = "extensions/yona"
+version = "0.1.6"
+
 [your-name-theme]
 submodule = "extensions/your-name-theme"
 version = "1.1.0"
@@ -5744,10 +5748,6 @@ version = "1.1.0"
 [yuck]
 submodule = "extensions/yuck"
 version = "0.1.0"
-
-[yona]
-submodule = "extensions/yona"
-version = "0.1.6"
 
 [yue-theme]
 submodule = "extensions/yue-theme"


### PR DESCRIPTION
Adds the official Yona extension, backed by `yls` and the public `tree-sitter-yona` grammar.

Validation:
- `npx tree-sitter-cli test`
- stdlib corpus parses without Tree-sitter ERROR nodes
- `cargo check` and `cargo check --target wasm32-wasip2`
- manifest/discovery smoke check