### PR TITLE
Add new YmmeLua extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5686,6 +5686,10 @@
 	path = extensions/yellowed
 	url = https://github.com/Gael-Lopes-Da-Silva/YellowedZed
 
+[submodule "extensions/ymmelua"]
+	path = extensions/ymmelua
+	url = https://github.com/tacc-tacc/Zed-YmmeLua
+
 [submodule "extensions/your-name-theme"]
 	path = extensions/your-name-theme
 	url = https://github.com/TheAhumMaitra/Your-Name-Zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5797,6 +5797,10 @@ version = "0.0.9"
 submodule = "extensions/yellowed"
 version = "0.0.3"
 
+[ymmelua]
+submodule = "extensions/ymmelua"
+version = "0.1.0"
+
 [your-name-theme]
 submodule = "extensions/your-name-theme"
 version = "1.1.0"


### PR DESCRIPTION
Hello. I'd like to be considered this extension to be added. The mentioned is a fork of current EmmyLua extension with two features that extension lacks:

- **Autospawn of interpreter**: If you read the documentation of [EmmyLua DAP](https://github.com/EmmyLuaLs/emmylua_dap), you will see that it is required to add bootstrap code (stuff like `dbg.tcpListen()`) at the beggining of the scripts. This "stains" all the tested scripts and it is needed then to clean up before uploading to a repo or everywhere it is needed. Besides, I'm too lazy to open the console, call `lua (script).lua` and then call the debugger from the IDE. Why not to do these two steps at once?
- **Autodownload EmmyLuaDebugger**: The core module of the debugger has to be manually downloaded and included (`require("emmy_core")`), and therefore you need to have [this repo](https://github.com/EmmyLua/EmmyLuaDebugger) inside your CWD or link the folder from the same script your are running, which is also a stain that you have to clean before publishing the script somewhere else.

I thought this module should replace the current EmmyLua, however looking at the EmmyLua DAP module it is all like that's the whole objective of that DAP: to be called from some process that is already running instead of calling itself.

Thanks for reviewing my contribution and I hope somehow will be useful for the community.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
