### PR TITLE
Update comphy-crisp-themes to v1.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -919,7 +919,7 @@ version = "1.0.4"
 
 [comphy-crisp-themes]
 submodule = "extensions/comphy-crisp-themes"
-version = "1.1.0"
+version = "1.2.0"
 
 [compline]
 submodule = "extensions/compline"


### PR DESCRIPTION
Release notes:

https://github.com/comphy-lab/comphy-zed-themes/releases/tag/v1.2.0

> Created by [zed-extension-action](https://github.com/huacnlee/zed-extension-action).