### PR TITLE
Add OKF LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3566,6 +3566,10 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
+[submodule "extensions/okf-lsp"]
+	path = extensions/okf-lsp
+	url = https://github.com/brentlee-personal/okf-lsp.git
+
 [submodule "extensions/oldbook-theme"]
 	path = extensions/oldbook-theme
 	url = https://github.com/gko/oldbook-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3629,6 +3629,11 @@ path = "crates/extension-zed"
 submodule = "extensions/oh-lucy"
 version = "0.0.1"
 
+[okf-lsp]
+submodule = "extensions/okf-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [oldbook-theme]
 submodule = "extensions/oldbook-theme"
 version = "1.5.5"


### PR DESCRIPTION
Adds the OKF LSP extension for Open Knowledge Format v0.2 Markdown bundles.

The extension provides diagnostics, completion, hover, definitions, references, and symbols. It downloads verified v0.1.0 language-server binaries from GitHub Releases for macOS arm64/x86_64, Linux arm64/x86_64, and Windows x86_64.

Validation:
- Installed and tested the dev extension at submodule commit `eabf108`.
- Confirmed Zed auto-downloads and launches the v0.1.0 release binary.
- Confirmed the sample bundle and project diagnostics are clean.
- Ran the registry TypeScript build and 115 tests successfully.
- Confirmed the five-platform release workflow succeeded.

Repository: https://github.com/brentlee-personal/okf-lsp
Release: https://github.com/brentlee-personal/okf-lsp/releases/tag/v0.1.0

- [x] I've read the contribution guidelines and followed the guidance for adding this extension.