### PR TITLE
Add scalino-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4486,6 +4486,10 @@
 	path = extensions/scala
 	url = https://github.com/scalameta/metals-zed.git
 
+[submodule "extensions/scalino-lsp"]
+	path = extensions/scalino-lsp
+	url = https://github.com/lolgab/scalino.git
+
 [submodule "extensions/schemalock-lsp"]
 	path = extensions/schemalock-lsp
 	url = https://github.com/schemalock/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4571,6 +4571,11 @@ version = "1.0.0"
 submodule = "extensions/scala"
 version = "0.2.3"
 
+[scalino-lsp]
+submodule = "extensions/scalino-lsp"
+path = "zed-extension"
+version = "0.0.1"
+
 [schemalock-lsp]
 submodule = "extensions/schemalock-lsp"
 version = "0.1.0"


### PR DESCRIPTION
## Description

Adds **Scalino LSP**, a JVM-free Scala language server extension backed by [`scalino-lsp`](https://github.com/lolgab/scalino) -- diagnostics/hover/definition/references/rename/completion/documentSymbol/workspace-symbol without Metals' JVM dependency. `scalino-lsp` itself is self-hosted: compiled by a patched `dotc` to NIR and linked into a real Scala Native executable, no JVM anywhere in the binary.

Defines its own `Scala (scalino)` language (grammar copied from [metals-zed](https://github.com/scalameta/metals-zed), see `languages/scala/NOTICE`), deliberately named differently from metals-zed's own `Scala` language and scoped to only `.scala` files, so both extensions can coexist without Zed having to arbitrarily pick a winner for `.scala` files on extension-load order.

Verified end-to-end against real Zed -- see [`docs/findings.md`](https://github.com/lolgab/scalino/blob/main/docs/findings.md)'s "JVM-free language server (LSP)" section for the real bugs found and fixed along the way, and [`zed-extension/README.md`](https://github.com/lolgab/scalino/blob/main/zed-extension/README.md) for install/setup steps.

## Checklist

- [x] Extension tested locally as a dev extension in Zed
- [x] `extension.toml`'s `version` matches the `extensions.toml` entry (`0.0.1`)
- [x] License: Apache 2.0, present at the extension's own subdirectory root (`zed-extension/LICENSE`)
- [x] Submodule uses an HTTPS URL, checked-out commit is on the `main` branch (not detached)
- [x] `extensions.toml`/`.gitmodules` entries inserted in sorted order