### PR TITLE
Add AstroDark theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/astrodark-theme"]
+	path = extensions/astrodark-theme
+	url = https://github.com/lemokami/astrodark-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -278,6 +278,10 @@
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
 
+[submodule "extensions/astrodark-theme"]
+	path = extensions/astrodark-theme
+	url = https://github.com/lemokami/astrodark-zed.git
+
 [submodule "extensions/atlas-ragnarok-theme"]
 	path = extensions/atlas-ragnarok-theme
 	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/astrodark-theme"]
-	path = extensions/astrodark-theme
-	url = https://github.com/lemokami/astrodark-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -280,13 +280,13 @@ version = "0.0.1"
 submodule = "extensions/astral-theme"
 version = "0.1.0"
 
-[astrodark-theme]
-submodule = "extensions/astrodark-theme"
-version = "0.1.0"
-
 [astro]
 submodule = "extensions/astro"
 version = "0.2.0"
+
+[astrodark-theme]
+submodule = "extensions/astrodark-theme"
+version = "0.1.0"
 
 [atlas-ragnarok-theme]
 submodule = "extensions/atlas-ragnarok-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -280,6 +280,10 @@ version = "0.0.1"
 submodule = "extensions/astral-theme"
 version = "0.1.0"
 
+[astrodark-theme]
+submodule = "extensions/astrodark-theme"
+version = "0.1.0"
+
 [astro]
 submodule = "extensions/astro"
 version = "0.2.0"


### PR DESCRIPTION
## Extension

AstroDark — a port of the [AstroDark](https://github.com/AstroNvim/astrotheme) colorscheme (from AstroNvim/astrotheme) to Zed's theme format.

- Repo: https://github.com/lemokami/astrodark-zed
- License: GPLv3 (matches upstream astrotheme, since this is a derivative of its palette)
- Colors sourced from upstream's `lua/astrotheme/palettes/astrodark.lua` and `extras/vscode/astrodark.json` (for precomputed terminal ANSI bright/dim variants)
- Tested locally as a dev extension in Zed

🤖 Generated with [Claude Code](https://claude.com/claude-code)