### PR TITLE
Add Oddities theme collection

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3562,6 +3562,10 @@
 	path = extensions/oceans-of-andromeda-theme
 	url = https://github.com/jdonlucas/zed-oceans-of-andromeda
 
+[submodule "extensions/oddities-theme"]
+	path = extensions/oddities-theme
+	url = https://github.com/tavasolireza/oddities-theme.git
+
 [submodule "extensions/odin"]
 	path = extensions/odin
 	url = https://github.com/zed-extensions/odin

--- a/extensions.toml
+++ b/extensions.toml
@@ -3626,6 +3626,10 @@ version = "1.1.0"
 submodule = "extensions/oceans-of-andromeda-theme"
 version = "1.0.1"
 
+[oddities-theme]
+submodule = "extensions/oddities-theme"
+version = "0.1.0"
+
 [odin]
 submodule = "extensions/odin"
 version = "0.3.16"


### PR DESCRIPTION
Adds Oddities: Uncommon Themes, a theme-only extension containing:

- Soft2000 Light and Soft2000 Dark
- Golden Eye Refined
- Yuuyake Refined

The extension repository includes a visual preview, an MIT license for the collection and port work, full copies of the three upstream licenses, and prominent attribution with links to each original project.

Validation:

- All four theme variants declare the Zed themes v0.2.0 schema.
- The extension ID, manifest, theme names, appearances, syntax maps, and color formats were checked locally.
- The extension themes were iterated in Zed before packaging.
- The registry sorter completed successfully.
- The registry test suite passed: 2 files, 115 tests.

- [x] I've read the contribution guidelines and followed the relevant guidance for adding my extension.