### PR TITLE
add caatinga-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
+[submodule "extensions/caatinga-theme"]
+	path = extensions/caatinga-theme
+	url = https://github.com/meluiz/caatinga.git
+
 [submodule "extensions/0-protan-prism-theme"]
 	path = extensions/0-protan-prism-theme
 	url = https://github.com/0rtbo/0-protan-prism-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -611,6 +611,10 @@ version = "1.0.0"
 submodule = "extensions/c3"
 version = "0.0.2"
 
+[caatinga-theme]
+submodule = "extensions/caatinga-theme"
+version = "0.1.0"
+
 [caddyfile]
 submodule = "extensions/caddyfile"
 version = "0.0.6"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

Add [Caatinga Theme](https://github.com/meluiz/caatinga), a warm, earthy theme with terracotta accents over sand-toned neutrals.

<img width="1670" height="1012" alt="caatinga-dark" src="https://github.com/user-attachments/assets/a7c470cd-d256-4e37-b1a0-ae2f83e0895a" />

<img width="1670" height="1012" alt="caatinga-light" src="https://github.com/user-attachments/assets/4ae41692-31c9-4e1d-ac8a-78419f8d465b" />


- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
