### PR TITLE
Add HBuilderX Soft Green theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2042,6 +2042,10 @@
 	path = extensions/hbuilderx-push-light
 	url = https://github.com/yuanzhhh/hbuilderx-theme-zed.git
 
+[submodule "extensions/hbuilderx-soft-green-theme"]
+	path = extensions/hbuilderx-soft-green-theme
+	url = https://github.com/qinains/hbuilderx-soft-green.git
+
 [submodule "extensions/hc-monokai-theme"]
 	path = extensions/hc-monokai-theme
 	url = https://github.com/p404/zed-hc-monokai.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2083,6 +2083,11 @@ version = "0.4.0"
 submodule = "extensions/hbuilderx-push-light"
 version = "0.1.0"
 
+[hbuilderx-soft-green-theme]
+submodule = "extensions/hbuilderx-soft-green-theme"
+path = "zed"
+version = "1.0.0"
+
 [hc-monokai-theme]
 submodule = "extensions/hc-monokai-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds HBuilderX Soft Green, a light and dark theme family inspired by HBuilderX.

- Extension ID: `hbuilderx-soft-green-theme`
- Extension path: `zed`
- Version: `1.0.0`
- Tested locally in Zed
- Theme schema validation passed

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.