### PR TITLE
Add goctl extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1510,6 +1510,10 @@
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets
 
+[submodule "extensions/goctl"]
+	path = extensions/goctl
+	url = https://github.com/caichuanwang/goctl-zed.git
+
 [submodule "extensions/godot-theme"]
 	path = extensions/godot-theme
 	url = https://github.com/D4r3NPo/zed-godot-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1535,6 +1535,10 @@ version = "1.4.0"
 submodule = "extensions/go-snippets"
 version = "0.1.5"
 
+[goctl]
+submodule = "extensions/goctl"
+version = "0.1.0"
+
 [godot-theme]
 submodule = "extensions/godot-theme"
 version = "1.3.0"


### PR DESCRIPTION

## Summary

Adds the `goctl` Zed extension for go-zero `.api` files.

Extension repository: https://github.com/caichuanwang/goctl-zed
Release asset: https://github.com/caichuanwang/goctl-zed/releases/download/v0.1.0/goctl-api-lsp.mjs

## Notes

- The extension id is `goctl`.
- The language server is not required to be bundled inside the published extension package. Runtime resolution checks `goctl-api-lsp` on PATH first, then cached/dev source, then downloads `goctl-api-lsp.mjs` from the GitHub Release.
- Formatting delegates to the installed `goctl` CLI.

## Verification

Ran in `caichuanwang/goctl-zed`:

- `node scripts/release/check.mjs`
- `node --test scripts/test.mjs`
- `cargo check`
- `cargo build --target wasm32-wasip2`
- `openspec validate --specs --strict`
- `openspec validate --changes --strict`

Ran in this registry checkout:

- `node src/sort-extensions.js`
- `git diff --exit-code -- .gitmodules extensions.toml`
