### PR TITLE
Add mimo-code-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3118,6 +3118,10 @@
 	path = extensions/miles-theme
 	url = https://github.com/imkarmona/miles-theme.git
 
+[submodule "extensions/mimo-code-theme"]
+	path = extensions/mimo-code-theme
+	url = https://github.com/jadmadi/zed-mimoCode-theme.git
+
 [submodule "extensions/min-theme"]
 	path = extensions/min-theme
 	url = https://github.com/phibr0/zed-min-theme/

--- a/extensions.toml
+++ b/extensions.toml
@@ -3180,6 +3180,10 @@ version = "0.0.1"
 submodule = "extensions/miles-theme"
 version = "0.1.0"
 
+[mimo-code-theme]
+submodule = "extensions/mimo-code-theme"
+version = "0.0.1"
+
 [min-theme]
 submodule = "extensions/min-theme"
 version = "0.2.2"


### PR DESCRIPTION
Adds the [MimoCode-theme](https://github.com/jadmadi/zed-mimoCode-theme) theme extension.

- **Extension id:** `mimo-code-theme`
- **Version:** `0.0.1` (tag `v0.0.1`, pinned to `410ec03`)
- **Themes:** `Mimocode` (dark) and `Mimocode Light` — a warm theme pair with signature orange accents; the light variant follows the same hue families
- **License:** MIT

Both themes were validated against the v0.2.0 themes schema and load correctly in Zed (manual test at the pinned commit).
