### PR TITLE
add revo language extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4286,6 +4286,10 @@
 	path = extensions/retropc-theme
 	url = https://github.com/abhishek-bhatkar/retroPC-zed-theme.git
 
+[submodule "extensions/revo"]
+	path = extensions/revo
+	url = https://github.com/scout0773/revo-zed-extension.git
+
 [submodule "extensions/rewrite-theme"]
 	path = extensions/rewrite-theme
 	url = https://github.com/RewriteToday/theme.git
@@ -5773,6 +5777,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/revo"]
-	path = extensions/revo
-	url = https://github.com/scout0773/revo-zed-extension.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5773,3 +5773,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/revo"]
+	path = extensions/revo
+	url = https://github.com/scout0773/revo-zed-extension.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4364,6 +4364,10 @@ version = "0.0.1"
 submodule = "extensions/retropc-theme"
 version = "0.0.1"
 
+[revo]
+submodule = "extensions/revo"
+version = "0.0.1"
+
 [rewrite-theme]
 submodule = "extensions/rewrite-theme"
 path = "zed"


### PR DESCRIPTION
## Revo

Adds Revo language support to Zed.

- Syntax highlighting via Tree-sitter
- `.rv` file support
- Revo language server integration via `revo lsp`
- Documentation comment highlighting

Repository: https://github.com/scout0773/revo-zed-extension

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
