### PR TITLE
Update codestackr to v0.0.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -890,7 +890,7 @@ version = "0.0.6"
 
 [codestackr]
 submodule = "extensions/codestackr"
-version = "0.0.1"
+version = "0.0.2"
 
 [coding-in-the-sun-theme]
 submodule = "extensions/coding-in-the-sun-theme"


### PR DESCRIPTION
Updates the codestackr extension to v0.0.2.

- Bumps submodule to https://github.com/Pjort/codestackr-zed/commit/9335c25c4b38ba2f5766d48e5889baf21dc44773
- New in this version: updated UI colors, version control colors, and diff highlights