### PR TITLE
Add skill extension (Cadence SKILL language support)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5757,3 +5757,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/skill"]
+	path = extensions/skill
+	url = https://github.com/deanyou/zed-skill

--- a/extensions.toml
+++ b/extensions.toml
@@ -32,7 +32,7 @@ version = "0.1.0"
 
 [actionscript]
 submodule = "extensions/actionscript"
-version = "0.1.1"
+version = "0.2.0"
 
 [activitywatch]
 submodule = "extensions/activitywatch"
@@ -372,7 +372,7 @@ version = "1.0.0"
 
 [azure-mcp]
 submodule = "extensions/azure-mcp"
-version = "0.1.1"
+version = "0.2.0"
 
 [azutiku-theme]
 submodule = "extensions/azutiku-theme"
@@ -381,7 +381,7 @@ version = "0.1.0"
 [babel-lsp]
 submodule = "extensions/babel-lsp"
 path = "editors/zed"
-version = "0.1.1"
+version = "0.2.0"
 
 [bamboo-theme]
 submodule = "extensions/bamboo-theme"
@@ -487,7 +487,7 @@ version = "0.1.3"
 
 [blackula]
 submodule = "extensions/blackula"
-version = "0.1.1"
+version = "0.2.0"
 
 [blade]
 submodule = "extensions/blade"
@@ -621,11 +621,11 @@ version = "0.0.2"
 
 [cairo]
 submodule = "extensions/cairo"
-version = "0.1.1"
+version = "0.2.0"
 
 [call-trans-opt-received]
 submodule = "extensions/call-trans-opt-received"
-version = "0.1.1"
+version = "0.2.0"
 
 [candela-theme]
 submodule = "extensions/candela-theme"
@@ -665,7 +665,7 @@ version = "0.4.1"
 
 [carve]
 submodule = "extensions/carve"
-version = "0.1.1"
+version = "0.2.0"
 
 [cassette-futurism-theme]
 submodule = "extensions/cassette-futurism-theme"
@@ -693,7 +693,7 @@ version = "0.3.4"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"
-version = "0.1.1"
+version = "0.2.0"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
@@ -731,7 +731,7 @@ version = "0.0.2"
 
 [chalice-theme]
 submodule = "extensions/chalice-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [chanterelle]
 submodule = "extensions/chanterelle"
@@ -743,11 +743,11 @@ version = "0.0.2"
 
 [charbox-theme]
 submodule = "extensions/charbox-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [charcoal-theme]
 submodule = "extensions/charcoal-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [charmed-icons]
 submodule = "extensions/charmed-icons"
@@ -816,7 +816,7 @@ version = "0.0.1"
 
 [clean-vscode-icons]
 submodule = "extensions/clean-vscode-icons"
-version = "0.1.1"
+version = "0.2.0"
 
 [clice]
 submodule = "extensions/clice"
@@ -997,12 +997,12 @@ version = "0.0.7"
 
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
-version = "0.1.1"
+version = "0.2.0"
 path = "crates/zed"
 
 [css-variables]
 submodule = "extensions/css-variables"
-version = "0.1.1"
+version = "0.2.0"
 
 [csskit-lsp]
 submodule = "extensions/csskit-lsp"
@@ -1091,11 +1091,11 @@ version = "0.1.0"
 
 [dang]
 submodule = "extensions/dang"
-version = "0.1.1"
+version = "0.2.0"
 
 [darcula-dark]
 submodule = "extensions/darcula-dark"
-version = "0.1.1"
+version = "0.2.0"
 
 [darcula-dark-okkano]
 submodule = "extensions/darcula-dark-okkano"
@@ -1163,7 +1163,7 @@ version = "0.0.1"
 
 [dbt]
 submodule = "extensions/dbt"
-version = "0.1.1"
+version = "0.2.0"
 
 [decorative-stitch]
 submodule = "extensions/decorative-stitch"
@@ -1175,7 +1175,7 @@ version = "0.1.0"
 
 [deep-slate-theme]
 submodule = "extensions/deep-slate-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [deepz-theme]
 submodule = "extensions/deepz-theme"
@@ -1379,7 +1379,7 @@ version = "1.0"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
@@ -1484,7 +1484,7 @@ version = "0.3.1"
 
 [erlang-qol-snippets]
 submodule = "extensions/erlang-qol-snippets"
-version = "0.1.1"
+version = "0.2.0"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
@@ -1547,7 +1547,7 @@ version = "1.0.0"
 [fastapi-lsp]
 submodule = "extensions/fastapi-lsp"
 path = "editors/zed"
-version = "0.1.1"
+version = "0.2.0"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
@@ -1575,7 +1575,7 @@ version = "0.1.0"
 
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
-version = "0.1.1"
+version = "0.2.0"
 
 [field-lights-theme]
 submodule = "extensions/field-lights-theme"
@@ -1591,11 +1591,11 @@ version = "1.0.3"
 
 [fineorite-theme]
 submodule = "extensions/fineorite-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [firebase-security-rules]
 submodule = "extensions/firebase-security-rules"
-version = "0.1.1"
+version = "0.2.0"
 
 [firefox-quantum-theme]
 submodule = "extensions/firefox-quantum-theme"
@@ -1668,7 +1668,7 @@ version = "0.2.0"
 
 [flynt-theme]
 submodule = "extensions/flynt-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [focus-theme]
 submodule = "extensions/focus-theme"
@@ -1761,12 +1761,12 @@ version = "1.0.1"
 [gas-plasma-icons]
 submodule = "extensions/gas-plasma-icons"
 path = "zed/gas-plasma-icons"
-version = "0.1.1"
+version = "0.2.0"
 
 [gas-plasma-theme]
 submodule = "extensions/gas-plasma-theme"
 path = "zed/gas-plasma-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [gatito-theme]
 submodule = "extensions/gatito-theme"
@@ -1847,7 +1847,7 @@ version = "0.0.3"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
@@ -2365,7 +2365,7 @@ version = "0.0.1"
 [jarl]
 submodule = "extensions/jarl"
 path = "editors/zed"
-version = "0.1.1"
+version = "0.2.0"
 
 [java]
 submodule = "extensions/java"
@@ -2449,11 +2449,11 @@ version = "0.0.3"
 
 [json5]
 submodule = "extensions/json5"
-version = "0.1.1"
+version = "0.2.0"
 
 [jsonl]
 submodule = "extensions/jsonl"
