### PR TITLE
Add cartan language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -662,6 +662,10 @@
 	path = extensions/cargo-tom
 	url = https://github.com/frederik-uni/zed-cargotom.git
 
+[submodule "extensions/cartan"]
+	path = extensions/cartan
+	url = https://github.com/cartan-lang/zed-cartan.git
+
 [submodule "extensions/carve"]
 	path = extensions/carve
 	url = https://github.com/markup-carve/zed-carve.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -675,6 +675,10 @@ version = "0.2.0"
 submodule = "extensions/cargo-tom"
 version = "0.4.1"
 
+[cartan]
+submodule = "extensions/cartan"
+version = "0.5.1"
+
 [carve]
 submodule = "extensions/carve"
 version = "0.1.1"


### PR DESCRIPTION
Adds the cartan extension at 0.4.2: language support for cartan documents (`.cart`) — the tree-sitter grammar from cartan-lang/tree-sitter-cartan and the `cartan lsp` language server, which the extension starts from the user's PATH. The extension repository (https://github.com/cartan-lang/zed-cartan) is refreshed per release of the language, in lockstep with its version.