### PR TITLE
Add Jira MCP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2430,6 +2430,10 @@
 	path = extensions/jinja2
 	url = https://github.com/ArcherHume/jinja2-support.git
 
+[submodule "extensions/jira-mcp"]
+	path = extensions/jira-mcp
+	url = https://github.com/superkacper4/zed-jira-mcp
+
 [submodule "extensions/jira-slash-command"]
 	path = extensions/jira-slash-command
 	url = https://github.com/trbroyles1/jira-slash-command.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2483,6 +2483,10 @@ version = "1.3.0"
 submodule = "extensions/jinja2"
 version = "0.0.1"
 
+[jira-mcp]
+submodule = "extensions/jira-mcp"
+version = "0.2.0"
+
 [jira-slash-command]
 submodule = "extensions/jira-slash-command"
 version = "0.0.1"


### PR DESCRIPTION
# Jira MCP

A Zed extension that provides Jira integration through the Model Context Protocol.

## Overview

**Jira MCP** allows you to interact with Jira directly from Zed Agent Panel. 

It provides an MCP server written in Rust that connects to the Jira REST API.

The extension automatically downloads the appropriate prebuilt MCP server binary for the user's platform, so no Rust installation or manual build step is required.

#### Prebuilt binaries for:
  - macOS ARM64
  - macOS x86_64
  - Linux x86_64
  - Windows x86_64

## Configuration

After installing the extension, configure your Jira credentials in Zed:

- `jira_url` — your Jira instance URL
- `jira_email` — the email address associated with your Atlassian account
- `jira_api_token` — your Atlassian API token

## Example

Once configured, you can ask Zed's AI assistant questions such as:

> Give me a quick summary of XX-XX from Jira.

The assistant can use the Jira MCP server to retrieve the relevant issue data.

<img width="516" height="146" alt="untitled" src="https://github.com/user-attachments/assets/73092f98-f7e1-4e89-a425-4752c4d04d7f" />


- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
