### PR TITLE
Add Sublime Text 4 Colorful theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4794,6 +4794,10 @@
 	path = extensions/sublime-mariana-theme
 	url = https://github.com/hnatiukr/zed-mariana-theme.git
 
+[submodule "extensions/sublime-text-4-colorful-theme"]
+	path = extensions/sublime-text-4-colorful-theme
+	url = https://github.com/Fan4Metal/sublime-text-4-colorful-zed.git
+
 [submodule "extensions/subliminal-nightfall"]
 	path = extensions/subliminal-nightfall
 	url = https://github.com/mhamrah/subliminal-nightfall

--- a/extensions.toml
+++ b/extensions.toml
@@ -4886,6 +4886,10 @@ version = "0.2.0"
 submodule = "extensions/sublime-mariana-theme"
 version = "1.1.4"
 
+[sublime-text-4-colorful-theme]
+submodule = "extensions/sublime-text-4-colorful-theme"
+version = "0.1.1"
+
 [subliminal-nightfall]
 submodule = "extensions/subliminal-nightfall"
 path = "zed"


### PR DESCRIPTION
Adds **Sublime Text 4 Colorful**, a dark theme for Zed.

- Repository: https://github.com/Fan4Metal/sublime-text-4-colorful-zed
- License: MIT

It is a port of the [Sublime Text 4 Colorful Theme](https://marketplace.visualstudio.com/items?itemName=Enubia.sublime-text-4-colorful-theme) for VS Code by Enubia (itself a fork of the Sublime Text 4 Theme by @EmilijanMB), with the Mariana palette used to fill in the token roles Zed exposes but the original theme did not map. Attribution for the whole chain is in the README and the LICENSE.

Tested locally as a dev extension at the submodule commit being submitted.
