### PR TITLE
Add hex-colorizer extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2102,6 +2102,10 @@
 	path = extensions/herzha-theme
 	url = https://github.com/madhanmaaz/herzha-theme.git
 
+[submodule "extensions/hex-colorizer"]
+	path = extensions/hex-colorizer
+	url = https://github.com/Web-Dev-Codi/zed-hexCode-colorizer.git
+
 [submodule "extensions/hex-light-theme"]
 	path = extensions/hex-light-theme
 	url = https://github.com/coghost/light-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -2148,6 +2148,10 @@ submodule = "extensions/herzha-theme"
 version = "0.1.0"
 path = "packages/zed"
 
+[hex-colorizer]
+submodule = "extensions/hex-colorizer"
+version = "0.1.0"
+
 [hex-light-theme]
 submodule = "extensions/hex-light-theme"
 version = "0.0.4"


### PR DESCRIPTION
## Add hex-colorizer extension

### What this extension is

[hex-colorizer](https://github.com/Web-Dev-Codi/zed-hexCode-colorizer) shows inline color swatches for hex codes (`#abc`, `#aabbcc`, `#aabbccdd`) in **any file type** — not just CSS-family files.

It ships a minimal, zero-dependency Node language server that claims only the LSP `colorProvider` capability. Because of that, it runs **alongside** your real language servers (tsserver, rust-analyzer, gopls, …) and never interferes with completions, diagnostics, formatting, or anything else. Swatches render via Zed's built-in `lsp_document_colors` pipeline (`inlay`, `border`, or `background`).

Coverage: 41 languages — JavaScript, TypeScript, TSX, Python, Rust, Go, JSON, YAML, TOML, Markdown, Plain Text, HTML, Shell Script, C/C++, and many more.

### My situation: why a new extension instead of contributing to an existing one

I know the contribution guidelines prefer improving an existing extension over adding an overlapping one, and there is an existing extension with similar functionality (**Color Highlight**). I considered it first, but decided a separate extension was the right call for these reasons:

1. **Different architecture.** Color Highlight renders decorations through the extension's own drawing API. This one instead reuses Zed's native `colorProvider` LSP pipeline — the exact mechanism Zed already uses for CSS swatches — so the swatches look and behave exactly like the built-in ones (including the `lsp_document_colors` setting), with no custom rendering code to maintain.
2. **Minimal surface area.** The server is a single dependency-free `server.js` that does one thing: scan for hex codes and report positions/colors. It claims only `colorProvider`, so it can't conflict with anything else. I wanted a small tool I fully control, both for learning purposes and to be able to extend it (e.g., language-aware filtering, more color formats later).
3. **Different trade-off philosophy.** This extension is regex-based and documented as such — it will show swatches on hex-looking strings that aren't colors (commit hashes, etc.). Rather than trying to be clever, the README states this limitation plainly up front and points users to Color Highlight if that trade-off doesn't suit them.

I've explicitly noted in the README that Color Highlight exists, describe the difference, and recommend trying it first. If maintainers would still prefer I upstream this approach into Color Highlight instead, I'm happy to discuss that.

### Design notes relevant to review

- **The embedded server script** is a single ~260-line dependency-free JS file, compiled into the WASM via `include_str!` and written to the extension's work directory on launch (same pattern as the emmet extension, since Zed's WASM sandbox can't see the extension's own source dir). It's not a bundled third-party binary — it's the extension's own code, and it prefers a user-installed `node` from PATH, falling back to Zed's managed Node runtime.
- **Known limitations are documented** in the README: regex false positives, hex-only support (no `rgb()`/`hsl()`/named colors), one small Node process per project.
- I've tested this locally as a dev extension in Zed at the submitted submodule commit (`b8834c6`).

### Checklist

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
- [x] Extension repository includes an accepted license (MIT) at the extension root
- [x] Extension ID is unique, kebab-cased, and contains neither `zed` nor `extension`
- [x] Submodule uses an HTTPS URL, pinned to a commit on `main` (not detached)
- [x] `extensions.toml` entry added with version matching `extension.toml` (`0.1.0`)
- [x] `pnpm sort-extensions` run — both files sorted
- [x] Tested manually in Zed as a dev extension