### PR TITLE
Add ini-migoto syntax extension for 3DMigoto INI files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2242,6 +2242,10 @@
 	path = extensions/ini
 	url = https://github.com/bajrangCoder/zed-ini.git
 
+[submodule "extensions/ini_migoto"]
+	path = extensions/ini_migoto
+	url = https://github.com/L1keyneko/zed-ini-3dmigoto.git
+
 [submodule "extensions/ink"]
 	path = extensions/ink
 	url = https://github.com/yuna0x0/zed-ink.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2289,6 +2289,10 @@ version = "0.1.0"
 submodule = "extensions/ini"
 version = "0.0.9"
 
+[ini_migoto]
+submodule = "extensions/ini_migoto"
+version = "0.1.0"
+
 [ink]
 submodule = "extensions/ink"
 version = "0.0.2"


### PR DESCRIPTION
This extension provides syntax highlighting for 3DMigoto-style INI files, which extend standard INI syntax with additional keywords like 'global' and 'persist' used in game modding configurations.

Features:
- Highlights global/persist declarations
- Supports $variable syntax
- Recognizes standard INI sections and key-value pairs
- Includes fold and outline support

Based on tree-sitter-migoto parser by lupomikti.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