-version = "0.1.1"
+version = "0.2.0"
 
 [jsonl-lsp]
 submodule = "extensions/jsonl-lsp"
@@ -2644,7 +2644,7 @@ version = "0.0.1"
 
 [leptos]
 submodule = "extensions/leptos"
-version = "0.1.1"
+version = "0.2.0"
 
 [less]
 submodule = "extensions/less"
@@ -2664,7 +2664,7 @@ version = "0.0.1"
 
 [lilypond]
 submodule = "extensions/lilypond"
-version = "0.1.1"
+version = "0.2.0"
 
 [lini]
 submodule = "extensions/lini"
@@ -2711,7 +2711,7 @@ version = "0.2.0"
 
 [llvm-ir]
 submodule = "extensions/llvm-ir"
-version = "0.1.1"
+version = "0.2.0"
 
 [lndpnr-theme]
 submodule = "extensions/lndpnr-theme"
@@ -2756,7 +2756,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.1.1"
+version = "0.2.0"
 
 [lua]
 submodule = "extensions/lua"
@@ -2780,7 +2780,7 @@ version = "0.0.2"
 
 [lumina-theme]
 submodule = "extensions/lumina-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [lusch-theme]
 submodule = "extensions/lusch-theme"
@@ -2817,7 +2817,7 @@ version = "0.10.0"
 
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [make]
 submodule = "extensions/make"
@@ -2905,7 +2905,7 @@ version = "0.0.1"
 
 [matlab]
 submodule = "extensions/matlab"
-version = "0.1.1"
+version = "0.2.0"
 
 [matt-white-theme]
 submodule = "extensions/matt-white-theme"
@@ -2917,7 +2917,7 @@ version = "1.2.0"
 
 [matte-black-theme]
 submodule = "extensions/matte-black-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [mau]
 submodule = "extensions/mau"
@@ -2934,7 +2934,7 @@ version = "0.1.0"
 
 [mc-dp-icons-theme]
 submodule = "extensions/mc-dp-icons-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [mcfunction]
 submodule = "extensions/mcfunction"
@@ -3180,7 +3180,7 @@ version = "0.1.0"
 
 [mint-theme]
 submodule = "extensions/mint-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [miramare-theme]
 submodule = "extensions/miramare-theme"
@@ -3301,7 +3301,7 @@ version = "0.0.2"
 
 [motoko]
 submodule = "extensions/motoko"
-version = "0.1.1"
+version = "0.2.0"
 
 [move]
 submodule = "extensions/move"
@@ -3433,7 +3433,7 @@ version = "0.1.0"
 
 [nightfox]
 submodule = "extensions/nightfox"
-version = "0.1.1"
+version = "0.2.0"
 
 [nightfox-m]
 submodule = "extensions/nightfox-m"
@@ -3478,7 +3478,7 @@ version = "0.0.2"
 
 [noir-and-blanc-theme]
 submodule = "extensions/noir-and-blanc-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [nomad]
 submodule = "extensions/nomad"
@@ -3671,7 +3671,7 @@ version = "0.0.2"
 
 [one-dark-pro-monokai-darker]
 submodule = "extensions/one-dark-pro-monokai-darker"
-version = "0.1.1"
+version = "0.2.0"
 
 [one-dark-pro-vivid-theme]
 submodule = "extensions/one-dark-pro-vivid-theme"
@@ -3691,7 +3691,7 @@ version = "0.1.0"
 
 [oolong]
 submodule = "extensions/oolong"
-version = "0.1.1"
+version = "0.2.0"
 
 [opaline-theme]
 submodule = "extensions/opaline-theme"
@@ -3800,7 +3800,7 @@ version = "2.35.1"
 
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [panda-theme]
 submodule = "extensions/panda-theme"
@@ -3861,7 +3861,7 @@ version = "0.0.2"
 
 [penumbra]
 submodule = "extensions/penumbra"
-version = "0.1.1"
+version = "0.2.0"
 
 [penumbra-plus]
 submodule = "extensions/penumbra-plus"
@@ -3889,7 +3889,7 @@ version = "0.2.0"
 
 [pest]
 submodule = "extensions/pest"
-version = "0.1.1"
+version = "0.2.0"
 
 [pgfmt-lsp]
 submodule = "extensions/pgfmt-lsp"
@@ -4133,7 +4133,7 @@ version = "0.1.0"
 
 [pyatlas-lsp]
 submodule = "extensions/pyatlas-lsp"
-version = "0.1.1"
+version = "0.2.0"
 
 [pycharm-modern-themes]
 submodule = "extensions/pycharm-modern-themes"
@@ -4154,7 +4154,7 @@ version = "0.24.0"
 
 [python-autodoc-lsp]
 submodule = "extensions/python-autodoc-lsp"
-version = "0.1.1"
+version = "0.2.0"
 
 [python-refactoring]
 submodule = "extensions/python-refactoring"
@@ -4230,11 +4230,11 @@ version = "0.2.5"
 
 [racket]
 submodule = "extensions/racket"
-version = "0.1.1"
+version = "0.2.0"
 
 [radical-reborn-theme]
 submodule = "extensions/radical-reborn-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [railgun]
 submodule = "extensions/railgun"
@@ -4263,7 +4263,7 @@ version = "1.0.1"
 
 [rasi]
 submodule = "extensions/rasi"
-version = "0.1.1"
+version = "0.2.0"
 
 [rcl]
 submodule = "extensions/rcl"
@@ -4560,7 +4560,7 @@ version = "0.2.0"
 
 [severance-theme]
 submodule = "extensions/severance-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"
@@ -4630,7 +4630,7 @@ version = "0.1.0"
 
 [skill]
 submodule = "extensions/skill"
-version = "0.1.1"
+version = "0.2.0"
 
 [skill-language-server]
 submodule = "extensions/skill-language-server"
@@ -4648,7 +4648,7 @@ version = "0.0.1"
 
 [slang]
 submodule = "extensions/slang"
-version = "0.1.1"
+version = "0.2.0"
 
 [slate]
 submodule = "extensions/slate"
@@ -4763,11 +4763,11 @@ version = "0.1.2"
 
 [sorbet]
 submodule = "extensions/sorbet"
-version = "0.1.1"
+version = "0.2.0"
 
 [souffle]
 submodule = "extensions/souffle"
-version = "0.1.1"
+version = "0.2.0"
 
 [sourcepawn]
 submodule = "extensions/sourcepawn"
