### PR TITLE
Update julia to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2534,7 +2534,7 @@ version = "0.1.0"
 
 [julia]
 submodule = "extensions/julia"
-version = "0.1.10"
+version = "0.2.0"
 
 [just]
 submodule = "extensions/just"


### PR DESCRIPTION
This is a breaking change. See the extension's [README](https://github.com/JuliaEditorSupport/zed-julia).

---

The previous v0.2.0 registration attempt was closed after review in zed-industries/extensions#7164 raised concerns about the broad `process:exec` capability, the uppercase language server ID, and network downloads performed outside Zed's capability controls.

The extension's `main` branch now narrows `process:exec` to its Julia invocation shapes and registers the server as `jetls`. Managed JETLS installation remains delegated to Julia's package manager, but it is now gated by a scoped Zed `download_file` request that fetches and verifies the pinned release descriptor before package installation starts. Denying that request prevents the installation from performing network activity (JuliaEditorSupport/zed-julia#79).

Update the Julia submodule to the commit containing those fixes and publish its manifest version as `0.2.0`.

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
