### PR TITLE
Add intellij-server — Java & Kotlin (IntelliJ engine)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2274,6 +2274,10 @@
 	path = extensions/intellij-newui-theme
 	url = https://github.com/kpitt/zed-theme-intellij-newui.git
 
+[submodule "extensions/intellij-server"]
+	path = extensions/intellij-server
+	url = https://github.com/SilyNoMeta/zed-intellij-server
+
 [submodule "extensions/intl-lens"]
 	path = extensions/intl-lens
 	url = https://github.com/nguyenphutrong/intl-lens.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2323,6 +2323,11 @@ version = "0.1.0"
 submodule = "extensions/intellij-newui-theme"
 version = "0.1.0"
 
+[intellij-server]
+submodule = "extensions/intellij-server"
+path = "extension"
+version = "0.1.0"
+
 [intl-lens]
 submodule = "extensions/intl-lens"
 path = "crates/intl-lens-extension"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2326,7 +2326,7 @@ version = "0.1.0"
 [intellij-server]
 submodule = "extensions/intellij-server"
 path = "extension"
-version = "0.1.0"
+version = "0.1.1"
 
 [intl-lens]
 submodule = "extensions/intl-lens"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## What it is

An IntelliJ-powered code engine for **Java** and **Kotlin** (display name: *Java & Kotlin (IntelliJ engine)*), driven by the JetBrains `intellij-server` backend — the IntelliJ IDEA engine running headless, the same backend JetBrains ships for their official VS Code extension (published on Open VSX). Diagnostics are real IntelliJ inspections; completion/navigation/refactorings come from the IntelliJ project model (Gradle, Maven, Bazel); debugging uses the IntelliJ debugger.

This is a different backend than the existing `java` (JDT LS) and `kotlin` (kotlin-lsp) extensions — same idea as multiple language servers coexisting for other languages.

## How it works

- `extension/` (the `path` in `extensions.toml`) is the Zed extension (Rust → wasm32-wasip2): it downloads the backend from `download.jetbrains.com` at first launch (per-platform, SHA-256 verified against a pinned manifest — the backend is never bundled or redistributed), gates on explicit EULA acceptance by the user (the backend validates the accepted agreement hash at startup; nothing is bypassed), and launches it over stdio LSP.
- `proxy/` (`ij-zed-proxy`, native, downloaded at runtime from our GitHub Releases, SHA-256 pinned) sits between Zed and the backend to provide what the WASM sandbox cannot: `jar:`/`jrt:` navigation targets materialized as real decompiled files, `intellij/reloadWorkspace` on build-file save, `intellij/*` protocol extensions, and the DAP bridge (`--dap` mode + `intellij-debugger` adapter) with launch-config enrichment (classpath incl. JPMS, cwd, java executable resolved from the project model).
- Java and Kotlin tree-sitter grammars pinned (same revisions as the existing `java` extension) with their queries.

## Testing done

- Driven the full lifecycle in real Zed sessions (stable 1.17.2): backend download + checksum + install, EULA gate message, Gradle import, diagnostics/completion/definition/rename in the editor, go-to-definition into the JDK opening a materialized decompiled file, and a debug session with breakpoint hit through the DAP bridge.
- Protocol-level integration suites run without an editor: 12/12 LSP checks through the proxy, 6/6 DAP checks (breakpoint, program output, clean termination) — see `tests/` in the extension repo.

## Notes for reviewers

- The pinned backend is a JetBrains **preview build that expires 30 days after its build date** (upstream design; the server exits with code 7 afterwards). A weekly GitHub Action checks Open VSX for a new backend and opens a bump PR, so the pin stays fresh.
- The extension and proxy are Apache-2.0; the backend is proprietary JetBrains software downloaded at install time under its own EAP agreement, which the user must explicitly accept before the server will start (documented acceptance mechanism of the product).
- Not affiliated with or endorsed by JetBrains.

## Third-party components (CLA §5/§7 disclosure)

- `extension/languages/java/` — tree-sitter queries and language configuration adapted from [zed-extensions/java](https://github.com/zed-extensions/java), copyright Java Extension Contributors, Apache-2.0.
- `extension/languages/kotlin/` — tree-sitter queries and language configuration adapted from [zed-extensions/kotlin](https://github.com/zed-extensions/kotlin), copyright (c) 2024 Evren Sen, MIT.

Attributions and license texts are in `extension/languages/NOTICE`. Everything else is original work.
