### PR TITLE
Add OKF LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3566,6 +3566,10 @@
 	path = extensions/oh-lucy
 	url = https://github.com/abdurrehman0206/Oh-Lucy.git
 
+[submodule "extensions/okf-lsp"]
+	path = extensions/okf-lsp
+	url = https://github.com/Brentbin/okf-lsp.git
+
 [submodule "extensions/oldbook-theme"]
 	path = extensions/oldbook-theme
 	url = https://github.com/gko/oldbook-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3629,6 +3629,11 @@ path = "crates/extension-zed"
 submodule = "extensions/oh-lucy"
 version = "0.0.1"
 
+[okf-lsp]
+submodule = "extensions/okf-lsp"
+path = "editors/zed"
+version = "0.1.1"
+
 [oldbook-theme]
 submodule = "extensions/oldbook-theme"
 version = "1.5.5"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3713,7 +3713,7 @@ version = "0.0.1"
 [okf-lsp]
 submodule = "extensions/okf-lsp"
 path = "editors/zed"
-version = "0.1.2"
+version = "0.1.3"
 
 [oldbook-theme]
 submodule = "extensions/oldbook-theme"

--- a/extensions.toml
+++ b/extensions.toml
@@ -3632,7 +3632,7 @@ version = "0.0.1"
 [okf-lsp]
 submodule = "extensions/okf-lsp"
 path = "editors/zed"
-version = "0.1.1"
+version = "0.1.2"
 
 [oldbook-theme]
 submodule = "extensions/oldbook-theme"


### PR DESCRIPTION
Please review this first registry submission for **OKF LSP 0.1.3** and merge when ready.
Adds diagnostics, completion, hover, definitions, references, and symbols for Open Knowledge Format v0.2 Markdown bundles.
**Status: awaiting maintainer merge; not yet published in the Zed marketplace.**
Please leave questions or requested changes on this PR.

## Release
- Extension: **0.1.3**.
- Source: [56d13d95f247d0af53eb1d7e7f5d0537c4d514e4](https://github.com/Brentbin/okf-lsp/commit/56d13d95f247d0af53eb1d7e7f5d0537c4d514e4).
- Server: [v0.4.0](https://github.com/Brentbin/okf-lsp/releases/tag/v0.4.0), a public, non-draft, non-prerelease release.
- Managed binaries: macOS arm64/x86_64, Linux arm64/x86_64, and Windows x86_64.

## New in server 0.4.0
- Opt-in CLI `--coverage` reports checked, skipped, and unreadable Markdown; LSP `okf.coverage` reports last-observed document coverage.
- `--all-files` uses explicit input roots instead of configured bundle-root expansion; ignores, validation policy, and scope still apply.
- `--require-checked` exits with status 1 when no Markdown was checked; it does not require every file to be checked.

## Validation
- Python: **655 pytest tests passed**; Ruff passed.
- macOS arm64 PyInstaller: CLI coverage/full scans and empty Git-index guards passed; stdio LSP coverage-command and history-file hash-protection smoke passed.
- [Main CI #34209106898](https://github.com/Brentbin/okf-lsp/actions/runs/34209106898): Python and Zed WASI passed on the source SHA above.
- [Native release #34209604307](https://github.com/Brentbin/okf-lsp/actions/runs/34209604307): all five platform builds and publication passed on the source SHA above; all five assets uploaded.
- Registry: **115 tests passed**; TypeScript build, sorting/idempotence, and version/gitlink checks passed.
- Manual Zed GUI testing: **server v0.4.0 / extension 0.1.3 remains pending**. The [prior author confirmation](https://github.com/zed-industries/extensions/pull/7381#issuecomment-5572663973) covers **server v0.3.0 / extension 0.1.2 only**; no issues were reported for that version.

This replaces #7380, which was closed because it was submitted from the wrong GitHub account.

- [x] I have read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md).