### PR TITLE
Update ad-astra-theme to v1.1.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -40,7 +40,7 @@ version = "0.1.2"
 
 [ad-astra-theme]
 submodule = "extensions/ad-astra-theme"
-version = "1.1.0"
+version = "1.1.2"
 
 [ada]
 submodule = "extensions/ada"


### PR DESCRIPTION
## Summary

  Refine Ad Astra’s search highlighting and dark-theme syntax colors.

  - Replace saturated search-result backgrounds with subtler neutral overlays in both themes.
  - Reduce the intensity of the dark theme’s active-line highlight.
  - Use gray for attributes and white for booleans in the dark theme, making them easier to distinguish from pink accent tokens.
  - Normalize theme JSON indentation.
  - Correct the maintainer email address.
  - Update the extension from `1.1.0` to `1.1.2`.

  These changes reduce visual noise while improving syntax-token distinction and search-result readability.