### PR TITLE
Update dependi to v1.11.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1196,7 +1196,7 @@ version = "0.1.2"
 [dependi]
 submodule = "extensions/dependi"
 path = "dependi-zed"
-version = "1.10.0"
+version = "1.11.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"


### PR DESCRIPTION
## Summary

- Update dependi extension to v1.11.0
- Point the dependi submodule at the v1.11.0 release commit

This is the last release under the `dependi` id: the extension is being renamed to `depsy` (mpiton/zed-dependi#377). The release only adds a startup notice pointing users at the new extension and pins the language server download to the v1.11.0 assets. A follow-up PR will add `depsy`, and `dependi` will be removed once users have had time to migrate.

## Type

chore

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm sort-extensions` (no changes)
- `cargo build --release --target wasm32-wasip2 --locked` in `dependi-zed` at the tagged commit
