### PR TITLE
Update aptos-move to v0.0.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -193,7 +193,7 @@ version = "1.9.1"
 
 [aptos-move]
 submodule = "extensions/aptos-move"
-version = "0.0.2"
+version = "0.0.3"
 
 [aquaflow-theme]
 submodule = "extensions/aquaflow-theme"


### PR DESCRIPTION
## Summary

- update the `aptos-move` extension registry version to `0.0.3`
- advance the submodule from `4ceeee9` to `0xbe1/aptos-move-zed-extension@e317982`
- add complete `Move.toml` language support, receiver-style method-call highlighting, updated Rust/CI validation, and a Windows language-server download fix

## Validation

Extension repository:

- `cargo fmt --check`
- `cargo clippy --locked --target wasm32-wasip2 -- -D warnings`
- `cargo test --locked`
- `cargo build --locked --target wasm32-wasip2 --release`
- all TOML files parsed with the registry parser
- all Tree-sitter queries validated and all Move/Move.toml fixtures parsed cleanly with `tree-sitter-cli@0.27`

Zed extensions registry:

- `pnpm sort-extensions`
- `pnpm build`
- `pnpm test` (115 tests passed)

The local registry packaging step requires the Linux-only `zed-extension` CI binary and is left to the official PR package check.