@@ -4944,7 +4944,7 @@ version = "3.0.2"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"
-version = "0.1.1"
+version = "0.2.0"
 
 [svelte-snippets]
 submodule = "extensions/svelte-snippets"
@@ -4986,7 +4986,7 @@ version = "0.0.1"
 
 [synthwave-alpha-theme]
 submodule = "extensions/synthwave-alpha-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [synthwave84]
 submodule = "extensions/synthwave84"
@@ -5099,7 +5099,7 @@ version = "0.1.0"
 
 [tflint]
 submodule = "extensions/tflint"
-version = "0.1.1"
+version = "0.2.0"
 
 [the-best-theme]
 submodule = "extensions/the-best-theme"
@@ -5215,7 +5215,7 @@ version = "0.4.2"
 
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"
-version = "0.1.1"
+version = "0.2.0"
 
 [triumph-theme]
 submodule = "extensions/triumph-theme"
@@ -5227,7 +5227,7 @@ version = "1.2.1"
 
 [ts-macro]
 submodule = "extensions/ts-macro"
-version = "0.1.1"
+version = "0.2.0"
 
 [tsar]
 submodule = "extensions/tsar"
@@ -5312,7 +5312,7 @@ version = "0.2.0"
 
 [umbra-theme]
 submodule = "extensions/umbra-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [umbralkai]
 submodule = "extensions/umbralkai"
@@ -5388,11 +5388,11 @@ version = "0.6.0"
 
 [vacuum]
 submodule = "extensions/vacuum"
-version = "0.1.1"
+version = "0.2.0"
 
 [vague]
 submodule = "extensions/vague"
-version = "0.1.1"
+version = "0.2.0"
 
 [vala]
 submodule = "extensions/vala"
@@ -5424,7 +5424,7 @@ version = "0.3.0"
 
 [veda-pro-theme]
 submodule = "extensions/veda-pro-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [vento]
 submodule = "extensions/vento"
@@ -5457,7 +5457,7 @@ version = "0.0.2"
 
 [vesper-blur]
 submodule = "extensions/vesper-blur"
-version = "0.1.1"
+version = "0.2.0"
 
 [vespertine-theme]
 submodule = "extensions/vespertine-theme"
@@ -5521,11 +5521,11 @@ version = "0.0.1"
 
 [voidline-theme]
 submodule = "extensions/voidline-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [vrl]
 submodule = "extensions/vrl"
-version = "0.1.1"
+version = "0.2.0"
 
 [vscode-2026-theme]
 submodule = "extensions/vscode-2026-theme"
@@ -5569,7 +5569,7 @@ version = "12.18.0"
 
 [vscode-light-modern]
 submodule = "extensions/vscode-light-modern"
-version = "0.1.1"
+version = "0.2.0"
 
 [vscode-light-plus]
 submodule = "extensions/vscode-light-plus"
@@ -5605,7 +5605,7 @@ version = "0.1.10"
 
 [wakfu-theme]
 submodule = "extensions/wakfu-theme"
-version = "0.1.1"
+version = "0.2.0"
 
 [warm-burnout-theme]
 submodule = "extensions/warm-burnout-theme"
@@ -5618,7 +5618,7 @@ version = "0.0.1"
 
 [warp-one-dark]
 submodule = "extensions/warp-one-dark"
-version = "0.1.1"
+version = "0.2.0"
 
 [warplabs]
 submodule = "extensions/warplabs"
@@ -5707,7 +5707,7 @@ version = "0.1.0"
 
 [xml]
 submodule = "extensions/xml"
-version = "0.1.1"
+version = "0.2.0"
 
 [xquery]
 submodule = "extensions/xquery"

--- a/extensions.toml
+++ b/extensions.toml
@@ -32,7 +32,7 @@ version = "0.1.0"
 
 [actionscript]
 submodule = "extensions/actionscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [activitywatch]
 submodule = "extensions/activitywatch"
@@ -282,7 +282,7 @@ version = "0.1.0"
 
 [astro]
 submodule = "extensions/astro"
-version = "0.2.0"
+version = "0.2.1"
 
 [atlas-ragnarok-theme]
 submodule = "extensions/atlas-ragnarok-theme"
@@ -372,7 +372,7 @@ version = "1.0.0"
 
 [azure-mcp]
 submodule = "extensions/azure-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [azutiku-theme]
 submodule = "extensions/azutiku-theme"
@@ -381,7 +381,7 @@ version = "0.1.0"
 [babel-lsp]
 submodule = "extensions/babel-lsp"
 path = "editors/zed"
-version = "0.2.0"
+version = "0.2.1"
 
 [bamboo-theme]
 submodule = "extensions/bamboo-theme"
@@ -487,7 +487,7 @@ version = "0.1.3"
 
 [blackula]
 submodule = "extensions/blackula"
-version = "0.2.0"
+version = "0.2.1"
 
 [blade]
 submodule = "extensions/blade"
@@ -621,11 +621,11 @@ version = "0.0.2"
 
 [cairo]
 submodule = "extensions/cairo"
-version = "0.2.0"
+version = "0.2.1"
 
 [call-trans-opt-received]
 submodule = "extensions/call-trans-opt-received"
-version = "0.2.0"
+version = "0.2.1"
 
 [candela-theme]
 submodule = "extensions/candela-theme"
@@ -657,7 +657,7 @@ version = "1.0.0"
 
 [cargo-appraiser]
 submodule = "extensions/cargo-appraiser"
-version = "0.2.0"
+version = "0.2.1"
 
 [cargo-tom]
 submodule = "extensions/cargo-tom"
@@ -665,7 +665,7 @@ version = "0.4.1"
 
 [carve]
 submodule = "extensions/carve"
-version = "0.2.0"
+version = "0.2.1"
 
 [cassette-futurism-theme]
 submodule = "extensions/cassette-futurism-theme"
@@ -693,7 +693,7 @@ version = "0.3.4"
 
 [catppuccin-blur-plus]
 submodule = "extensions/catppuccin-blur-plus"
-version = "0.2.0"
+version = "0.2.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
@@ -731,7 +731,7 @@ version = "0.0.2"
 
 [chalice-theme]
 submodule = "extensions/chalice-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [chanterelle]
 submodule = "extensions/chanterelle"
