### PR TITLE
Add iron-man-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2298,6 +2298,10 @@
 	path = extensions/irodori-theme
 	url = https://github.com/agrahamlincoln/irodori.git
 
+[submodule "extensions/iron-man-theme"]
+	path = extensions/iron-man-theme
+	url = https://github.com/bkataru/iron-man-zed.git
+
 [submodule "extensions/islands-theme"]
 	path = extensions/islands-theme
 	url = https://github.com/himattm/zed-islands-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -2348,6 +2348,10 @@ version = "0.1.0"
 submodule = "extensions/irodori-theme"
 version = "1.0.0"
 
+[iron-man-theme]
+submodule = "extensions/iron-man-theme"
+version = "2.0.0"
+
 [islands-theme]
 submodule = "extensions/islands-theme"
 version = "0.2.0"


### PR DESCRIPTION
## Extension

- **ID:** `iron-man-theme`
- **Name:** Iron Man
- **Version:** 2.0.0
- **Type:** Theme extension (dark + light variants, pure themes — no wasm)
- **Repository:** https://github.com/bkataru/iron-man-zed
- **License:** MIT

## Checklist (publishing prerequisites)

- [x] Unique kebab-case ID that does **not** contain `zed` or `extension`
- [x] ID indicates this is a theme (`-theme` suffix)
- [x] Theme-only (no languages, LSPs, MCP, snippets)
- [x] Accepted license (MIT)
- [x] Tested locally as a dev extension on Zed 1.15.1 — both variants register (`Iron Man Dark`, `Iron Man Light`)
- [x] 128×128 `icon.png` at repo root
- [x] `extension.toml` with `themes` key, `schema_version = 1`
- [x] Submodule uses HTTPS URL; commit is on `main` (`ff8d664`)
- [x] `extensions.toml` / `.gitmodules` sorted via `pnpm sort-extensions`

## Context

This is a fresh submission replacing closed #7330. The original ID was `iron-man`; a maintainer asked that it follow the theme-ID guideline. The ID is now `iron-man-theme`.

Iron Man is a Tony Stark inspired color scheme: arc-reactor golds, repulsor blues, and deep crimson reds on near-black chrome. Dark variant uses a three-lane syntax hierarchy (repulsor blue for types, arc gold for values, bright gold for functions) with red reserved for keywords; light variant darkens the same palette for white backgrounds.