### PR TITLE
Add forest-night-ethereal extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1682,6 +1682,10 @@
 	path = extensions/forest-night
 	url = https://github.com/jarith/forest-night-zed.git
 
+[submodule "extensions/forest-night-ethereal"]
+	path = extensions/forest-night-ethereal
+	url = https://github.com/bashln/zed-forest-night-ethereal-theme.git
+
 [submodule "extensions/formosa-theme"]
 	path = extensions/formosa-theme
 	url = https://github.com/takeshiyu/formosa-zed-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1716,6 +1716,10 @@ version = "0.1.0"
 submodule = "extensions/forest-night"
 version = "0.1.0"
 
+[forest-night-ethereal]
+submodule = "extensions/forest-night-ethereal"
+version = "0.1.0"
+
 [formosa-theme]
 submodule = "extensions/formosa-theme"
 version = "1.0.0"


### PR DESCRIPTION
Adds the `forest-night-ethereal` theme extension.

- Repository: https://github.com/bashln/zed-forest-night-ethereal-theme
- Color palette based on the original theme by Forrest Knight
- Includes solid, soft blur, and deep blur variants

Tested locally via `zed: install dev extension`.

---

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
