### PR TITLE
Add grok-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1970,6 +1970,10 @@
 	path = extensions/grit
 	url = https://github.com/mantou132/zed-grit
 
+[submodule "extensions/grok-theme"]
+	path = extensions/grok-theme
+	url = https://github.com/EngineerEthan/zed-grok-theme.git
+
 [submodule "extensions/groovy"]
 	path = extensions/groovy
 	url = https://github.com/valentinegb/zed-groovy.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2012,6 +2012,10 @@ version = "0.1.0"
 submodule = "extensions/grit"
 version = "0.0.1"
 
+[grok-theme]
+submodule = "extensions/grok-theme"
+version = "0.0.1"
+
 [groovy]
 submodule = "extensions/groovy"
 version = "1.3.0"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds [Grok Theme](https://github.com/EngineerEthan/zed-grok-theme): **Grok Night** and **Grok Day**, the [Grok Build](https://docs.x.ai/build) TUI palette from [xAI](https://x.ai) — the lab behind [Grok](https://grok.com) — ported to Zed.

Neutral gray chrome with [Tokyo Night](https://github.com/enkia/tokyo-night-vscode-theme) accents, the same pairing Grok Build uses. Visual family of [Grok](https://grok.com), [xAI](https://x.ai), [SpaceX](https://www.spacex.com), [Tesla](https://www.tesla.com), and [X](https://x.com).

Not an official xAI, SpaceX, or X product.

- **ID:** `grok-theme`
- **Version:** `0.0.1`
- **Themes:** Grok Night (dark), Grok Day (light)
- **License:** MIT
- **Source:** https://github.com/EngineerEthan/zed-grok-theme
- **Palette:** [xai-org/grok-build](https://github.com/xai-org/grok-build) · [theming docs](https://docs.x.ai/build/features/theming)

Tested locally as a Zed 1.18.1 dev extension. Ran `pnpm sort-extensions`.
