### PR TITLE
Add fluid extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1630,6 +1630,10 @@
 	path = extensions/fluent-oled-theme
 	url = https://github.com/fermeridamagni/fluent-oled-for-zed.git
 
+[submodule "extensions/fluid"]
+	path = extensions/fluid
+	url = https://github.com/onza/typo3-fluid.git
+
 [submodule "extensions/flutter-snippets"]
 	path = extensions/flutter-snippets
 	url = https://github.com/luisdanieldlcg/flutter-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -1662,6 +1662,10 @@ version = "0.13.0"
 submodule = "extensions/fluent-oled-theme"
 version = "1.0.0"
 
+[fluid]
+submodule = "extensions/fluid"
+version = "0.1.3"
+
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
 version = "0.2.0"


### PR DESCRIPTION
### Summary
Adds support for **TYPO3 Fluid** templates (HTML/XML/JSON/text variants): Tree-sitter highlighting, snippets, and a helper LSP for completions, `fluid:analyze`, and schema.

### What is this?
* **TYPO3 templating language:** Fluid is the template engine of the TYPO3 CMS (widely used in Europe). Templates usually live under `Resources/Private/` as `*.html` / `*.xml` (and related formats).
* **NOT plain HTML:** Fluid looks like HTML, but adds ViewHelper tags (`<f:…>`), inline expressions (`{variable}`, `{f:vh(…)}`), and namespaces that a normal HTML grammar does not understand.
* **Syntax mix:** Markup structure like HTML/XML, plus Fluid-specific tags and curly-brace expressions inside attributes and text.
* **Helper LSP (downloaded, not bundled):** Completions and project tooling come from a small Node helper published as a GitHub Release asset (`fluid-lsp.tar.gz`), following Zed marketplace rules.

Extension: https://github.com/onza/typo3-fluid