### PR TITLE
Update magequery-lsp to v0.1.1

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2865,7 +2865,7 @@ version = "0.1.0"
 [magequery-lsp]
 submodule = "extensions/magequery-lsp"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.1.1"
 
 [maho-lsp]
 submodule = "extensions/maho-lsp"


### PR DESCRIPTION
Bump magequery-lsp to 0.1.1. Fixes the extension failing to start after downloading the server binary.