### PR TITLE
Add Pigments extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3930,6 +3930,10 @@
 	path = extensions/pierre-theme
 	url = https://github.com/pierrecomputer/theme.git
 
+[submodule "extensions/pigments-lsp"]
+	path = extensions/pigments-lsp
+	url = https://github.com/JonathonRP/zed-pigments.git
+
 [submodule "extensions/pigs-in-space"]
 	path = extensions/pigs-in-space
 	url = https://github.com/kreek/pigs-in-space-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4002,6 +4002,11 @@ submodule = "extensions/pierre-theme"
 path = "zed"
 version = "0.0.29"
 
+[pigments-lsp]
+submodule = "extensions/pigments-lsp"
+path = "zed-pigments"
+version = "0.3.1"
+
 [pigs-in-space]
 submodule = "extensions/pigs-in-space"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Adds [Pigments](https://github.com/JonathonRP/zed-pigments), a language-server extension providing native Zed document-color previews.

- Registry ID: `pigments-lsp`
- Version: `0.3.1`
- Extension path: `zed-pigments`
- Pinned source commit: [`545ee63`](https://github.com/JonathonRP/zed-pigments/commit/545ee63ba654a57e322e109b09ff249c908c1ec6)
- Release: [`v0.3.1`](https://github.com/JonathonRP/zed-pigments/releases/tag/v0.3.1)

## Existing extensions and differentiation

This overlaps with the document-color use case served by [Color Highlight](https://zed.dev/extensions/color-highlight) and the narrower `hex-colorizer` submission in #7456. Pigments is based on ColorLSP and preserves attribution, but materially expands the behavior:

- language-aware, context-aware parsing rather than matching every hex-looking token
- CSS hex (including `#RGBA`), `0x`, RGB/HSL, CSS Color 4 (`hwb`, `lab`, `lch`, `oklab`, and `oklch`), and safe named-color recognition
- recursive document-local CSS custom-property and Sass/Less/Stylus variable resolution, with scope and cycle safeguards
- UTF-16-correct LSP ranges
- hover details and style-preserving `colorPresentation` edits

The source README documents the supported syntax, semantic safeguards, limitations, attribution, and architecture.

## Validation

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests)
- `pnpm package-extensions pigments-lsp` using the upstream Linux packaging environment: Node 24, Rust 1.90, `wasm32-wasip2`, and pinned `zed-extension` CLI `9ee3c503a4bbbc6b4a0f8a789acca4871d773223`
- Confirmed the pinned commit remains reachable from the source repository's `main` history and publication branch

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.