### PR TITLE
Update fsharp to v0.0.11

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1762,7 +1762,7 @@ version = "0.0.1"
 
 [fsharp]
 submodule = "extensions/fsharp"
-version = "0.0.9"
+version = "0.0.11"
 
 [fsm]
 submodule = "extensions/fsm"


### PR DESCRIPTION
Bumps the F# extension from `0.0.9` to `0.0.11`.

Changes since `0.0.9`:

- `.fsscript` file support
- Syntax highlighting: module colour, bracket formatting, `:` as a delimiter
- LSP: sensible default `initialization_options` for fsautocomplete, deep-merged with user-supplied options so overriding one setting no longer discards the defaults
- Docs: configuration reference for `env`, `initialization_options`, `fsac_custom_args` and `fsac_custom_path`

`0.0.10` was skipped — it was tagged upstream but never published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTxTK5HAMWFCvPcBrHftpC