### PR TITLE
Update greycat to v0.1.10

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1998,7 +1998,7 @@ version = "0.1.0"
 
 [greycat]
 submodule = "extensions/greycat"
-version = "0.1.9"
+version = "0.1.10"
 
 [grimaces-birthday]
 submodule = "extensions/grimaces-birthday"


### PR DESCRIPTION
## Fix
Pins `tree-sitter-greycat` `347df84`, which fixes parsing of an empty array
literal in last-element position (`[[]]`, `[1, []]`).

## Guidelines
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
