### PR TITLE
Add tcl-lsp extension v2.2.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5026,6 +5026,10 @@
 	path = extensions/tcl
 	url = https://github.com/richnou/kissb-zed-tcl.git
 
+[submodule "extensions/tcl-lsp"]
+	path = extensions/tcl-lsp
+	url = https://github.com/bitwisecook/tcl-lsp.git
+
 [submodule "extensions/tech49-theme"]
 	path = extensions/tech49-theme
 	url = https://github.com/timdang/tech49_theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5127,6 +5127,11 @@ version = "1.0.0"
 submodule = "extensions/tcl"
 version = "0.0.2"
 
+[tcl-lsp]
+submodule = "extensions/tcl-lsp"
+path = "editors/zed"
+version = "2.2.3"
+
 [tech49-theme]
 submodule = "extensions/tech49-theme"
 version = "0.2.3"


### PR DESCRIPTION
Add the Tcl LSP extension at v2.2.3.

Release: https://github.com/bitwisecook/tcl-lsp/releases/tag/v2.2.3
