### PR TITLE
Add umbra-charcoal-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5286,6 +5286,10 @@
 	path = extensions/ultraviolet-theme
 	url = https://github.com/Gurvirr/zed-ultraViolet.git
 
+[submodule "extensions/umbra-charcoal-theme"]
+	path = extensions/umbra-charcoal-theme
+	url = https://github.com/eduardoaugustolb/umbra.git
+
 [submodule "extensions/umbra-theme"]
 	path = extensions/umbra-theme
 	url = https://github.com/zaitsev-av/umbra

--- a/extensions.toml
+++ b/extensions.toml
@@ -5395,6 +5395,11 @@ version = "0.0.2"
 submodule = "extensions/ultraviolet-theme"
 version = "0.2.0"
 
+[umbra-charcoal-theme]
+submodule = "extensions/umbra-charcoal-theme"
+path = "themes/zed/umbra"
+version = "0.7.0"
+
 [umbra-theme]
 submodule = "extensions/umbra-theme"
 version = "0.1.1"


### PR DESCRIPTION
Dark charcoal theme with semantic accents and controlled color.

- Extension ID: `umbra-charcoal-theme` (note: `umbra-theme` is already taken)
- Submodule: https://github.com/eduardoaugustolb/umbra (public, commit on `main`)
- Extension path within repo: `themes/zed/umbra` (monorepo layout, license included in the extension directory)
- Version: 0.7.0 (matches `extension.toml`)
- License: MIT (included at `themes/zed/umbra/LICENSE`)
- Contents: themes only (single `Umbra` dark theme + README/CHANGELOG/screenshots)

Tested locally by copying `themes/zed/umbra/umbra.json` into Zed's themes directory and selecting Umbra.