### PR TITLE
Update catppuccin to v0.2.26

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -697,7 +697,7 @@ version = "1.0.1"
 
 [catppuccin]
 submodule = "extensions/catppuccin"
-version = "0.2.25"
+version = "0.2.26"
 
 [catppuccin-black-theme]
 submodule = "extensions/catppuccin-black-theme"


### PR DESCRIPTION
Update Catppuccin to [v0.2.26](https://github.com/catppuccin/zed/releases/tag/v0.2.26), with the submodule pinned to release commit `9e24b02f32ca6bba7ac0cfb1bf758b1ccd8ee5cb` and the registry version matching its manifest.

The release passed Whiskers and JSON checks, with 28 generated assets verified and a smoke check in Zed 1.18.1 across the four flavors, blue accent, and a no-italics variant.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
