### PR TITLE
Update agnix to v0.52.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -81,7 +81,7 @@ version = "0.2.1"
 [agnix]
 submodule = "extensions/agnix"
 path = "editors/zed"
-version = "0.48.0"
+version = "0.52.1"
 
 [agno-theme]
 submodule = "extensions/agno-theme"


### PR DESCRIPTION
Updates the agnix extension from v0.48.0 to v0.52.1.

Release notes: https://github.com/agent-sh/agnix/releases

Highlights since v0.48.0: rule count 448 -> 454 (new Claude Code v2.1.247 settings coverage), refreshed tool/spec baselines for Claude Code, Cursor, Cline, Codex CLI, amp, and Gemini CLI, and distribution work (PyPI wheels, self-installing pre-commit hooks) that does not affect the Zed extension surface. The extension itself (editors/zed) is unchanged in shape; the submodule pin moves to the v0.52.1 tag with the version field matching the extension.toml at that commit.