### PR TITLE
Update s-dark-theme to v3.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4485,7 +4485,7 @@ version = "0.1.0"
 
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
-version = "2.0.5"
+version = "3.0.0"
 
 [sagemath]
 submodule = "extensions/sagemath"


### PR DESCRIPTION
_Split the original S-Dark theme into three separate variants: S-Dark Cobalt, S-Dark Violet, and S-Dark Onyx. All three now appear as independent options in the theme picker._

## What's new

**S-Dark Cobalt**  
The blue variant. Syntax colors (keywords, functions, strings, comments, punctuation) have been redesigned. The UI frame — title bar, tabs, and panels — still uses the original blue accent.

**S-Dark Violet** (new)  
A softer purple variant with slightly lower contrast in the UI and muted text. Code colors are warmer (amber for modified lines, orange-brown strings, teal tags). A good choice if you want something less blue and easier on the eyes during long sessions.

**S-Dark Onyx** (new)  
Shares the same warm syntax palette as Violet, but the entire UI frame (title bar, tabs, panels, terminal, and editor) is pure black. Flat, OLED-friendly, and completely free of color noise around the code. Ideal if you want the darkest possible surroundings with maximum focus on the text.

> - [X] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.