### PR TITLE
Add CodeGloss

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -854,6 +854,10 @@
 	path = extensions/codebook
 	url = https://github.com/blopker/codebook-zed.git
 
+[submodule "extensions/codegloss-lsp"]
+	path = extensions/codegloss-lsp
+	url = https://github.com/shutx-net/codegloss.git
+
 [submodule "extensions/codely-theme"]
 	path = extensions/codely-theme
 	url = https://github.com/GOI17/codely-theme-zed

--- a/extensions.toml
+++ b/extensions.toml
@@ -872,6 +872,11 @@ version = "0.0.5"
 submodule = "extensions/codebook"
 version = "0.2.14"
 
+[codegloss-lsp]
+submodule = "extensions/codegloss-lsp"
+path = "editors/zed"
+version = "0.0.2"
+
 [codely-theme]
 submodule = "extensions/codely-theme"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds the CodeGloss extension v0.0.2.

CodeGloss shows Japanese translations of English code comments as hovers and code lenses, leaving the source file unchanged. Translation runs locally with candle + FuguMT; no code is sent to a service.

The extension only resolves and starts the language server. The server is downloaded from the release matching the extension's own version, and the translation model is fetched by the server in the background, so neither is bundled here.