### PR TITLE
Add Solarized Osaka Glass theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4654,6 +4654,10 @@
 	path = extensions/solarized-fp
 	url = https://github.com/lohazo/zed-solarized-fp.git
 
+[submodule "extensions/solarized-osaka-glass-theme"]
+	path = extensions/solarized-osaka-glass-theme
+	url = https://github.com/thaodangspace/zed-solarized-osaka.git
+
 [submodule "extensions/solarized-osaka-theme"]
 	path = extensions/solarized-osaka-theme
 	url = https://github.com/clouby/solarized-osaka-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4742,6 +4742,10 @@ version = "0.4.0"
 submodule = "extensions/solarized-fp"
 version = "0.0.1"
 
+[solarized-osaka-glass-theme]
+submodule = "extensions/solarized-osaka-glass-theme"
+version = "0.1.0"
+
 [solarized-osaka-theme]
 submodule = "extensions/solarized-osaka-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds Solarized Osaka Glass, a transparent and blurred adaptation of
craftzdog's Solarized Osaka theme for Zed.

The theme differs from the existing Solarized Osaka extension by providing
a glass-style transparent UI and blurred background treatment.

Repository:
https://github.com/thaodangspace/zed-solarized-osaka