### PR TITLE
Add sqldex language server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4794,6 +4794,10 @@
 	path = extensions/sqlc-snippets
 	url = https://github.com/NarmadaWeb/sqlc-snippets-zed.git
 
+[submodule "extensions/sqldex-lsp"]
+	path = extensions/sqldex-lsp
+	url = https://github.com/sdvallejo/sqldex.git
+
 [submodule "extensions/sqlmesh"]
 	path = extensions/sqlmesh
 	url = https://github.com/GitToby/zed-sqlmesh.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4887,6 +4887,11 @@ version = "0.1.2"
 submodule = "extensions/sqlc-snippets"
 version = "0.2.0"
 
+[sqldex-lsp]
+submodule = "extensions/sqldex-lsp"
+path = "editors/zed"
+version = "0.1.0"
+
 [sqlmesh]
 submodule = "extensions/sqlmesh"
 version = "0.1.4"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds `sqldex-lsp`, a Zed client for the sqldex language server.

sqldex is static analysis for MySQL schemas that live as `.sql` files in a repository — no live database involved. It reads the repo's DDL into a catalog of tables, columns, indexes, foreign keys, triggers and routines, and runs lint rules against it, so the diagnostics Zed shows are the same ones `sqldex check` reports in CI. What gets reported is decided by the project's own `.sqldex.json`, not by editor settings.

The extension doesn't bundle the server. It uses a `sqldex-lsp` already on `PATH` if there is one, and otherwise installs `@sqldex/lsp` from npm through the `npm:install` capability.

The extension lives at `editors/zed` inside the sqldex monorepo, which is what the `path` field in the `extensions.toml` entry points at.

Tested manually in Zed at the submitted commit, installed as a dev extension.