### PR TITLE
Add GJS Debugger Extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1878,6 +1878,10 @@
 	path = extensions/gitlab-web-ide-theme
 	url = https://github.com/karnauhmax/zed-gitlab-web-ide-theme.git
 
+[submodule "extensions/gjs-debugger"]
+	path = extensions/gjs-debugger
+	url = https://gitlab.gnome.org/vixalien/gjs-dap
+
 [submodule "extensions/glass-theme"]
 	path = extensions/glass-theme
 	url = https://github.com/b4bury/zed-glass.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1915,6 +1915,10 @@ version = "1.0.1"
 submodule = "extensions/gitlab-web-ide-theme"
 version = "0.1.0"
 
+[gjs-debugger]
+submodule = "extensions/gjs-debugger"
+version = "0.1.0"
+
 [glass-theme]
 submodule = "extensions/glass-theme"
 version = "0.1.0"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Part of Google Summer of Code 2026, here's an outline of the project: https://www.vixalien.com/blog/gjs-dap/
