### PR TITLE
Update fastapi-snippets to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1577,7 +1577,7 @@ version = "0.1.1"
 
 [fastapi-snippets]
 submodule = "extensions/fastapi-snippets"
-version = "0.2.0"
+version = "0.3.0"
 
 [fedaykin-themes]
 submodule = "extensions/fedaykin-themes"


### PR DESCRIPTION
- Bump version 0.2.0 -> 0.3.0 in extensions.toml and extension.toml (extensions/fastapi-snippets:61c9313)
- Add FastAPI Cloud & CLI support snippets: fastcloudapp, fastlifespan, fastcloudhealth, fastcloudsettings
- Modernize fastasyncdb/fastcache to use lifespan @asynccontextmanager instead of deprecated @app.on_event
- Fix fastcrud to use Pydantic v2 model_dump() instead of dict()
