### PR TITLE
Update mach to v0.5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2780,7 +2780,7 @@
 
 [submodule "extensions/mach"]
 	path = extensions/mach
-	url = https://github.com/octalide/mach-zed.git
+	url = https://github.com/briar-systems/mach-zed.git
 
 [submodule "extensions/macos-classic"]
 	path = extensions/macos-classic

--- a/extensions.toml
+++ b/extensions.toml
@@ -2840,7 +2840,7 @@ version = "0.0.4"
 
 [mach]
 submodule = "extensions/mach"
-version = "0.4.2"
+version = "0.5.0"
 
 [macos-classic]
 submodule = "extensions/macos-classic"


### PR DESCRIPTION
Updates Mach to v0.5.0 with annotations, recursive secret types, and secret strip expressions. Also transfers the submodule URL to briar-systems/mach-zed.

Validation:
- pnpm build
- pnpm test, 115 tests passed
- pnpm sort-extensions
- pnpm package-extensions mach

- [x] I have read the contribution guidelines and followed the relevant guidance for updating this extension.