### PR TITLE
Update jb-high-contrast-theme to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2381,7 +2381,7 @@ version = "0.1.0"
 
 [jb-high-contrast-theme]
 submodule = "extensions/jb-high-contrast-theme"
-version = "0.1.0"
+version = "0.1.1"
 
 [jdl]
 submodule = "extensions/jdl"


### PR DESCRIPTION
- [x] I've read the contribution guidelines and followed the relevant guidance for updating my extension.

Updates jb-high-contrast-theme to v0.1.1 and points the registry submodule at the reviewed source merge commit.
The extension was installed and visually tested as a Zed dev extension.