### PR TITLE
Add True Monokai theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5202,6 +5202,10 @@
 	path = extensions/tron-legacy
 	url = https://github.com/bcomnes/zed-theme-tron-legacy.git
 
+[submodule "extensions/true-monokai-theme"]
+	path = extensions/true-monokai-theme
+	url = https://github.com/jigyansunanda/true-monokai-for-zed.git
+
 [submodule "extensions/ts-macro"]
 	path = extensions/ts-macro
 	url = https://github.com/XiNiHa/ts-macro-zed
@@ -5853,6 +5857,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/true-monokai-theme"]
-	path = extensions/true-monokai-theme
-	url = https://github.com/jigyansunanda/true-monokai-for-zed.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -5853,3 +5853,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/true-monokai-theme"]
+	path = extensions/true-monokai-theme
+	url = https://github.com/jigyansunanda/true-monokai-for-zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5310,6 +5310,10 @@ version = "0.1.0"
 submodule = "extensions/tron-legacy"
 version = "1.2.1"
 
+[true-monokai-theme]
+submodule = "extensions/true-monokai-theme"
+version = "1.0.0"
+
 [ts-macro]
 submodule = "extensions/ts-macro"
 version = "0.1.1"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

## Add True Monokai theme

### Summary
Adds **True Monokai**, a Zed theme extension recreating the original [Monokai Color Scheme](https://monokai.com/) (the classic Sublime Text / TextMate palette by **[Wimer Hazenberg](https://wimer.frl/)**), as opposed to the many Monokai **Pro** or Monokai-**inspired** variants currently in the Zed extension registry.

### Why this is distinct from existing Monokai extensions

Most Monokai-family themes already in the registry are one of two things:

1. **Monokai Pro derivatives**: `monokai-pro-ce`, `zedokai`, and others are based on the *redesigned* Monokai Pro palette (different backgrounds, different accent hues, different contrast philosophy from the original).
2. **Reinterpretations / stylized variants**: `monokai-nebula`, `monokai-sharp`, `monokai-vibrant-amped`, `monokai-reversed`, etc. are explicitly "inspired by" or remixed takes on Monokai, not reproductions of the original palette.

There is one existing extension, `monokai-og`, that also targets the original (non-Pro) palette. True Monokai differs from it in:

- **`comment` - `#75715e` vs `monokai-og`'s `#88846f`** : The original tmTheme comment color is exactly `#75715E`. `#88846F` comes from later Monokai derivatives, not the original.
- **`warning` - `#fd971f` vs `monokai-og`'s `#fafa78`** : `#fafa78` isn't in the Monokai palette at all. Orange `#FD971F` is. `monokai-og` also uses three different yellows across its warning group (`#fafa78`, `#e6db74`, `#e6db74`) rather than one consistent value: its `warning` is `#fafa78` but its `warning.background` and `warning.border` are both `#e6db74`, so three different yellows in one status group.
- **`variable.parameter` - `monokai-og` omits it entirely** : Original Monokai has an explicit "Function argument" entry at `#FD971F` italic. That's one of the scheme's signature colors, and `monokai-og`'s theme leaves parameters falling through to plain foreground. Yours has the orange.
- **`string.regex` - `#e6db74` vs `monokai-og`'s `#fd971f`** : The original has no separate regex scope, so regexes inherit the string color. Orange is a later-variant invention.
- **Terminal cyan - `#a1efe4` vs `monokai-og`'s `#66d9ef`** : `monokai-og` sets `cyan` and `blue` to the same value, collapsing two ANSI slots into one. `#A1EFE4` is the genuine Monokai sea-green that fills the cyan slot in standard Monokai terminal palettes.
- **All eight bright ANSI colors.** : `monokai-og` sets every `bright_*` identical to its base color, so bold terminal output is indistinguishable from normal. `true-monokai` real bright variants.
- **`punctuation.list_marker` - `#f8f8f2` vs `monokai-og`'s `#a6e22e`.** : the original doesn't define `markup.list`, so it falls to foreground.
- **`diff.plus` / `diff.minus` and the whole `version_control.*` group** : absent from `monokai-og`, so git gutter and inline diffs go unstyled.

### What's included in True Monokai
- `True Monokai (Default)`: faithful recreation of the classic Monokai palette and contrast
- `True Monokai (Low Contrast)`: same palette with muted foreground text for reduced eye strain in long/low-light sessions

### Checklist
- [x] Extension ID (`true-monokai-theme`) is kebab-case, unique, does not contain "zed" or "extension", and is suffixed `-theme`
- [x] Extension only provides themes (no unrelated resources)
- [x] Licensed under MIT
- [x] All user-facing text is in English
- [x] Tested manually in Zed at the submodule commit being submitted
- [x] `extensions.toml` version matches `extension.toml` version (`1.0.0`)
- [x] Ran `pnpm sort-extensions`

**GitHub Repo:** https://github.com/jigyansunanda/true-monokai-for-zed