### PR TITLE
Add depsy language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1178,6 +1178,10 @@
 	path = extensions/deps-language-server
 	url = https://github.com/bug-ops/deps-zed.git
 
+[submodule "extensions/depsy-lsp"]
+	path = extensions/depsy-lsp
+	url = https://github.com/mpiton/zed-depsy.git
+
 [submodule "extensions/deputy"]
 	path = extensions/deputy
 	url = https://github.com/filiptibell/deputy.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1202,6 +1202,11 @@ version = "1.11.0"
 submodule = "extensions/deps-language-server"
 version = "0.1.8"
 
+[depsy-lsp]
+submodule = "extensions/depsy-lsp"
+path = "depsy-zed"
+version = "2.0.1"
+
 [deputy]
 submodule = "extensions/deputy"
 path = "editors/zed"


### PR DESCRIPTION
## Summary

- Add the `depsy` extension (mpiton/zed-depsy at v2.0.0)

Depsy is the extension previously published as `dependi`, renamed at the request of the dependi.io maintainers, who are taking over the `dependi` id with their own extension (mpiton/zed-depsy#377). Same features as before: dependency version hints, vulnerability diagnostics and update code actions for Cargo.toml, package.json, requirements.txt, pyproject.toml, go.mod, composer.json, pubspec.yaml, csproj, Gemfile and pom.xml.

The existing `dependi` entry stays for now. dependi 1.11.0 (#7362) shows a startup notice pointing users here; a follow-up PR will remove `dependi` once users have had time to migrate.

## Type

feat

## Validation

- `pnpm build`
- `pnpm test`
- `pnpm sort-extensions` (no changes)
- `cargo build --release --target wasm32-wasip2 --locked` in `depsy-zed` at the tagged commit

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.