### PR TITLE
[OLD] Update s-dark-theme to v3.0.0 – Closed due to new update in #7421

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4485,7 +4485,7 @@ version = "0.1.0"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
-version = "2.0.5"
+version = "3.0.0"
 
 [sagemath]
 submodule = "extensions/sagemath"


### PR DESCRIPTION
_Split the single S-Dark theme into two separate variants: S-Dark Cobalt and S-Dark Violet. Now both show up as separate options in the theme picker, instead of one theme just called "S-Dark Theme"._

## What's new
 S-Dark Cobalt — the blue variant ( #396BD5). The code colors (keywords, functions, strings, comments, punctuation) were redesigned and updated. The blue color is still used for the app's frame — things like the title bar, tabs, and panels. 

S-Dark Violet (new) — a purple variant ( #8359d5). The overall look is a bit darker and softer (less contrast in the UI frame and muted text), and the code colors are warmer (yellow/amber for changed lines, orange-brown strings, teal tags). Good option for people who want something less blue and easier on the eyes for long coding sessions.

> - [X] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.



**_[CLOSED] Update s-dark-theme to v3.0.0 – Replaced by #7421_**

