### PR TITLE
Update laravel to v0.7.5

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2613,7 +2613,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.7.1"
+version = "0.7.5"
 
 [laravel-official]
 submodule = "extensions/laravel-official"


### PR DESCRIPTION
Bumps `laravel-ce` from 0.7.2 to v0.7.5.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.5
Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.4
Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.3