### PR TITLE
Add Filament theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1550,6 +1550,10 @@
 	path = extensions/field-lights-theme
 	url = https://github.com/adamsharifc/zed-field-lights
 
+[submodule "extensions/filament-theme"]
+	path = extensions/filament-theme
+	url = https://github.com/mehcode/filament.git
+
 [submodule "extensions/file-icons"]
 	path = extensions/file-icons
 	url = https://github.com/toxblh/zed-file-icons.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1581,6 +1581,10 @@ version = "0.1.1"
 submodule = "extensions/field-lights-theme"
 version = "1.0.0"
 
+[filament-theme]
+submodule = "extensions/filament-theme"
+version = "0.2.0"
+
 [file-icons]
 submodule = "extensions/file-icons"
 version = "1.0.0"


### PR DESCRIPTION
Adds [Filament](https://github.com/mehcode/filament), a warm, filament-lit theme.


<table>
  <tr>
    <td width="50%"><img src="https://raw.githubusercontent.com/mehcode/filament/refs/heads/main/assets/zed/rust.png" alt="Filament Dark rendering Rust"></td>
    <td width="50%"><img src="https://raw.githubusercontent.com/mehcode/filament/refs/heads/main/assets/zed/go.png" alt="Filament Dark rendering Go"></td>
  </tr>
  <tr>
    <td width="50%"><img src="https://raw.githubusercontent.com/mehcode/filament/refs/heads/main/assets/zed/python.png" alt="Filament Dark rendering Python"></td>
    <td width="50%"><img src="https://raw.githubusercontent.com/mehcode/filament/refs/heads/main/assets/zed/vue.png" alt="Filament Dark rendering Vue"></td>
  </tr>
</table>


- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
