### PR TITLE
Update asciidoc to v0.5.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -242,7 +242,7 @@ version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
-version = "0.5.2"
+version = "0.5.3"
 
 [ashen]
 submodule = "extensions/ashen"


### PR DESCRIPTION
Updates the AsciiDoc extension to v0.5.3.

- Pins both grammars to `e0710115e7b060ce6681b5182a49a792813006f1`
- Updates the extension registry version to `0.5.3`