### PR TITLE
Update windows-batch to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5659,7 +5659,7 @@ version = "0.0.1"
 
 [windows-batch]
 submodule = "extensions/windows-batch"
-version = "0.2.0"
+version = "0.3.0"
 
 [wit]
 submodule = "extensions/wit"


### PR DESCRIPTION
Command arguments like `--id=Figma.Figma` were parsed as a single node, so flags, separators and values all got one color. The grammar now splits them, and the queries highlight each part.

| Before | After |
| --- | --- |
| <img width="420" alt="before" src="https://github.com/user-attachments/assets/9c7955b2-2f6c-4f62-95af-527b36bd2f31" /> | <img width="420" alt="after" src="https://github.com/user-attachments/assets/4ce05793-afd6-408d-ba5c-6482706a5990" /> |


Ref pleahmacaka/zed-batch#1

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.