### PR TITLE
Add Badness language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -374,6 +374,10 @@
 	path = extensions/babel-lsp
 	url = https://github.com/alex-oleshkevich/babel-lsp
 
+[submodule "extensions/badness-language-server"]
+	path = extensions/badness-language-server
+	url = https://github.com/jolars/badness.git
+
 [submodule "extensions/bamboo-theme"]
 	path = extensions/bamboo-theme
 	url = https://github.com/LoamStudios/zed-bamboo-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -383,6 +383,11 @@ submodule = "extensions/babel-lsp"
 path = "editors/zed"
 version = "0.1.1"
 
+[badness-language-server]
+submodule = "extensions/badness-language-server"
+path = "editors/zed"
+version = "0.1.0"
+
 [bamboo-theme]
 submodule = "extensions/bamboo-theme"
 version = "0.1.0"


### PR DESCRIPTION
This PR adds support for [Badness](https://badness.dev), a language server, formatter, and linter for LaTeX (and BibTeX). 

- Repo: https://github.com/jolars/badness
- Current version: 0.20.0

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
