### PR TITLE
Add Deluge extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1162,6 +1162,10 @@
 	path = extensions/defold
 	url = https://github.com/whiterabbit1983/zed-defold
 
+[submodule "extensions/deluge"]
+	path = extensions/deluge
+	url = https://github.com/attilaacs/zed-deluge.git
+
 [submodule "extensions/demotape"]
 	path = extensions/demotape
 	url = https://github.com/fnando/zed-demotape.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1185,6 +1185,10 @@ version = "0.0.1"
 submodule = "extensions/defold"
 version = "0.1.4"
 
+[deluge]
+submodule = "extensions/deluge"
+version = "0.1.0"
+
 [demotape]
 submodule = "extensions/demotape"
 version = "0.0.2"


### PR DESCRIPTION
Adds syntax highlighting for **Deluge**, Zoho's scripting language, used across Zoho CRM, Creator, Books, Desk and Flow. `.dg` files.

- Extension: https://github.com/attilaacs/zed-deluge
- Grammar: https://github.com/attilaacs/tree-sitter-deluge

### Why

There was no Tree-sitter grammar for Deluge anywhere, and no Deluge extension in the registry, so both were written for this submission.

### What it provides

Language config for `.dg`, plus `highlights`, `brackets`, `outline` and `indents` queries. No Rust code and no language server — grammar and queries only.

The grammar was written against real-world Deluge rather than the reference docs alone, so it handles constructs a generic C-like grammar gets wrong:

- integration tasks used as **expressions** — `response = invokeurl [ url : "..." type : POST ];`
- optional parameter types — `decimal safe_decimal(val)`
- Zoho Creator record statements — `insert into Form [ Field = value ];`, `delete Form[criteria];`
- Creator fetch criteria `Form[Field == "x"]` and field qualifiers `input.Field:ui`
- lists and maps sharing `{}`, including the empty and nested forms

### Testing

- Installed and exercised in Zed as a dev extension; the grammar compiles and highlighting renders.
- Parses **46 real-world `.dg` files** collected from public repositories with zero errors.
- 15 `tree-sitter test` corpus cases covering each construct above.

### Checklist

- ID `deluge` is unique, kebab-cased, contains neither "zed" nor "extension", and matches the language name.
- MIT licensed, `LICENSE` at the extension root.
- Grammar defined for the language provided.
- All user-facing text is English.