### PR TITLE
Add Quint Language Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4222,6 +4222,10 @@
 	path = extensions/quint
 	url = https://github.com/zdavison/zed-quint.git
 
+[submodule "extensions/quint-language-support"]
+	path = extensions/quint-language-support
+	url = https://github.com/LegacyCodeHQ/tree-sitter-quint.git
+
 [submodule "extensions/qwark-theme"]
 	path = extensions/qwark-theme
 	url = https://github.com/biancofla/qwark.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4300,6 +4300,11 @@ version = "0.2.2"
 submodule = "extensions/quint"
 version = "0.2.0"
 
+[quint-language-support]
+submodule = "extensions/quint-language-support"
+path = "editors/zed"
+version = "0.1.0"
+
 [qwark-theme]
 submodule = "extensions/qwark-theme"
 version = "0.2.0"


### PR DESCRIPTION
Adds an independently maintained language extension for [Quint](https://quint-lang.org/).

The extension provides:

- `.qnt` and `.quint` file detection
- Syntax highlighting
- Bracket matching
- Automatic indentation
- Symbol outlines

It uses the Apache-2.0 licensed [`tree-sitter-quint`](https://github.com/LegacyCodeHQ/tree-sitter-quint) grammar, which tracks Quint 0.32.0 and has been tested against the official Quint example corpus.

The extension was installed and tested locally in Zed. The Zed registry build and all 115 registry tests also pass.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
