### PR TITLE
Update stylelint to v3.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -4941,7 +4941,7 @@ version = "0.0.1"
 
 [stylelint]
 submodule = "extensions/stylelint"
-version = "3.1.0"
+version = "3.2.0"
 
 [styx]
 submodule = "extensions/styx"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Changes:

* **lsp:** Allow opting out of the managed language server download via `lsp.stylelint-lsp.settings.download`
  * Setting `download` to `false` makes the extension only use `binary.path` or the worktree `PATH`, and fail with an explicit error when neither provides the binary, instead of silently falling back to the extension-managed download.
  * Omitting the setting or using `true` preserves the managed fallback.
