### PR TITLE
Add Lumenhush Theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2778,6 +2778,10 @@
 	path = extensions/lume-theme
 	url = https://github.com/danfry1/lume-zed-theme.git
 
+[submodule "extensions/lumenhush-theme"]
+	path = extensions/lumenhush-theme
+	url = https://github.com/pedronhamirre/lumenhush-theme.git
+
 [submodule "extensions/lumin-theme"]
 	path = extensions/lumin-theme
 	url = https://github.com/frypan05/Lumin.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2838,6 +2838,10 @@ version = "0.4.0"
 submodule = "extensions/lume-theme"
 version = "0.1.0"
 
+[lumenhush-theme]
+submodule = "extensions/lumenhush-theme"
+version = "0.0.1"
+
 [lumin-theme]
 submodule = "extensions/lumin-theme"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

- Add the Lumenhush Theme extension.
- Provide a calm dark theme with warm accents and low-contrast color separation.
- Link the extension to the public repository at https://github.com/pedronhamirre/lumenhush-theme.

## Notes

This is a theme-only extension with an MIT license. The extension manifest and theme JSON were validated locally, and the installer dry-run successfully extracted the renamed theme file.
