### PR TITLE
Add ry-lsp 0.9.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4470,6 +4470,10 @@
 	path = extensions/rux
 	url = https://github.com/rux-lang/Zed.git
 
+[submodule "extensions/ry-lsp"]
+	path = extensions/ry-lsp
+	url = https://github.com/sims1253/ry
+
 [submodule "extensions/s-dark-theme"]
 	path = extensions/s-dark-theme
 	url = https://github.com/sinamombeiny/S-DarkTheme.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4555,6 +4555,11 @@ version = "0.1.0"
 submodule = "extensions/rux"
 version = "0.1.0"
 
+[ry-lsp]
+submodule = "extensions/ry-lsp"
+path = "editors/zed"
+version = "0.9.0"
+
 [s-dark-theme]
 submodule = "extensions/s-dark-theme"
 version = "3.0.0"


### PR DESCRIPTION
Adds ry, a static type checker and language server for R, as `ry-lsp` version 0.9.0. It supplies diagnostics, inferred type hints, and suppression code actions alongside the existing R language extension.

The extension lives in `editors/zed` within the linked repository. It downloads the server from GitHub releases and verifies executable SHA-256 sidecars, including cached binaries on restart. Explicitly configured and PATH binaries take precedence. Core v0.9.0 and its six platform archives and executable checksum sidecars are published.

Validation:
- All 11 Rust extension tests passed, and the `wasm32-wasip2` build passed.
- The maintainer manually tested the submitted source commit `db51dfe` in Zed 1.15.0 on Windows x64: automatic server download, expected RY040 diagnostic, clearing the diagnostic after an edit, and restoring it after restarting Zed all worked.
- `pnpm sort-extensions` completed.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
