### PR TITLE
Update catppuccin-icons to v1.24.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -713,7 +713,7 @@ version = "0.1.1"
 
 [catppuccin-icons]
 submodule = "extensions/catppuccin-icons"
-version = "1.23.1"
+version = "1.24.0"
 
 [cds-lsp]
 submodule = "extensions/cds-lsp"


### PR DESCRIPTION
Release notes:

https://github.com/catppuccin/zed-icons/releases/tag/v1.24.0