### PR TITLE
Add ember n ash

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5817,3 +5817,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/ember-n-ash"]
+	path = extensions/ember-n-ash
+	url = https://github.com/bashln/zed-ember-n-ash-theme

--- a/.gitmodules
+++ b/.gitmodules
@@ -1434,6 +1434,10 @@
 	path = extensions/ember
 	url = https://github.com/jylamont/zed-ember.git
 
+[submodule "extensions/ember-n-ash"]
+	path = extensions/ember-n-ash
+	url = https://github.com/bashln/zed-ember-n-ash-theme
+
 [submodule "extensions/ember-theme"]
 	path = extensions/ember-theme
 	url = https://github.com/biaqat/ember-theme-zed.git
@@ -5817,6 +5821,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/ember-n-ash"]
-	path = extensions/ember-n-ash
-	url = https://github.com/bashln/zed-ember-n-ash-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -1464,6 +1464,10 @@ version = "0.1.0"
 submodule = "extensions/ember"
 version = "0.1.0"
 
+[ember-n-ash]
+submodule = "extensions/ember-n-ash"
+version = "0.1.0"
+
 [ember-theme]
 submodule = "extensions/ember-theme"
 version = "0.9.1"


### PR DESCRIPTION
Adds the `ember-n-ash` theme extension.
  - Repository: https://github.com/bashln/zed-ember-n-ash-theme
  - Color palette based on the original theme by Hydradevx
  - Includes solid, soft blur, and deep blur variants

Tested locally via `zed: install dev extension`.

---

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
