### PR TITLE
Add whim language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5622,6 +5622,10 @@
 	path = extensions/wgsl-wesl
 	url = https://github.com/lucascompython/wgsl-wesl-zed
 
+[submodule "extensions/whim-lang"]
+	path = extensions/whim-lang
+	url = https://github.com/carthage-software/whim-zed.git
+
 [submodule "extensions/whkd"]
 	path = extensions/whkd
 	url = https://github.com/LGUG2Z/zed-whkd.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5734,6 +5734,10 @@ version = "0.0.1"
 submodule = "extensions/wgsl-wesl"
 version = "0.0.3"
 
+[whim-lang]
+submodule = "extensions/whim-lang"
+version = "0.1.0"
+
 [whkd]
 submodule = "extensions/whkd"
 version = "0.1.0"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

This PR adds a Zed extension ( https://github.com/carthage-software/whim-zed/tree/main ) which adds support for the Whim Programming Language ( https://github.com/carthage-software/whim ).

The LSP is part of the `whim` binary: https://github.com/carthage-software/whim/blob/main/src/server/mod.rs, and the extension merely just starts the server using the globally installed `whim` binary.