### PR TITLE
Add Java Properties extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2326,6 +2326,10 @@
 	path = extensions/java-eclipse-jdtls
 	url = https://github.com/ABckh/zed-java-language-support-jdtls
 
+[submodule "extensions/java-properties"]
+	path = extensions/java-properties
+	url = https://github.com/peppe1337/zed-java-properties.git
+
 [submodule "extensions/javascript-snippets"]
 	path = extensions/javascript-snippets
 	url = https://github.com/seekode/zed-js-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -2375,6 +2375,10 @@ version = "6.8.26"
 submodule = "extensions/java-eclipse-jdtls"
 version = "0.2.5"
 
+[java-properties]
+submodule = "extensions/java-properties"
+version = "0.1.0"
+
 [javascript-snippets]
 submodule = "extensions/javascript-snippets"
 version = "0.1.0"


### PR DESCRIPTION
Adds syntax highlighting for Java `.properties` files (`java.util.Properties`).

**Why:** `.properties` files currently open as plain text. No built-in grammar under `crates/grammars/src` claims the `properties` path suffix, the `java` extension claims only `["java"]`, and the extension search API returns no results for `properties`. I did not check the `path_suffixes` of all 1442 registered extensions individually.

**Grammar:** [tree-sitter-grammars/tree-sitter-properties](https://github.com/tree-sitter-grammars/tree-sitter-properties) (MIT), pinned to `6310671b24d4e04b803577b1c675d765cbd5773b`.

**Contents:** grammar and `highlights.scm` only. No Rust code, no language server, no snippets.

**Testing:** I installed the extension at commit `8e3ed4a` into Zed 1.16.3 on Linux and opened a `.properties` file containing comments (`#` and `!`), both `=` and `:` separators, a Unicode escape and a line continuation. The status bar reads `Java Properties` and highlighting is applied. With the extension removed, the same file in the same editor reads `Unknown` and shows no highlighting.
