### PR TITLE
Add Celestia extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -706,6 +706,10 @@
 	path = extensions/cedar
 	url = https://github.com/chrnorm/zed-cedar.git
 
+[submodule "extensions/celestia"]
+	path = extensions/celestia
+	url = https://github.com/fits-ki/celestia.git
+
 [submodule "extensions/cem"]
 	path = extensions/cem
 	url = https://github.com/bennypowers/cem.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -719,6 +719,10 @@ version = "0.0.2"
 submodule = "extensions/cedar"
 version = "0.0.1"
 
+[celestia]
+submodule = "extensions/celestia"
+version = "0.1.0"
+
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds Celestia language support for sixteen Celestia authoring formats, backed by four pinned Tree-sitter grammars and the Celestia language server.

The submitted public extension commit is `1e555025cf461ac3e6de0d77890cc69278fafe2f` on `fits-ki/celestia` `main`, version `0.1.0`. It downloads checksum-pinned native language-server releases for macOS, Linux, and Windows on AArch64 and x86-64.

Validation completed before submission:

- installed and exercised as a Zed dev extension
- exact-six native build, executable, integrity, and LSP handshake qualification
- complete Celestia release gate
- registry TypeScript build
- 115 registry tests
- sorted `extensions.toml` and `.gitmodules`