### PR TITLE
Update depsy to v2.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1205,7 +1205,7 @@ version = "0.1.8"
 [depsy-lsp]
 submodule = "extensions/depsy-lsp"
 path = "depsy-zed"
-version = "2.0.1"
+version = "2.0.2"
 
 [deputy]
 submodule = "extensions/deputy"


### PR DESCRIPTION
## Summary

- Update the `depsy-lsp` extension to v2.0.2
- Point the `extensions/depsy-lsp` submodule at the v2.0.2 release commit

Patch release, no changes to the extension manifest or settings. The language server gains Cargo target-specific dependency sections (`[target.'cfg(unix)'.dependencies]` and friends), several Maven/pom parsing fixes (entity references, CDATA, `<exclusions>`), and lockfile resolution that matches the requirement declared in the manifest instead of the first matching entry. Full notes: https://github.com/mpiton/zed-depsy/blob/v2.0.2/CHANGELOG.md

## Type

chore

## Validation

- `pnpm build`
- `pnpm test` (115 passed)
- `pnpm sort-extensions` (no changes)
- `cargo build --release --target wasm32-wasip2 --locked` in `depsy-zed` at the tagged commit
- Release assets published for all five targets at https://github.com/mpiton/zed-depsy/releases/tag/v2.0.2