### PR TITLE
Update laravel to v0.7.6

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2659,7 +2659,7 @@ version = "1.0.3"
 
 [laravel]
 submodule = "extensions/laravel"
-version = "0.7.5"
+version = "0.7.6"
 
 [laravel-official]
 submodule = "extensions/laravel-official"


### PR DESCRIPTION
Bumps `laravel` to v0.7.6.

Release notes: https://github.com/mike-bronner/zed-laravel/releases/tag/0.7.6