### PR TITLE
Add console-log-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -910,6 +910,10 @@
 	path = extensions/conl
 	url = https://github.com/ConradIrwin/zed-extension-conl
 
+[submodule "extensions/console-log-lsp"]
+	path = extensions/console-log-lsp
+	url = https://github.com/JacobZyy/zed-extensions-set.git
+
 [submodule "extensions/cooklang"]
 	path = extensions/cooklang
 	url = https://github.com/hugginsio/zed-cooklang.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -930,6 +930,11 @@ version = "1.0.0"
 submodule = "extensions/conl"
 version = "2.0.1"
 
+[console-log-lsp]
+submodule = "extensions/console-log-lsp"
+path = "packages/console-log"
+version = "0.1.0"
+
 [cooklang]
 submodule = "extensions/cooklang"
 version = "1.3.3"


### PR DESCRIPTION
## Summary

- Add the `console-log-lsp` extension from `JacobZyy/zed-extensions-set`.
- Provide code actions that insert contextual `console.log` statements for JavaScript, TypeScript, TSX, and Vue script blocks.
- Download the versioned native language-server binary from the extension repository's GitHub Release.

## Validation

- Installed and tested as a Zed dev extension.
- Verified selected-expression and location-only code actions in Zed.
- Verified the extension downloads and starts the macOS ARM64 Release binary when no PATH binary exists.
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked` (9 tests)
- `wasm32-wasip2` release build
- Six native Release assets built successfully for macOS, Linux, and Windows on x86_64 and ARM64.

Release: https://github.com/JacobZyy/zed-extensions-set/releases/tag/console-log-v0.1.0

- [x] I've read the contribution guidelines and followed the relevant guidance for adding my extension.
