### PR TITLE
Add Rust Glancer language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4386,6 +4386,10 @@
 	path = extensions/rust-and-brown
 	url = https://github.com/LukianovII/rust-and-brown-zed.git
 
+[submodule "extensions/rust-glancer"]
+	path = extensions/rust-glancer
+	url = https://github.com/rust-glancer/rust-glancer.git
+
 [submodule "extensions/rust-rover-dark-theme"]
 	path = extensions/rust-rover-dark-theme
 	url = https://github.com/blkmlk/RustRover-Zed-Theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4467,6 +4467,11 @@ version = "1.0.0"
 submodule = "extensions/rust-and-brown"
 version = "1.0.0"
 
+[rust-glancer]
+submodule = "extensions/rust-glancer"
+path = "editors/zed"
+version = "0.2.0"
+
 [rust-rover-dark-theme]
 submodule = "extensions/rust-rover-dark-theme"
 version = "1.0.3"


### PR DESCRIPTION
This PR adds [Rust Glancer](https://github.com/rust-glancer/rust-glancer) extension -- a new experimental Rust LSP that aims to have very low idle memory. I'm preparing the second release, and Zed extension [was requested](https://github.com/rust-glancer/rust-glancer) by the community. It was [discussed on r/rust before too](https://www.reddit.com/r/rust/comments/1vtn6nv/rust_glancer_a_memoryefficient_rust_language/).

The extension itself is pretty basic, it uses all the defaults and can either download the artifact for the platform or use configured path. I've checked manually that all the functionality works.

Minimal required configuration is:
```
  "languages": {
    "Rust": {
      "language_servers": ["rust-glancer", "!rust-analyzer"],
    },
  }
```

The extension does not abuse any zed APIs, but there is one slight hack: I've noticed that Zed supports rust-analyzer's `experimental/serverStatus` LSP method so I use it for status communication as well, since Zed doesn't give much controls for that otherwise. Hope that's fine.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
