### PR TITLE
Update kokedera-theme to v2.0.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2572,7 +2572,7 @@
 
 [submodule "extensions/kokedera-theme"]
 	path = extensions/kokedera-theme
-	url = https://github.com/7th-Layer/kokedera-theme-extension-zed.git
+	url = https://github.com/lastdescent/kokedera-theme-extension-zed.git
 
 [submodule "extensions/kotlin"]
 	path = extensions/kotlin

--- a/extensions.toml
+++ b/extensions.toml
@@ -2627,7 +2627,7 @@ version = "0.0.1"
 
 [kokedera-theme]
 submodule = "extensions/kokedera-theme"
-version = "2.0.0"
+version = "2.0.1"
 
 [kotlin]
 submodule = "extensions/kotlin"


### PR DESCRIPTION
Updates Kokedera Theme from v2.0.0 to v2.0.1 so the extension listing uses the current **Kokedera Theme** name and description of its nine palettes. This release also refreshes the README, adds the shared golem logo, updates the variant descriptions, and clarifies installation and local development instructions.

The nine theme definitions, colors and selectable theme names are unchanged from v2.0.0.

- Sets the registry version to `2.0.1` and pins the submodule to [5a4c53e](https://github.com/lastdescent/kokedera-theme-extension-zed/commit/5a4c53e95d01e5cb77ee6cf9ed74b35fdf9c9bc8).
- Updates the submodule URL to the repository's current owner, `lastdescent`.

**Validation:** All nine variants pass Zed's theme JSON schema. Registry, manifest, version, license and submodule checks pass, along with `pnpm build`, all 115 tests and `pnpm sort-extensions`.