@@ -743,11 +743,11 @@ version = "0.0.2"
 
 [charbox-theme]
 submodule = "extensions/charbox-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [charcoal-theme]
 submodule = "extensions/charcoal-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [charmed-icons]
 submodule = "extensions/charmed-icons"
@@ -816,7 +816,7 @@ version = "0.0.1"
 
 [clean-vscode-icons]
 submodule = "extensions/clean-vscode-icons"
-version = "0.2.0"
+version = "0.2.1"
 
 [clice]
 submodule = "extensions/clice"
@@ -886,7 +886,7 @@ version = "0.0.1"
 
 [coi]
 submodule = "extensions/coi"
-version = "0.2.0"
+version = "0.2.1"
 
 [color-highlight]
 submodule = "extensions/color-highlight"
@@ -961,7 +961,7 @@ version = "3.0.0"
 
 [crates-lsp]
 submodule = "extensions/crates-lsp"
-version = "0.2.0"
+version = "0.2.1"
 
 [crimson-theme]
 submodule = "extensions/crimson-theme"
@@ -997,12 +997,12 @@ version = "0.0.7"
 
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"
-version = "0.2.0"
+version = "0.2.1"
 path = "crates/zed"
 
 [css-variables]
 submodule = "extensions/css-variables"
-version = "0.2.0"
+version = "0.2.1"
 
 [csskit-lsp]
 submodule = "extensions/csskit-lsp"
@@ -1063,7 +1063,7 @@ version = "0.0.2"
 
 [cylc]
 submodule = "extensions/cylc"
-version = "0.2.0"
+version = "0.2.1"
 
 [cypher]
 submodule = "extensions/cypher"
@@ -1071,7 +1071,7 @@ version = "0.0.1"
 
 [cython]
 submodule = "extensions/cython"
-version = "0.2.0"
+version = "0.2.1"
 
 [d]
 submodule = "extensions/d"
@@ -1091,11 +1091,11 @@ version = "0.1.0"
 
 [dang]
 submodule = "extensions/dang"
-version = "0.2.0"
+version = "0.2.1"
 
 [darcula-dark]
 submodule = "extensions/darcula-dark"
-version = "0.2.0"
+version = "0.2.1"
 
 [darcula-dark-okkano]
 submodule = "extensions/darcula-dark-okkano"
@@ -1163,7 +1163,7 @@ version = "0.0.1"
 
 [dbt]
 submodule = "extensions/dbt"
-version = "0.2.0"
+version = "0.2.1"
 
 [decorative-stitch]
 submodule = "extensions/decorative-stitch"
@@ -1175,7 +1175,7 @@ version = "0.1.0"
 
 [deep-slate-theme]
 submodule = "extensions/deep-slate-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [deepz-theme]
 submodule = "extensions/deepz-theme"
@@ -1319,7 +1319,7 @@ version = "0.0.4"
 
 [earo-theme]
 submodule = "extensions/earo-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [earthfile]
 submodule = "extensions/earthfile"
@@ -1379,11 +1379,11 @@ version = "1.0"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [ejentum-mcp]
 submodule = "extensions/ejentum-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [ejs]
 submodule = "extensions/ejs"
@@ -1484,7 +1484,7 @@ version = "0.3.1"
 
 [erlang-qol-snippets]
 submodule = "extensions/erlang-qol-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [esmerald-theme]
 submodule = "extensions/esmerald-theme"
@@ -1496,7 +1496,7 @@ version = "0.0.1"
 
 [everforest]
 submodule = "extensions/everforest"
-version = "0.2.0"
+version = "0.2.1"
 
 [everforest-blurred]
 submodule = "extensions/everforest-blurred"
@@ -1547,11 +1547,11 @@ version = "1.0.0"
 [fastapi-lsp]
 submodule = "extensions/fastapi-lsp"
 path = "editors/zed"
-version = "0.2.0"
+version = "0.2.1"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"
@@ -1575,7 +1575,7 @@ version = "0.1.0"
 
 [fiberplane-studio]
 submodule = "extensions/fiberplane-studio"
-version = "0.2.0"
+version = "0.2.1"
 
 [field-lights-theme]
 submodule = "extensions/field-lights-theme"
@@ -1591,11 +1591,11 @@ version = "1.0.3"
 
 [fineorite-theme]
 submodule = "extensions/fineorite-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [firebase-security-rules]
 submodule = "extensions/firebase-security-rules"
-version = "0.2.0"
+version = "0.2.1"
 
 [firefox-quantum-theme]
 submodule = "extensions/firefox-quantum-theme"
@@ -1623,7 +1623,7 @@ version = "0.5.1"
 
 [flat-themes]
 submodule = "extensions/flat-themes"
-version = "0.2.0"
+version = "0.2.1"
 
 [flatbuffers]
 submodule = "extensions/flatbuffers"
@@ -1664,11 +1664,11 @@ version = "1.0.0"
 
 [flutter-snippets]
 submodule = "extensions/flutter-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [flynt-theme]
 submodule = "extensions/flynt-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [focus-theme]
 submodule = "extensions/focus-theme"
@@ -1700,7 +1700,7 @@ version = "0.0.3"
 
 [fountain]
 submodule = "extensions/fountain"
-version = "0.2.0"
+version = "0.2.1"
 
 [fozzy]
 submodule = "extensions/fozzy"
@@ -1761,16 +1761,16 @@ version = "1.0.1"
 [gas-plasma-icons]
 submodule = "extensions/gas-plasma-icons"
 path = "zed/gas-plasma-icons"
-version = "0.2.0"
+version = "0.2.1"
 
 [gas-plasma-theme]
 submodule = "extensions/gas-plasma-theme"
 path = "zed/gas-plasma-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [gatito-theme]
 submodule = "extensions/gatito-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [gato-theme]
 submodule = "extensions/gato-theme"
@@ -1799,7 +1799,7 @@ version = "0.1.0"
 
 [geno]
 submodule = "extensions/geno"
-version = "0.2.0"
+version = "0.2.1"
 
 [gentle-dark]
 submodule = "extensions/gentle-dark"
@@ -1847,7 +1847,7 @@ version = "0.0.3"
 
 [github-copilot-theme]
 submodule = "extensions/github-copilot-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [github-dark-default]
 submodule = "extensions/github-dark-default"
@@ -1916,7 +1916,7 @@ version = "1.3.0"
 
 [golangci-lint]
 submodule = "extensions/golangci-lint"
