### PR TITLE
Add alabaster-official color theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -122,6 +122,10 @@
 	path = extensions/alabaster-dark
 	url = https://github.com/findrakecil/alabaster-dark-zed-theme.git
 
+[submodule "extensions/alabaster-official"]
+	path = extensions/alabaster-official
+	url = https://github.com/tonsky/zed-theme-alabaster.git
+
 [submodule "extensions/alpental-theme"]
 	path = extensions/alpental-theme
 	url = https://github.com/ascarter/zed-alpental-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -126,6 +126,10 @@ version = "0.0.5"
 submodule = "extensions/alabaster-dark"
 version = "2.0.2"
 
+[alabaster-official]
+submodule = "extensions/alabaster-official"
+version = "0.1.0"
+
 [alpental-theme]
 submodule = "extensions/alpental-theme"
 version = "0.0.9"


### PR DESCRIPTION
I used "official" as part of the id since "alabaster" was already taken and I am the original author of Alabaster themes https://github.com/search?q=owner%3Atonsky+alabaster&type=repositories

<!-- Please confirm the checklist below, then remove this comment. -->

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
