### PR TITLE
Add go-sql-highlighter extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1898,6 +1898,10 @@
 	path = extensions/go-snippets
 	url = https://github.com/ayberkgezer/go-zed-snippets
 
+[submodule "extensions/go-sql-highlighter"]
+	path = extensions/go-sql-highlighter
+	url = https://github.com/MuhamedUsman/go-sql-highlighter.git
+
 [submodule "extensions/godot-theme"]
 	path = extensions/godot-theme
 	url = https://github.com/D4r3NPo/zed-godot-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1940,6 +1940,10 @@ version = "1.4.0"
 submodule = "extensions/go-snippets"
 version = "0.1.5"
 
+[go-sql-highlighter]
+submodule = "extensions/go-sql-highlighter"
+version = "0.0.1"
+
 [godot-theme]
 submodule = "extensions/godot-theme"
 version = "1.3.0"


### PR DESCRIPTION
- [x] I've read the contribution guidelines and followed the relevant guidance for adding my extension.

## What it does

`go-sql-highlighter` injects SQL syntax highlighting into Go string literals whose identifier ends in `SQL`/`sql`, `Query`/`query`, or `Qry`/`QRY`/`qry`. Highlighting only - no language server inside the strings. It also stitches SQL split across string concatenation (`` `SELECT ` + cols + ` FROM t` ``) into a single injected SQL document.

Repo: https://github.com/MuhamedUsman/go-sql-highlighter
Tested locally as a dev extension on Zed (Windows 11). MIT licensed.

## Why it re-ships the full Go language

Zed currently has no way for an extension to add injection patterns on top of a built-in language's queries (zed-industries/zed#40532). The only mechanism is to re-register `Go` with the complete set of query files. Every file in `languages/go/` except `injections.scm` is Zed's upstream copy, kept byte-for-byte unchanged and re-syncable via the extension's `sync-upstream.sh`.

Happy to adjust the approach if you'd prefer this handled differently.