### PR TITLE
Add aster extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5853,3 +5853,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/aster"]
+	path = extensions/aster
+	url = https://github.com/Zfinix/aster.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -270,6 +270,10 @@
 	path = extensions/ast-grep
 	url = https://github.com/mathieulj/ast-grep-zed
 
+[submodule "extensions/aster"]
+	path = extensions/aster
+	url = https://github.com/Zfinix/aster.git
+
 [submodule "extensions/asteroid"]
 	path = extensions/asteroid
 	url = https://github.com/webhooked/asteroid-zed
@@ -5853,6 +5857,3 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
-[submodule "extensions/aster"]
-	path = extensions/aster
-	url = https://github.com/Zfinix/aster.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -244,10 +244,6 @@ version = "0.4.0"
 submodule = "extensions/arturo"
 version = "1.0.3"
 
-[aster]
-submodule = "extensions/aster"
-version = "0.1.0"
-
 [asciidoc]
 submodule = "extensions/asciidoc"
 version = "0.5.3"
@@ -278,6 +274,10 @@ version = "0.1.0"
 
 [ast-grep]
 submodule = "extensions/ast-grep"
+version = "0.1.0"
+
+[aster]
+submodule = "extensions/aster"
 version = "0.1.0"
 
 [asteroid]

--- a/extensions.toml
+++ b/extensions.toml
@@ -244,6 +244,10 @@ version = "0.4.0"
 submodule = "extensions/arturo"
 version = "1.0.3"
 
+[aster]
+submodule = "extensions/aster"
+version = "0.1.0"
+
 [asciidoc]
 submodule = "extensions/asciidoc"
 version = "0.5.3"

--- a/extensions.toml
+++ b/extensions.toml
@@ -278,6 +278,7 @@ version = "0.1.0"
 
 [aster]
 submodule = "extensions/aster"
+path = "editors/zed"
 version = "0.1.0"
 
 [asteroid]


### PR DESCRIPTION
Adds the **Aster** extension (id: `aster`, version 0.1.0, Apache-2.0).

- Repository: https://github.com/Zfinix/aster, submodule at `extensions/aster`
- Adds a `/aster-review` slash command to the Zed assistant panel that runs an Aster review of the current changes and inserts the findings
- Builds clean against the Zed extension API (wasm target, verified locally)