-version = "0.2.0"
+version = "0.2.1"
 
 [gosum]
 submodule = "extensions/gosum"
@@ -1952,7 +1952,7 @@ version = "0.0.3"
 
 [gren]
 submodule = "extensions/gren"
-version = "0.2.0"
+version = "0.2.1"
 
 [grey-theme]
 submodule = "extensions/grey-theme"
@@ -1996,7 +1996,7 @@ version = "0.0.1"
 
 [gruvbox-crisp-themes]
 submodule = "extensions/gruvbox-crisp-themes"
-version = "0.2.0"
+version = "0.2.1"
 
 [gruvbox-ish]
 submodule = "extensions/gruvbox-ish"
@@ -2057,7 +2057,7 @@ version = "0.5.0"
 
 [haml]
 submodule = "extensions/haml"
-version = "0.2.0"
+version = "0.2.1"
 
 [hare]
 submodule = "extensions/hare"
@@ -2126,7 +2126,7 @@ version = "1.0.0"
 
 [hivacruz-theme]
 submodule = "extensions/hivacruz-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [hl7v2]
 submodule = "extensions/hl7v2"
@@ -2142,7 +2142,7 @@ version = "0.0.1"
 
 [hocon]
 submodule = "extensions/hocon"
-version = "0.2.0"
+version = "0.2.1"
 
 [hoon]
 submodule = "extensions/hoon"
@@ -2336,7 +2336,7 @@ version = "1.0.0"
 
 [islands-theme]
 submodule = "extensions/islands-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [isle]
 submodule = "extensions/isle"
@@ -2365,7 +2365,7 @@ version = "0.0.1"
 [jarl]
 submodule = "extensions/jarl"
 path = "editors/zed"
-version = "0.2.0"
+version = "0.2.1"
 
 [java]
 submodule = "extensions/java"
@@ -2449,11 +2449,11 @@ version = "0.0.3"
 
 [json5]
 submodule = "extensions/json5"
-version = "0.2.0"
+version = "0.2.1"
 
 [jsonl]
 submodule = "extensions/jsonl"
-version = "0.2.0"
+version = "0.2.1"
 
 [jsonl-lsp]
 submodule = "extensions/jsonl-lsp"
@@ -2478,7 +2478,7 @@ version = "0.1.10"
 
 [just]
 submodule = "extensions/just"
-version = "0.2.0"
+version = "0.2.1"
 
 [k8s-crd-lsp]
 submodule = "extensions/k8s-crd-lsp"
@@ -2631,7 +2631,7 @@ version = "1.0.1"
 
 [ledger]
 submodule = "extensions/ledger"
-version = "0.2.0"
+version = "0.2.1"
 
 [legendary-dark-theme]
 submodule = "extensions/legendary-dark-theme"
@@ -2644,7 +2644,7 @@ version = "0.0.1"
 
 [leptos]
 submodule = "extensions/leptos"
-version = "0.2.0"
+version = "0.2.1"
 
 [less]
 submodule = "extensions/less"
@@ -2664,7 +2664,7 @@ version = "0.0.1"
 
 [lilypond]
 submodule = "extensions/lilypond"
-version = "0.2.0"
+version = "0.2.1"
 
 [lini]
 submodule = "extensions/lini"
@@ -2707,11 +2707,11 @@ version = "0.0.4"
 
 [livetennis-mcp]
 submodule = "extensions/livetennis-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [llvm-ir]
 submodule = "extensions/llvm-ir"
-version = "0.2.0"
+version = "0.2.1"
 
 [lndpnr-theme]
 submodule = "extensions/lndpnr-theme"
@@ -2756,7 +2756,7 @@ version = "0.0.1"
 
 [ltex]
 submodule = "extensions/ltex"
-version = "0.2.0"
+version = "0.2.1"
 
 [lua]
 submodule = "extensions/lua"
@@ -2780,7 +2780,7 @@ version = "0.0.2"
 
 [lumina-theme]
 submodule = "extensions/lumina-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [lusch-theme]
 submodule = "extensions/lusch-theme"
@@ -2817,7 +2817,7 @@ version = "0.10.0"
 
 [mainframe-theme]
 submodule = "extensions/mainframe-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [make]
 submodule = "extensions/make"
@@ -2841,7 +2841,7 @@ version = "0.1.2"
 
 [mantle-theme]
 submodule = "extensions/mantle-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [manuscript-theme]
 submodule = "extensions/manuscript-theme"
@@ -2905,7 +2905,7 @@ version = "0.0.1"
 
 [matlab]
 submodule = "extensions/matlab"
-version = "0.2.0"
+version = "0.2.1"
 
 [matt-white-theme]
 submodule = "extensions/matt-white-theme"
@@ -2917,11 +2917,11 @@ version = "1.2.0"
 
 [matte-black-theme]
 submodule = "extensions/matte-black-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [mau]
 submodule = "extensions/mau"
-version = "0.2.0"
+version = "0.2.1"
 
 [maya]
 submodule = "extensions/maya"
@@ -2934,7 +2934,7 @@ version = "0.1.0"
 
 [mc-dp-icons-theme]
 submodule = "extensions/mc-dp-icons-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcfunction]
 submodule = "extensions/mcfunction"
@@ -2950,15 +2950,15 @@ version = "0.0.2"
 
 [mcp-server-atexplore]
 submodule = "extensions/mcp-server-atexplore"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-atproto-docs]
 submodule = "extensions/mcp-server-atproto-docs"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-brave-search]
 submodule = "extensions/mcp-server-brave-search"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-buildkite]
 submodule = "extensions/mcp-server-buildkite"
@@ -2986,7 +2986,7 @@ version = "0.1.0"
 
 [mcp-server-figma]
 submodule = "extensions/mcp-server-figma"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-firecrawl]
 submodule = "extensions/mcp-server-firecrawl"
@@ -3062,7 +3062,7 @@ version = "0.0.1"
 
 [mcp-server-relytone]
 submodule = "extensions/mcp-server-relytone"
-version = "0.2.0"
+version = "0.2.1"
 
 [mcp-server-repomix]
 submodule = "extensions/mcp-server-repomix"
@@ -3152,11 +3152,11 @@ version = "0.1.21"
 
 [metascript]
 submodule = "extensions/metascript"
-version = "0.2.0"
+version = "0.2.1"
 
 [microscript]
 submodule = "extensions/microscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [midnight-marina]
 submodule = "extensions/midnight-marina"
