### PR TITLE
Add Void OLED theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5426,6 +5426,10 @@
 	path = extensions/vivid-void-theme
 	url = https://github.com/fn-jakubkarp/zed-vivid-void-theme.git
 
+[submodule "extensions/void-oled-theme"]
+	path = extensions/void-oled-theme
+	url = https://github.com/RustyDaemon/zed-void-oled-theme.git
+
 [submodule "extensions/voidline-theme"]
 	path = extensions/voidline-theme
 	url = https://github.com/knownIndie/voidline-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -5533,6 +5533,10 @@ version = "1.0.0"
 submodule = "extensions/vivid-void-theme"
 version = "0.0.1"
 
+[void-oled-theme]
+submodule = "extensions/void-oled-theme"
+version = "0.8.9"
+
 [voidline-theme]
 submodule = "extensions/voidline-theme"
 version = "0.1.1"


### PR DESCRIPTION
Add Void OLED theme - "A true black OLED theme for Zed editor"

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
