### PR TITLE
Update blueprint to v0.5.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -544,7 +544,7 @@ version = "1.0.0"
 
 [blueprint]
 submodule = "extensions/blueprint"
-version = "0.4.1"
+version = "0.5.0"
 
 [blueprint-dark-theme]
 submodule = "extensions/blueprint-dark-theme"


### PR DESCRIPTION
Changes:
- Use captures used by Zed for indentation
- Update grammar to [`f2b0439`](https://github.com/smrtrfszm/tree-sitter-blueprint/commit/f2b043912ffbfcf4e9e8d09709b86ab39a4b78ea)
- Update `zed_extension_api` to `0.7.0`

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
