### PR TITLE
Add css-var-kit language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -990,6 +990,10 @@
 	path = extensions/css-modules-kit
 	url = https://github.com/mizdra/css-modules-kit.git
 
+[submodule "extensions/css-var-kit-lsp"]
+	path = extensions/css-var-kit-lsp
+	url = https://github.com/jo16oh/css-var-kit.git
+
 [submodule "extensions/css-variables"]
 	path = extensions/css-variables
 	url = https://github.com/lmn451/css-variables-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1012,6 +1012,11 @@ submodule = "extensions/css-modules-kit"
 version = "0.1.1"
 path = "crates/zed"
 
+[css-var-kit-lsp]
+submodule = "extensions/css-var-kit-lsp"
+path = "crates/zed-extension"
+version = "0.4.0"
+
 [css-variables]
 submodule = "extensions/css-variables"
 version = "0.1.1"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Resubmission of #5850, which was closed as stale. Thank you for the review. The issues pointed out there have been fixed: I specified the MIT license and added the `-lsp` suffix to the extension ID.

[css-var-kit](https://github.com/jo16oh/css-var-kit) is a linter and language server for CSS custom properties that enables type-aware linting and completion. This extension is a thin wrapper for `css-var-kit`.


