### PR TITLE
Add AstroTheme (AstroDark, AstroLight, AstroJupiter, AstroMars)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -278,6 +278,10 @@
 	path = extensions/astro
 	url = https://github.com/zed-extensions/astro.git
 
+[submodule "extensions/astrotheme-theme"]
+	path = extensions/astrotheme-theme
+	url = https://github.com/lemokami/astrotheme-zed.git
+
 [submodule "extensions/atlas-ragnarok-theme"]
 	path = extensions/atlas-ragnarok-theme
 	url = https://github.com/AyoubTadlaoui/atlas-ragnarok.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -284,6 +284,10 @@ version = "0.1.0"
 submodule = "extensions/astro"
 version = "0.2.0"
 
+[astrotheme-theme]
+submodule = "extensions/astrotheme-theme"
+version = "0.2.0"
+
 [atlas-ragnarok-theme]
 submodule = "extensions/atlas-ragnarok-theme"
 path = "editors/zed"


### PR DESCRIPTION
## Extension

AstroTheme — a port of all four [AstroNvim/astrotheme](https://github.com/AstroNvim/astrotheme) colorschemes to Zed's theme format: AstroDark, AstroLight, AstroJupiter, AstroMars.

- Repo: https://github.com/lemokami/astrotheme-zed
- License: GPLv3 (matches upstream astrotheme, since this is a derivative of its palette)
- Colors sourced from upstream's `lua/astrotheme/palettes/*.lua` and `extras/vscode/*.json` (for precomputed terminal ANSI bright variants), mapped role-by-role onto Zed's theme schema
- Tested locally as a dev extension in Zed
- Supersedes an earlier closed PR that only covered the AstroDark variant