### PR TITLE
Add Autohotkey v2 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -322,6 +322,10 @@
 	path = extensions/autohotkey
 	url = https://github.com/alfredomtx/tree-sitter-autohotkey.git
 
+[submodule "extensions/autohotkey2"]
+	path = extensions/autohotkey2
+	url = https://github.com/surwall/zed-ahk2.git
+
 [submodule "extensions/autumnal-marscape"]
 	path = extensions/autumnal-marscape
 	url = https://github.com/lilyyy411/autumnal-marscape-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -330,6 +330,10 @@ version = "0.2.2"
 submodule = "extensions/autohotkey"
 version = "2.0.1"
 
+[autohotkey2]
+submodule = "extensions/autohotkey2"
+version = "0.1.0"
+
 [autumnal-marscape]
 submodule = "extensions/autumnal-marscape"
 version = "0.0.1"


### PR DESCRIPTION
The current [AutoHotkey extension](https://github.com/alfredomtx/tree-sitter-autohotkey) is built for AHK v1, while AHK v2 introduces entirely‑different syntax.

[AutoHotkey](https://www.autohotkey.com/docs/) users typically stick with v1 or migrate fully to v2. Combining both versions into one extension would demand substantial maintenance work and carries a risk of breaking the existing extension’s behaviour, so maintaining two separate extensions is the more reasonable approach.

There is an existing PR (#6469) for AutoHotkey v2 support, however it only provides syntax highlighting. This extension integrates the popular [autohotkey v2 lsp](https://github.com/thqby/vscode-autohotkey2-lsp) and also provides a debugger.

Repository: https://github.com/surwall/zed-ahk2

---
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
