### PR TITLE
Add georgy-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5705,6 +5705,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/georgy-themes-zed"]
-	path = extensions/georgy-themes-zed
+[submodule "extensions/georgy-theme"]
+	path = extensions/georgy-theme
 	url = https://github.com/GeorgyDesign/georgy-themes-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1782,6 +1782,10 @@
 	path = extensions/geode-theme
 	url = https://github.com/almeladev/geode-zed.git
 
+[submodule "extensions/georgy-theme"]
+	path = extensions/georgy-theme
+	url = https://github.com/GeorgyDesign/georgy-themes-zed.git
+
 [submodule "extensions/ghost-in-the-shell-theme"]
 	path = extensions/ghost-in-the-shell-theme
 	url = https://github.com/ddoemonn/ghost-in-the-shell-theme.git
@@ -5773,6 +5777,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/georgy-theme"]
-	path = extensions/georgy-theme
-	url = https://github.com/GeorgyDesign/georgy-themes-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5705,3 +5705,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/georgy-themes-zed"]
+	path = extensions/georgy-themes-zed
+	url = https://github.com/GeorgyDesign/georgy-themes-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1784,6 +1784,10 @@ version = "1.2.2"
 submodule = "extensions/geode-theme"
 version = "2.0.1"
 
+[georgy-theme]
+submodule = "extensions/georgy-theme"
+version = "0.1.0"
+
 [ghost-in-the-shell-theme]
 submodule = "extensions/ghost-in-the-shell-theme"
 version = "0.1.0"


### PR DESCRIPTION
## Summary
Adds the `georgy-theme` extension featuring a dark theme family for Zed:
- Georgy Dark
- Georgy Black
- Georgy Black Dim

*Resubmitting with guideline fixes (supersedes #7199).*

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
