### PR TITLE
Update lisette to v0.1.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2704,7 +2704,7 @@ version = "0.1.0"
 [lisette]
 submodule = "extensions/lisette"
 path = "editors/zed"
-version = "0.1.2"
+version = "0.1.3"
 
 [little-league-theme]
 submodule = "extensions/little-league-theme"


### PR DESCRIPTION
Catches the Zed extension up on Lisette grammar additions since v0.1.2.

I've tested a dev build locally. Additions listed at: https://github.com/ivov/lisette/pull/1347

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
