### PR TITLE
Add intellij-high-contrast-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2294,6 +2294,10 @@
 	path = extensions/inlang-language-server
 	url = https://github.com/NEKOYASAN/inlang-zed
 
+[submodule "extensions/intellij-high-contrast-theme"]
+	path = extensions/intellij-high-contrast-theme
+	url = https://github.com/igorlealantunes/intellij-high-contrast-zed.git
+
 [submodule "extensions/intellij-light-theme"]
 	path = extensions/intellij-light-theme
 	url = https://github.com/chandruscm/intellij-light-theme-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2345,6 +2345,10 @@ version = "0.0.1"
 submodule = "extensions/inlang-language-server"
 version = "0.0.1"
 
+[intellij-high-contrast-theme]
+submodule = "extensions/intellij-high-contrast-theme"
+version = "0.1.0"
+
 [intellij-light-theme]
 submodule = "extensions/intellij-light-theme"
 version = "0.1.0"


### PR DESCRIPTION
A port of the **High Contrast** accessibility theme bundled with JetBrains IDEs.

- Repository: https://github.com/igorlealantunes/intellij-high-contrast-zed
- Submodule pinned at `acb51b3`
- License: MIT

This is a fork of [`cringoleg/jetbrains-high-contrast-zed`](https://github.com/cringoleg/jetbrains-high-contrast-zed), already in the registry as `jb-high-contrast-theme`, with the colors matched more closely against a running JetBrains IDE. Credit for the original port goes to them. The ID and display name are distinct, so both coexist in the theme picker.
