### PR TITLE
Add AppliedML extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,6 +142,10 @@
 	path = extensions/amber-monochrome-monitor-crt-phosphor
 	url = https://github.com/Takk8IS/amber-monochrome-monitor-crt-phosphor-theme-for-zed.git
 
+[submodule "extensions/aml"]
+	path = extensions/aml
+	url = https://github.com/arkenstone-lab/amlc-lsp.git
+
 [submodule "extensions/andromeda"]
 	path = extensions/andromeda
 	url = https://github.com/ChocolateNao/andromeda-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -146,6 +146,11 @@ version = "0.3.2"
 submodule = "extensions/amber-monochrome-monitor-crt-phosphor"
 version = "0.1.3"
 
+[aml]
+submodule = "extensions/aml"
+path = "zed"
+version = "0.3.0"
+
 [andromeda]
 submodule = "extensions/andromeda"
 version = "0.1.2"


### PR DESCRIPTION
## Summary

Adds Applied Meta Language (AppliedML) support to Zed.

The `aml` language extension recognizes `.aml` files, provides the AppliedML grammar and highlighting, and connects to the separately installed `amlc-lsp` server. The extension does not bundle AMLC or the language server; it honors Zed's configured binary path and otherwise searches the worktree environment.

This submission points to amlc-lsp v0.3.0.

## Validation

- Tested locally as a Zed development extension.
- The extension builds with the locked `wasm32-wasip2` dependencies in the v0.3.0 upstream CI.
- `pnpm sort-extensions` completed without additional changes.
- `pnpm build` passes.
- The registry test suite passes (115 tests).

- [x] I've read the [contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
