### PR TITLE
Add migoto-ini language extension for 3DMigoto-style INI files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3102,6 +3102,10 @@
 	path = extensions/midnight-marina
 	url = https://github.com/Muddyblack/midnight-marina-zed.git
 
+[submodule "extensions/migoto-ini"]
+	path = extensions/migoto-ini
+	url = https://codeberg.org/lupomikti/migoto-ini-zed
+
 [submodule "extensions/miles-theme"]
 	path = extensions/miles-theme
 	url = https://github.com/imkarmona/miles-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3162,6 +3162,10 @@ version = "0.2.0"
 submodule = "extensions/midnight-marina"
 version = "0.0.1"
 
+[migoto-ini]
+submodule = "extensions/migoto-ini"
+version = "0.12.0"
+
 [miles-theme]
 submodule = "extensions/miles-theme"
 version = "0.1.0"


### PR DESCRIPTION
This language extension currently provides syntax highlighting for 3DMigoto-style INI files. These files are not a standard configuration type and instead make use of a niche DSL that is best described as a "pidgin scripting language". Historically, the files started off as pure INI, but scripting capabilities were grafted into it over time as needed. This file type is used in game modding configurations for use with the 3DMigoto project, primarily the XXMI fork of it.

Further language features are planned for the future, such as a formatter and a language server.

---
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