@@ -3180,7 +3180,7 @@ version = "0.1.0"
 
 [mint-theme]
 submodule = "extensions/mint-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [miramare-theme]
 submodule = "extensions/miramare-theme"
@@ -3196,7 +3196,7 @@ version = "0.0.1"
 
 [mjml]
 submodule = "extensions/mjml"
-version = "0.2.0"
+version = "0.2.1"
 
 [mlir-tablegen]
 submodule = "extensions/mlir-tablegen"
@@ -3277,7 +3277,7 @@ version = "0.0.4"
 
 [monosami]
 submodule = "extensions/monosami"
-version = "0.2.0"
+version = "0.2.1"
 
 [monospace-icon-theme]
 submodule = "extensions/monospace-icon-theme"
@@ -3289,7 +3289,7 @@ version = "0.2.1"
 
 [moonbit]
 submodule = "extensions/moonbit"
-version = "0.2.0"
+version = "0.2.1"
 
 [moonlight]
 submodule = "extensions/moonlight"
@@ -3301,7 +3301,7 @@ version = "0.0.2"
 
 [motoko]
 submodule = "extensions/motoko"
-version = "0.2.0"
+version = "0.2.1"
 
 [move]
 submodule = "extensions/move"
@@ -3313,7 +3313,7 @@ version = "0.0.2"
 
 [mpls]
 submodule = "extensions/mpls"
-version = "0.2.0"
+version = "0.2.1"
 
 [msun-dark]
 submodule = "extensions/msun-dark"
@@ -3381,7 +3381,7 @@ version = "0.0.1"
 
 [neon-verdigris-theme]
 submodule = "extensions/neon-verdigris-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [neosolarized]
 submodule = "extensions/neosolarized"
@@ -3433,7 +3433,7 @@ version = "0.1.0"
 
 [nightfox]
 submodule = "extensions/nightfox"
-version = "0.2.0"
+version = "0.2.1"
 
 [nightfox-m]
 submodule = "extensions/nightfox-m"
@@ -3445,7 +3445,7 @@ version = "1.0.0"
 
 [nim]
 submodule = "extensions/nim"
-version = "0.2.0"
+version = "0.2.1"
 
 [ninja]
 submodule = "extensions/ninja"
@@ -3478,7 +3478,7 @@ version = "0.0.2"
 
 [noir-and-blanc-theme]
 submodule = "extensions/noir-and-blanc-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [nomad]
 submodule = "extensions/nomad"
@@ -3530,7 +3530,7 @@ version = "1.0.6"
 
 [nsis]
 submodule = "extensions/nsis"
-version = "0.2.0"
+version = "0.2.1"
 
 [nstlgy-dark]
 submodule = "extensions/nstlgy-dark"
@@ -3671,7 +3671,7 @@ version = "0.0.2"
 
 [one-dark-pro-monokai-darker]
 submodule = "extensions/one-dark-pro-monokai-darker"
-version = "0.2.0"
+version = "0.2.1"
 
 [one-dark-pro-vivid-theme]
 submodule = "extensions/one-dark-pro-vivid-theme"
@@ -3691,7 +3691,7 @@ version = "0.1.0"
 
 [oolong]
 submodule = "extensions/oolong"
-version = "0.2.0"
+version = "0.2.1"
 
 [opaline-theme]
 submodule = "extensions/opaline-theme"
@@ -3703,7 +3703,7 @@ version = "0.0.1"
 
 [openfga]
 submodule = "extensions/openfga"
-version = "0.2.0"
+version = "0.2.1"
 
 [openscad]
 submodule = "extensions/openscad"
@@ -3743,7 +3743,7 @@ version = "0.1.0"
 
 [oscura]
 submodule = "extensions/oscura"
-version = "0.2.0"
+version = "0.2.1"
 
 [oso]
 submodule = "extensions/oso"
@@ -3800,7 +3800,7 @@ version = "2.35.1"
 
 [panda-plus-theme]
 submodule = "extensions/panda-plus-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [panda-theme]
 submodule = "extensions/panda-theme"
@@ -3812,7 +3812,7 @@ version = "1.0.0"
 
 [papercolor]
 submodule = "extensions/papercolor"
-version = "0.2.0"
+version = "0.2.1"
 
 [papyrus]
 submodule = "extensions/papyrus"
@@ -3849,7 +3849,7 @@ version = "1.3.0"
 
 [pbxproj]
 submodule = "extensions/pbxproj"
-version = "0.2.0"
+version = "0.2.1"
 
 [pearish-theme]
 submodule = "extensions/pearish-theme"
@@ -3861,7 +3861,7 @@ version = "0.0.2"
 
 [penumbra]
 submodule = "extensions/penumbra"
-version = "0.2.0"
+version = "0.2.1"
 
 [penumbra-plus]
 submodule = "extensions/penumbra-plus"
@@ -3885,11 +3885,11 @@ version = "0.0.4"
 
 [perplexity]
 submodule = "extensions/perplexity"
-version = "0.2.0"
+version = "0.2.1"
 
 [pest]
 submodule = "extensions/pest"
-version = "0.2.0"
+version = "0.2.1"
 
 [pgfmt-lsp]
 submodule = "extensions/pgfmt-lsp"
@@ -3960,7 +3960,7 @@ version = "0.1.0"
 
 [pink-candy-theme]
 submodule = "extensions/pink-candy-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [pink-cat-boo-theme]
 submodule = "extensions/pink-cat-boo-theme"
@@ -4052,7 +4052,7 @@ version = "1.0.3"
 
 [poryscript]
 submodule = "extensions/poryscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
@@ -4064,7 +4064,7 @@ version = "0.1.0"
 
 [postman-context-server]
 submodule = "extensions/postman-context-server"
-version = "0.2.0"
+version = "0.2.1"
 
 [powershell]
 submodule = "extensions/powershell"
@@ -4084,7 +4084,7 @@ version = "0.1.9"
 
 [prisma-mcp]
 submodule = "extensions/prisma-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [probe-rs]
 submodule = "extensions/probe-rs"
@@ -4117,7 +4117,7 @@ version = "0.0.3"
 
 [puppet]
 submodule = "extensions/puppet"
-version = "0.2.0"
+version = "0.2.1"
 
 [puppydog-theme]
 submodule = "extensions/puppydog-theme"
@@ -4133,7 +4133,7 @@ version = "0.1.0"
 
 [pyatlas-lsp]
 submodule = "extensions/pyatlas-lsp"
