### PR TITLE
Add Common Lisp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -894,6 +894,10 @@
 	path = extensions/comment-block-snippets
 	url = https://github.com/rami-shalhoub/comment-blocks-zed.git
 
+[submodule "extensions/common-lisp"]
+	path = extensions/common-lisp
+	url = https://github.com/etyurkin/zed-cl.git
+
 [submodule "extensions/comphy-crisp-themes"]
 	path = extensions/comphy-crisp-themes
 	url = https://github.com/VatsalSy/comphy-zed-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -913,6 +913,11 @@ version = "0.6.8"
 submodule = "extensions/comment-block-snippets"
 version = "1.0.4"
 
+[common-lisp]
+submodule = "extensions/common-lisp"
+path = "extension"
+version = "1.1.2"
+
 [comphy-crisp-themes]
 submodule = "extensions/comphy-crisp-themes"
 version = "1.1.0"


### PR DESCRIPTION
- [X ] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Common Lisp support: tree-sitter grammar, LSP (completions, hover, goto-definition), and a shared-state REPL via Zed's REPL support. The language server and companion tools are downloaded from the extension repo's GitHub releases at first use, not bundled. Tested as a dev extension on macOS (Zed 1.17.2) and Windows.