### PR TITLE
Add raylang extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4190,6 +4190,10 @@
 	path = extensions/rasi
 	url = https://github.com/mikaeladev/zed-rasi.git
 
+[submodule "extensions/raylang"]
+	path = extensions/raylang
+	url = https://github.com/ray-language/zed-raylang.git
+
 [submodule "extensions/rcl"]
 	path = extensions/rcl
 	url = https://github.com/rcl-lang/zed-rcl.git
@@ -5757,6 +5761,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/raylang"]
-	path = extensions/raylang
-	url = https://github.com/ray-language/zed-raylang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/raylang"]
+	path = extensions/raylang
+	url = https://github.com/ray-language/zed-raylang.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4265,6 +4265,10 @@ version = "1.0.1"
 submodule = "extensions/rasi"
 version = "0.1.1"
 
+[raylang]
+submodule = "extensions/raylang"
+version = "0.1.0"
+
 [rcl]
 submodule = "extensions/rcl"
 version = "0.12.0"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4267,7 +4267,7 @@ version = "0.1.1"
 
 [raylang]
 submodule = "extensions/raylang"
-version = "0.1.0"
+version = "0.1.1"
 
 [rcl]
 submodule = "extensions/rcl"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4267,7 +4267,7 @@ version = "0.1.1"
 
 [raylang]
 submodule = "extensions/raylang"
-version = "0.1.1"
+version = "0.1.2"
 
 [rcl]
 submodule = "extensions/rcl"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds language support for [raylang](https://raylang.dev), a statically typed, expression-oriented language: tree-sitter syntax highlighting, outline, indentation, and integration with the language server shipped in the `ray` toolchain (`ray lsp`).

Extension repository: https://github.com/ray-language/zed-raylang
Grammar: https://github.com/ray-language/tree-sitter-raylang (validated in CI against the 284 `.ray` files of the language repository)