### PR TITLE
Added Monkey C language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3242,6 +3242,10 @@
 	path = extensions/molten-theme
 	url = https://github.com/vaqxai/zed-molten-theme.git
 
+[submodule "extensions/monkey-c-ce"]
+	path = extensions/monkey-c-ce
+	url = https://github.com/egrook/monkey-c-zed.git
+
 [submodule "extensions/monobrut-theme"]
 	path = extensions/monobrut-theme
 	url = https://github.com/akullpp/monobrut-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3306,6 +3306,10 @@ version = "0.0.1"
 submodule = "extensions/molten-theme"
 version = "1.0.0"
 
+[monkey-c-ce]
+submodule = "extensions/monkey-c-ce"
+version = "0.1.0"
+
 [monobrut-theme]
 submodule = "extensions/monobrut-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds **Monkey C** — language support for [Monkey C](https://developer.garmin.com/connect-iq/monkey-c/),
the language used for Garmin Connect IQ apps.

Repository: https://github.com/egrook/monkey-c-zed

A grammar-only language extension: syntax highlighting, outline, indents, brackets,
text objects and snippets for `.mc` files. No Rust code, since there is no open-source
Monkey C language server to wrap.

The extension ID is `monkey-c-ce` (community edition) rather than `monkey-c`. Garmin
publishes an official Monkey C extension for VS Code but nothing for Zed; since Zed IDs
are global and permanent, this leaves `monkey-c` free in case that ever changes.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
