### PR TITLE
Add Source Engine Formats extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4734,6 +4734,10 @@
 	path = extensions/souffle
 	url = https://github.com/panosdimak/zed-souffle.git
 
+[submodule "extensions/source-engine-formats"]
+	path = extensions/source-engine-formats
+	url = https://github.com/Ultikynnys/zed-source-engine-formats.git
+
 [submodule "extensions/sourcepawn"]
 	path = extensions/sourcepawn
 	url = https://github.com/tsuza/zed-sourcepawn-ext.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4826,6 +4826,10 @@ version = "0.1.1"
 submodule = "extensions/souffle"
 version = "0.1.1"
 
+[source-engine-formats]
+submodule = "extensions/source-engine-formats"
+version = "0.2.0"
+
 [sourcepawn]
 submodule = "extensions/sourcepawn"
 version = "0.0.1"


### PR DESCRIPTION
## Summary

Adds the Source Engine Formats extension to the Zed extension registry.

The extension provides Tree-sitter parsing and syntax highlighting for:

- Source Engine StudioMDL QC and QCI files
- Valve Material Type (VMT) files

It also provides bracket matching, indentation, outlines, and Vim text objects for both languages.

Repository: https://github.com/Ultikynnys/zed-source-engine-formats

## Validation

- Installed and tested locally as a Zed dev extension on Windows
- Zed successfully compiled and loaded both grammars
- QC/QCI corpus: 3/3 passing
- VMT corpus: 3/3 passing
- Representative QC and VMT files parse without error nodes
- MIT licensed
- Registry TypeScript build passes locally

Note: the full registry Vitest run requires Node 24.20.0; this machine currently has Node 20.11.1, so CI is expected to run that suite in the repository's pinned Node environment.