### PR TITLE
Add HarmonyOS Debugger extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2030,6 +2030,10 @@
 	path = extensions/hare
 	url = https://github.com/xdBronch/hare-zed.git
 
+[submodule "extensions/harmonyos-debugger"]
+	path = extensions/harmonyos-debugger
+	url = https://github.com/qinains/zed-harmonyos.git
+
 [submodule "extensions/harper"]
 	path = extensions/harper
 	url = https://github.com/zed-extensions/harper.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2074,7 +2074,7 @@ version = "0.0.1"
 
 [harmonyos-debugger]
 submodule = "extensions/harmonyos-debugger"
-version = "0.1.0"
+version = "0.1.1"
 
 [harper]
 submodule = "extensions/harper"

--- a/extensions.toml
+++ b/extensions.toml
@@ -2072,6 +2072,10 @@ version = "0.2.0"
 submodule = "extensions/hare"
 version = "0.0.1"
 
+[harmonyos-debugger]
+submodule = "extensions/harmonyos-debugger"
+version = "0.1.0"
+
 [harper]
 submodule = "extensions/harper"
 version = "0.1.5"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Summary

- Add a debugger-only extension for HarmonyOS ArkTS applications; it complements the existing ArkTS language extension without adding a grammar or language server.
- This submission pins **0.1.1**, submodule commit `ed48a5572afe6a7bb63713344dd623af3c01fa57`.
- Download the version-matched DAP adapter from the public [v0.1.1 release](https://github.com/qinains/zed-harmonyos/releases/tag/v0.1.1) and verify its SHA-256 digest.
- Support HarmonyOS project discovery, Launch, Attach, breakpoints, stepping, frames, variables, expression evaluation, and explicit device reselection via `selectDevice`.

## Recorded validation for the submitted version

- Development-extension acceptance was performed in Zed 1.17.2. The recorded acceptance includes two clean emulator Launch runs and two clean emulator Attach runs, plus two clean Launch and two clean Attach runs on a debug-enabled physical device.
- These bounded runs checked breakpoints, populated Frames/scopes, expression evaluation, Continue, and forwarding cleanup. They are not a claim of exhaustive device/API-level compatibility.
- Native and wasm32-wasip2 builds, Cargo tests, Clippy, rustfmt, adapter self-tests, and repository CI passed in the recorded validation.
- Both v0.1.1 release assets were downloaded into a clean directory, passed the published SHA-256 check, and matched the committed files byte for byte.
- Version-pinned evidence: [development handoff](https://github.com/qinains/zed-harmonyos/blob/ed48a5572afe6a7bb63713344dd623af3c01fa57/docs/development-handoff.md) and [validation record](https://github.com/qinains/zed-harmonyos/blob/ed48a5572afe6a7bb63713344dd623af3c01fa57/docs/validation/arkts-debugging.md).

## Scope and subsequent findings

- The pinned 0.1.1 does not include hot reload, WebView/Native debugging, profiling, automatic reconnection, or automatic emulator startup.
- Subsequent testing found a Zed execution-response/state race; the client fix is under review in [zed-industries/zed#63979](https://github.com/zed-industries/zed/pull/63979). Later successful UI tests using a locally patched Zed must not be read as validation of an unpatched official client.
- Additional adapter lifecycle fixes and experimental hot reload are on the extension repository's main branch as **unreleased 0.1.2**. They are not included in this registry PR, and their later test results do not replace the pinned-version evidence above.
- The initial acceptance record predates these subsequent findings. Please consider those limitations during review; I can coordinate any required changes to the submission rather than silently moving its version or release assets.
