### PR TITLE
Update Hearth theme to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2099,7 +2099,7 @@ version = "0.0.1"
 [hearth-theme]
 submodule = "extensions/hearth-theme"
 path = "zed"
-version = "0.2.0"
+version = "0.3.0"
 
 [hearthcode-theme]
 submodule = "extensions/hearthcode-theme"


### PR DESCRIPTION
## Summary

- update Hearth submodule to commit `5afac811abb8cb88993acf6d63a39c50c414e128` (`v0.3.0`)
- update the registry version from `0.2.0` to `0.3.0`

## Testing

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests passed)

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for updating my extension.