### PR TITLE
Update lini to 0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2733,7 +2733,7 @@ version = "0.1.1"
 [lini]
 submodule = "extensions/lini"
 path = "editors/zed"
-version = "0.1.0"
+version = "0.2.0"
 
 [linkerscript]
 submodule = "extensions/linkerscript"


### PR DESCRIPTION
Bumps the Lini extension to 0.2.0.

- The tree-sitter grammar gains a rule for `--name:` variable declarations; the regenerated parser (ABI 14) parses every sample in the Lini repo with zero ERROR nodes.
- `highlights.scm` regenerated from the 1.0 property ledger.
- Grammar pin in `extension.toml` moved to the commit carrying the regenerated parser.