### PR TITLE
Add Vue-I18n (#7402)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5494,6 +5494,10 @@
 	path = extensions/vue
 	url = https://github.com/zed-extensions/vue.git
 
+[submodule "extensions/vue-i18n"]
+	path = extensions/vue-i18n
+	url = https://github.com/XusCloud/zed-vue-i18n.git
+
 [submodule "extensions/vue-snippets"]
 	path = extensions/vue-snippets
 	url = https://github.com/rubjo/zed-vue-snippets

--- a/extensions.toml
+++ b/extensions.toml
@@ -5601,6 +5601,11 @@ version = "0.0.2"
 submodule = "extensions/vue"
 version = "0.4.0"
 
+[vue-i18n]
+submodule = "extensions/vue-i18n"
+path = "extension"
+version = "0.1.0"
+
 [vue-snippets]
 submodule = "extensions/vue-snippets"
 version = "0.0.3"


### PR DESCRIPTION
Add vue-i18n for zed
Show configurable inline translations for i18n keys in Vue/TS/TSX, with hover, diagnostics, completion, definition, and references.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
