### PR TITLE
Add java-snippets extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/java-snippets"]
+	path = extensions/java-snippets
+	url = https://github.com/Joggoaleo-tech/zed-java-snippets.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2375,6 +2375,10 @@ version = "6.8.26"
 submodule = "extensions/java-eclipse-jdtls"
 version = "0.2.5"
 
+[java-snippets]
+submodule = "extensions/java-snippets"
+version = "0.1.0"
+
 [javascript-snippets]
 submodule = "extensions/javascript-snippets"
 version = "0.1.0"


### PR DESCRIPTION


- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.


Adds "Java Snippets", a small extension that provides handy Java code snippets (pkg, sout, psvm, class, ctor, getters/setters, for-loops, try/catch).

Repository: https://github.com/Joggoaleo-tech/zed-java-snippets