-version = "0.2.0"
+version = "0.2.1"
 
 [pycharm-modern-themes]
 submodule = "extensions/pycharm-modern-themes"
@@ -4154,7 +4154,7 @@ version = "0.24.0"
 
 [python-autodoc-lsp]
 submodule = "extensions/python-autodoc-lsp"
-version = "0.2.0"
+version = "0.2.1"
 
 [python-refactoring]
 submodule = "extensions/python-refactoring"
@@ -4218,11 +4218,11 @@ version = "0.2.2"
 
 [quint]
 submodule = "extensions/quint"
-version = "0.2.0"
+version = "0.2.1"
 
 [qwark-theme]
 submodule = "extensions/qwark-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [r]
 submodule = "extensions/r"
@@ -4230,11 +4230,11 @@ version = "0.2.5"
 
 [racket]
 submodule = "extensions/racket"
-version = "0.2.0"
+version = "0.2.1"
 
 [radical-reborn-theme]
 submodule = "extensions/radical-reborn-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [railgun]
 submodule = "extensions/railgun"
@@ -4263,7 +4263,7 @@ version = "1.0.1"
 
 [rasi]
 submodule = "extensions/rasi"
-version = "0.2.0"
+version = "0.2.1"
 
 [rcl]
 submodule = "extensions/rcl"
@@ -4292,11 +4292,11 @@ version = "0.1.4"
 
 [red]
 submodule = "extensions/red"
-version = "0.2.0"
+version = "0.2.1"
 
 [redscript]
 submodule = "extensions/redscript"
-version = "0.2.0"
+version = "0.2.1"
 
 [regedit]
 submodule = "extensions/regedit"
@@ -4320,7 +4320,7 @@ version = "0.0.5"
 
 [remedy-theme]
 submodule = "extensions/remedy-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [remix-min-darker-theme]
 submodule = "extensions/remix-min-darker-theme"
@@ -4382,7 +4382,7 @@ version = "0.1.0"
 
 [roc]
 submodule = "extensions/roc"
-version = "0.2.0"
+version = "0.2.1"
 
 [rockide-language-server]
 submodule = "extensions/rockide-language-server"
@@ -4471,7 +4471,7 @@ version = "2.0.3"
 
 [sagemath]
 submodule = "extensions/sagemath"
-version = "0.2.0"
+version = "0.2.1"
 
 [salesforce]
 submodule = "extensions/salesforce"
@@ -4556,11 +4556,11 @@ version = "0.0.1"
 
 [setinox-theme]
 submodule = "extensions/setinox-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [severance-theme]
 submodule = "extensions/severance-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [shadcn-mcp]
 submodule = "extensions/shadcn-mcp"
@@ -4568,7 +4568,7 @@ version = "0.1.0"
 
 [shader-ls]
 submodule = "extensions/shader-ls"
-version = "0.2.0"
+version = "0.2.1"
 
 [shades-of-purple-theme]
 submodule = "extensions/shades-of-purple-theme"
@@ -4630,7 +4630,7 @@ version = "0.1.0"
 
 [skill]
 submodule = "extensions/skill"
-version = "0.2.0"
+version = "0.2.1"
 
 [skill-language-server]
 submodule = "extensions/skill-language-server"
@@ -4648,7 +4648,7 @@ version = "0.0.1"
 
 [slang]
 submodule = "extensions/slang"
-version = "0.2.0"
+version = "0.2.1"
 
 [slate]
 submodule = "extensions/slate"
@@ -4682,7 +4682,7 @@ version = "0.0.1"
 
 [sml]
 submodule = "extensions/sml"
-version = "0.2.0"
+version = "0.2.1"
 
 [smooth]
 submodule = "extensions/smooth"
@@ -4738,7 +4738,7 @@ version = "0.1.0"
 
 [solidity]
 submodule = "extensions/solidity"
-version = "0.2.0"
+version = "0.2.1"
 
 [solitude-theme]
 submodule = "extensions/solitude-theme"
@@ -4763,11 +4763,11 @@ version = "0.1.2"
 
 [sorbet]
 submodule = "extensions/sorbet"
-version = "0.2.0"
+version = "0.2.1"
 
 [souffle]
 submodule = "extensions/souffle"
-version = "0.2.0"
+version = "0.2.1"
 
 [sourcepawn]
 submodule = "extensions/sourcepawn"
@@ -4800,7 +4800,7 @@ version = "0.1.2"
 
 [sqlc-snippets]
 submodule = "extensions/sqlc-snippets"
-version = "0.2.0"
+version = "0.2.1"
 
 [sqlmesh]
 submodule = "extensions/sqlmesh"
@@ -4828,11 +4828,11 @@ version = "0.4.1"
 
 [statamic-antlers]
 submodule = "extensions/statamic-antlers"
-version = "0.2.0"
+version = "0.2.1"
 
 [stimulus]
 submodule = "extensions/stimulus"
-version = "0.2.0"
+version = "0.2.1"
 
 [stix-theme]
 submodule = "extensions/stix-theme"
@@ -4866,7 +4866,7 @@ version = "0.1.0"
 [suannhai-theme]
 submodule = "extensions/suannhai-theme"
 path = "suannhai-zed"
-version = "0.2.0"
+version = "0.2.1"
 
 [sublime-mariana-theme]
 submodule = "extensions/sublime-mariana-theme"
@@ -4944,7 +4944,7 @@ version = "3.0.2"
 
 [svelte-mcp]
 submodule = "extensions/svelte-mcp"
-version = "0.2.0"
+version = "0.2.1"
 
 [svelte-snippets]
 submodule = "extensions/svelte-snippets"
@@ -4986,11 +4986,11 @@ version = "0.0.1"
 
 [synthwave-alpha-theme]
 submodule = "extensions/synthwave-alpha-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [synthwave84]
 submodule = "extensions/synthwave84"
-version = "0.2.0"
+version = "0.2.1"
 
 [sysml-v2]
 submodule = "extensions/sysml-v2"
@@ -5099,7 +5099,7 @@ version = "0.1.0"
 
 [tflint]
 submodule = "extensions/tflint"
-version = "0.2.0"
+version = "0.2.1"
 
 [the-best-theme]
 submodule = "extensions/the-best-theme"
@@ -5131,7 +5131,7 @@ version = "0.0.2"
 
 [tla-plus]
 submodule = "extensions/tla-plus"
