### PR TITLE
Add faded-prism-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1530,6 +1530,10 @@
 	path = extensions/ezio-theme
 	url = https://github.com/dsantolo/ezio-zed.git
 
+[submodule "extensions/faded-prism-theme"]
+	path = extensions/faded-prism-theme
+	url = https://github.com/ryanabx/faded-prism-zed.git
+
 [submodule "extensions/falcon-theme"]
 	path = extensions/falcon-theme
 	url = https://github.com/panxiaoan/falcon-zed-themes.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1561,6 +1561,10 @@ version = "0.0.1"
 submodule = "extensions/ezio-theme"
 version = "0.0.8"
 
+[faded-prism-theme]
+submodule = "extensions/faded-prism-theme"
+version = "1.4.1"
+
 [falcon-theme]
 submodule = "extensions/falcon-theme"
 version = "1.0.10"


### PR DESCRIPTION
Adds the [Faded
Prism](https://github.com/ryanabx/faded-prism-color-theme) theme extension.

- **Extension id:** `faded-prism-theme`
- **Version:** `1.4.1` (tag `v1.4.1`, pinned to `f27eb2bf`)
- **Themes:** `Faded Prism` (dark)
- **License:** MIT

The theme was validated against the v0.2.0 themes schema and loads correctly in Zed (manual extension load).

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
