### PR TITLE
Add Dark Matter Code theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1102,6 +1102,10 @@
 	path = extensions/dark-material-dracula
 	url = https://github.com/wladpaiva/zed-dark-material-dracula.git
 
+[submodule "extensions/dark-matter-code-theme"]
+	path = extensions/dark-matter-code-theme
+	url = https://github.com/amiralibg/Dark-Matter-Code.git
+
 [submodule "extensions/dark-oled"]
 	path = extensions/dark-oled
 	url = https://github.com/DaviAragorn/dark-oled-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1125,6 +1125,11 @@ version = "0.3.0"
 submodule = "extensions/dark-material-dracula"
 version = "0.0.1"
 
+[dark-matter-code-theme]
+submodule = "extensions/dark-matter-code-theme"
+path = "zed"
+version = "0.0.8"
+
 [dark-oled]
 submodule = "extensions/dark-oled"
 version = "0.1.0"


### PR DESCRIPTION
Adds **Dark Matter Code**, a family of seven dark themes in three collections:

- **Mars** (warm/reddish) — Medium, Soft, Hard
- **Neptune** (cool/blueish) — Medium, Soft, Hard
- **Pluto** — true black `#000000`, OLED-friendly

Syntax colours are shared across all seven variants; only the UI chrome changes, so the collections differ in background temperature and contrast rather than in highlighting.

The extension lives in the `zed/` subdirectory of the repository, hence the `path` field. It is licensed MIT, with the license present inside `zed/` as required.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.