### PR TITLE
Add Decl extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1162,6 +1162,10 @@
 	path = extensions/dbt
 	url = https://github.com/kylejbrk/zed-dbt.git
 
+[submodule "extensions/decl"]
+	path = extensions/decl
+	url = https://github.com/luuvish/decl-lang
+
 [submodule "extensions/decorative-stitch"]
 	path = extensions/decorative-stitch
 	url = https://github.com/keithrowell/zed-theme-decorative-stitch.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -1185,6 +1185,11 @@ version = "0.0.1"
 submodule = "extensions/dbt"
 version = "0.1.2"
 
+[decl]
+submodule = "extensions/decl"
+path = "extension/zed"
+version = "0.3.0"
+
 [decorative-stitch]
 submodule = "extensions/decorative-stitch"
 version = "1.0.0"


### PR DESCRIPTION
Adds the Decl extension: syntax highlighting, outline, indents, brackets, and runnables for Decl (`.decl`), a declarative language for describing, generating, and validating structured data, plus its language server `decl-lsp`, which the extension finds on `PATH` or a setting, or downloads from the project's GitHub releases (macOS, Linux, Windows; arm64 and x86_64).

- Repository: https://github.com/luuvish/decl-lang (the extension lives in `extension/zed`, hence `path`)
- License: MIT (`extension/zed/LICENSE`)
- Tested as a dev extension in Zed 1.18.1 at the submitted commit: the grammar compiles from the pinned revision, highlighting and diagnostics work, and the server download from the release works.
- The same extension is published for VS Code (Marketplace and Open VSX as `luuvish.vscode-decl`).

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
