### PR TITLE
Add ARB language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -198,6 +198,10 @@
 	path = extensions/aquarium-theme
 	url = https://github.com/biaqat/aquarium-theme-zed.git
 
+[submodule "extensions/arb"]
+	path = extensions/arb
+	url = https://github.com/AlexanderRavenscroft/arb.git
+
 [submodule "extensions/arc-dark-theme"]
 	path = extensions/arc-dark-theme
 	url = https://github.com/wcygan/zed-arc-dark-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -203,6 +203,10 @@ version = "1.0.3"
 submodule = "extensions/aquarium-theme"
 version = "0.8.0"
 
+[arb]
+submodule = "extensions/arb"
+version = "1.0.0"
+
 [arc-dark-theme]
 submodule = "extensions/arc-dark-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds language support for Flutter ARB (`.arb`) localization files,
including syntax highlighting, metadata completions, diagnostics,
metadata quick fixes, and snippets.

Uses a pinned Tree-sitter JSON grammar and installs
`arb-language-server@1.0.0` through Zed's extension API.

Tested locally in Zed using the exact submitted submodule checkout.
Zed version: 1.18.1
OS: Windows 11

See the [README](https://github.com/AlexanderRavenscroft/arb#readme)
for setup, features, and current limitations.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
