### PR TITLE
Add ICU theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2250,6 +2250,10 @@
 	path = extensions/icons-modern-material
 	url = https://github.com/JosMiguelMM/icons-modern-material
 
+[submodule "extensions/icu"]
+	path = extensions/icu
+	url = https://github.com/dbkarashev/zed-icu.git
+
 [submodule "extensions/idris2"]
 	path = extensions/idris2
 	url = https://github.com/dylanbraithwaite/zed-idris2-lsp

--- a/extensions.toml
+++ b/extensions.toml
@@ -2301,6 +2301,10 @@ version = "0.3.14"
 submodule = "extensions/icons-modern-material"
 version = "1.2.0"
 
+[icu]
+submodule = "extensions/icu"
+version = "0.1.0"
+
 [idris2]
 submodule = "extensions/idris2"
 version = "0.0.1"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

ICU is a transparent theme for Zed, with dark and light variants. Tested locally as a dev extension at the submitted commit.