-version = "0.2.0"
+version = "0.2.1"
 
 [tlapalli-theme]
 submodule = "extensions/tlapalli-theme"
@@ -5203,7 +5203,7 @@ version = "0.3.1"
 
 [tonel-smalltalk]
 submodule = "extensions/tonel-smalltalk"
-version = "0.2.0"
+version = "0.2.1"
 
 [toon]
 submodule = "extensions/toon"
@@ -5215,7 +5215,7 @@ version = "0.4.2"
 
 [tree-sitter-query]
 submodule = "extensions/tree-sitter-query"
-version = "0.2.0"
+version = "0.2.1"
 
 [triumph-theme]
 submodule = "extensions/triumph-theme"
@@ -5227,7 +5227,7 @@ version = "1.2.1"
 
 [ts-macro]
 submodule = "extensions/ts-macro"
-version = "0.2.0"
+version = "0.2.1"
 
 [tsar]
 submodule = "extensions/tsar"
@@ -5300,7 +5300,7 @@ version = "0.0.2"
 
 [ultimate-dark-neo]
 submodule = "extensions/ultimate-dark-neo"
-version = "0.2.0"
+version = "0.2.1"
 
 [ultralytics-snippets]
 submodule = "extensions/ultralytics-snippets"
@@ -5308,11 +5308,11 @@ version = "0.0.2"
 
 [ultraviolet-theme]
 submodule = "extensions/ultraviolet-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [umbra-theme]
 submodule = "extensions/umbra-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [umbralkai]
 submodule = "extensions/umbralkai"
@@ -5372,7 +5372,7 @@ version = "0.1.0"
 
 [utl]
 submodule = "extensions/utl"
-version = "0.2.0"
+version = "0.2.1"
 
 [v]
 submodule = "extensions/v"
@@ -5388,15 +5388,15 @@ version = "0.6.0"
 
 [vacuum]
 submodule = "extensions/vacuum"
-version = "0.2.0"
+version = "0.2.1"
 
 [vague]
 submodule = "extensions/vague"
-version = "0.2.0"
+version = "0.2.1"
 
 [vala]
 submodule = "extensions/vala"
-version = "0.2.0"
+version = "0.2.1"
 
 [vale]
 submodule = "extensions/vale"
@@ -5424,7 +5424,7 @@ version = "0.3.0"
 
 [veda-pro-theme]
 submodule = "extensions/veda-pro-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [vento]
 submodule = "extensions/vento"
@@ -5457,7 +5457,7 @@ version = "0.0.2"
 
 [vesper-blur]
 submodule = "extensions/vesper-blur"
-version = "0.2.0"
+version = "0.2.1"
 
 [vespertine-theme]
 submodule = "extensions/vespertine-theme"
@@ -5521,11 +5521,11 @@ version = "0.0.1"
 
 [voidline-theme]
 submodule = "extensions/voidline-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [vrl]
 submodule = "extensions/vrl"
-version = "0.2.0"
+version = "0.2.1"
 
 [vscode-2026-theme]
 submodule = "extensions/vscode-2026-theme"
@@ -5569,7 +5569,7 @@ version = "12.18.0"
 
 [vscode-light-modern]
 submodule = "extensions/vscode-light-modern"
-version = "0.2.0"
+version = "0.2.1"
 
 [vscode-light-plus]
 submodule = "extensions/vscode-light-plus"
@@ -5605,7 +5605,7 @@ version = "0.1.10"
 
 [wakfu-theme]
 submodule = "extensions/wakfu-theme"
-version = "0.2.0"
+version = "0.2.1"
 
 [warm-burnout-theme]
 submodule = "extensions/warm-burnout-theme"
@@ -5618,7 +5618,7 @@ version = "0.0.1"
 
 [warp-one-dark]
 submodule = "extensions/warp-one-dark"
-version = "0.2.0"
+version = "0.2.1"
 
 [warplabs]
 submodule = "extensions/warplabs"
@@ -5663,7 +5663,7 @@ version = "0.0.1"
 
 [windows-batch]
 submodule = "extensions/windows-batch"
-version = "0.2.0"
+version = "0.2.1"
 
 [wit]
 submodule = "extensions/wit"
@@ -5707,7 +5707,7 @@ version = "0.1.0"
 
 [xml]
 submodule = "extensions/xml"
-version = "0.2.0"
+version = "0.2.1"
 
 [xquery]
 submodule = "extensions/xquery"
@@ -5787,7 +5787,7 @@ version = "1.2.2"
 
 [zedokai-darkest-machine]
 submodule = "extensions/zedokai-darkest-machine"
-version = "0.2.0"
+version = "0.2.1"
 
 [zedrack-theme]
 submodule = "extensions/zedrack-theme"
@@ -5863,4 +5863,4 @@ version = "0.0.1"
 
 [zwirn]
 submodule = "extensions/zwirn"
-version = "0.2.0"
+version = "0.2.1"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4628,6 +4628,10 @@ version = "0.0.12"
 submodule = "extensions/sitruuna"
 version = "0.1.0"
 
+[skill]
+submodule = "extensions/skill"
+version = "0.1.0"
+
 [skill-language-server]
 submodule = "extensions/skill-language-server"
 path = "ext/zed"

--- a/extensions.toml
+++ b/extensions.toml
@@ -4630,7 +4630,7 @@ version = "0.1.0"
 
 [skill]
 submodule = "extensions/skill"
-version = "0.1.0"
+version = "0.1.1"
 
 [skill-language-server]
 submodule = "extensions/skill-language-server"


### PR DESCRIPTION
Adds the `skill` extension: language support for Cadence SKILL, the Lisp-based scripting language used in Cadence Virtuoso EDA tools.

- Repository: https://github.com/deanyou/zed-skill (MIT licensed)
- Tree-sitter grammar for SKILL: quoting/quasiquote, block comments (`/* */`), keyword arguments (`?key`), character literals (`?a`), dotted pairs, hex/float numbers
- Syntax highlighting tuned for SKILL special forms (`defun`, `let`, `foreach`, ...) and common built-ins (lists, printf, db*/ge*/hi* EDA APIs)
- Bundled language server (Rust/tower-lsp): completion (100+ built-ins), hover docs, diagnostics, go-to-definition, document symbols, snippets

Tested locally as a dev extension in Zed on macOS; grammar WASM compiled with the WASI SDK clang toolchain.