### PR TITLE
Update vscode-classic-themes to v0.4.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5630,7 +5630,7 @@ version = "0.0.1"
 
 [vscode-classic-themes]
 submodule = "extensions/vscode-classic-themes"
-version = "0.4.1"
+version = "0.4.2"
 
 [vscode-dark-high-contrast]
 submodule = "extensions/vscode-dark-high-contrast"


### PR DESCRIPTION
Updates the **VS Code Classics** theme extension to v0.4.2.

Changes since 0.4.1:
- Sync theme sources to VS Code 1.136.1. Dark 2026 / Light 2026 list hover, selection and focus colors follow upstream's switch to neutral overlays; Light 2026 scrollbar and minimap sliders darken per upstream.
- Derived alpha now scales from the source color instead of replacing it, fixing near-opaque active/selected element states in Dark 2026, Light 2026 and Tomorrow Night Blue.
- Apply VS Code's default `editor.selectionBackground` (#264F78 dark, #ADD6FF light, #0F4A85 HC light) to the default-family themes that omit it in their JSON, instead of a gray fallback.

Source: https://github.com/alanisme/vscode-themes-for-zed
