### PR TITLE
Update asciidoc to v0.5.4

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -246,7 +246,7 @@ version = "1.0.3"
 
 [asciidoc]
 submodule = "extensions/asciidoc"
-version = "0.5.3"
+version = "0.5.4"
 
 [ashen]
 submodule = "extensions/ashen"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Updates the AsciiDoc extension to v0.5.4.

- Advances the submodule to `69e2c6b4cdf60b428549b72415173aa1e6ffceb5`
- Updates the extension registry version to `0.5.4`
- Adds section folding and includes the latest highlight-query fixes