### PR TITLE
Update cspell to v0.0.8

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -993,7 +993,7 @@ version = "1.3.0"
 
 [cspell]
 submodule = "extensions/cspell"
-version = "0.0.7"
+version = "0.0.8"
 
 [css-modules-kit]
 submodule = "extensions/css-modules-kit"


### PR DESCRIPTION
Updates CSpell to v0.0.8.

- Adds `MDX` to the CSpell language server list so it attaches to buffers provided by the MDX extension.
- Enables `--sortWords` so words added through code actions are kept alphabetically sorted.
- Updates the registry version and cspell submodule commit.
- Related to mantou132/zed-cspell#21 and mantou132/zed-cspell#22.

Validation:
- `cargo check --target wasm32-wasip1`
- `cargo test`
- `pnpm build`
- `pnpm test` (115 passed)
- `pnpm sort-extensions`

- [x] I've read the [contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for updating my extension.