### PR TITLE
Add Celestia extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -706,6 +706,10 @@
 	path = extensions/cedar
 	url = https://github.com/chrnorm/zed-cedar.git
 
+[submodule "extensions/celestia"]
+	path = extensions/celestia
+	url = https://github.com/fits-ki/celestia
+
 [submodule "extensions/cem"]
 	path = extensions/cem
 	url = https://github.com/bennypowers/cem.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -719,6 +719,10 @@ version = "0.0.2"
 submodule = "extensions/cedar"
 version = "0.0.1"
 
+[celestia]
+submodule = "extensions/celestia"
+version = "0.1.1"
+
 [cem]
 submodule = "extensions/cem"
 path = "extensions/zed"


### PR DESCRIPTION
Adds Celestia authoring-format support through published `fits-ki/celestia` extension repository at v0.1.1.

Extension includes syntax support for Celestia catalogs, configuration, metadata, trajectories, CEL/CELX, and Lua modules, plus Celestia language server for diagnostics and editor features.

Validation:
- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests)
- public v0.1.1 release and adapter checks pass on Linux, macOS, and Windows
- MIT license present at repository root

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed them.
