### PR TITLE
Add Arity language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -218,6 +218,10 @@
 	path = extensions/ariake
 	url = https://github.com/artivilla/zed-ariake-theme
 
+[submodule "extensions/arity-language-server"]
+	path = extensions/arity-language-server
+	url = https://github.com/jolars/arity.git
+
 [submodule "extensions/arkts"]
 	path = extensions/arkts
 	url = https://github.com/liuyanghejerry/zed-arkts.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -223,6 +223,11 @@ version = "0.1.0"
 submodule = "extensions/ariake"
 version = "0.0.1"
 
+[arity-language-server]
+submodule = "extensions/arity-language-server"
+path = "editors/zed"
+version = "0.1.0"
+
 [arkts]
 submodule = "extensions/arkts"
 version = "0.3.0"


### PR DESCRIPTION
This PR adds support for [Arity](https://arity.cc), a language server, formatter, and linter for R.

- Repo: https://github.com/jolars/arity
- Current version: 0.21.0

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
