### PR TITLE
Add pogo-django-orm-lsp extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4022,6 +4022,10 @@
 	path = extensions/po
 	url = https://git.disroot.org/gemmaro/zed-po.git
 
+[submodule "extensions/pogo-django-orm-lsp"]
+	path = extensions/pogo-django-orm-lsp
+	url = https://github.com/amirhasanzadehpy/Pogo.git
+
 [submodule "extensions/poimandres"]
 	path = extensions/poimandres
 	url = https://github.com/mshaugh/poimandres.zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4095,6 +4095,11 @@ version = "0.1.2"
 submodule = "extensions/po"
 version = "0.1.0"
 
+[pogo-django-orm-lsp]
+submodule = "extensions/pogo-django-orm-lsp"
+path = "client/zed"
+version = "0.1.0"
+
 [poimandres]
 submodule = "extensions/poimandres"
 version = "0.0.4"


### PR DESCRIPTION
Adds Pogo, a Django ORM language server, as a Zed extension.

Django builds its ORM schema at runtime — installed apps, abstract fields, custom managers, and settings all shape what a query can express — so static analysis alone cannot see it. Pogo starts the project's Django, inspects the initialized app registry, and serves completion, hover, signature help, diagnostics, and go-to-definition for field paths, lookups, relations, reverse accessors, `Model.Meta`, and QuerySet methods.

It registers as an additional Python language server and runs alongside Pyright, BasedPyright, or Ruff rather than replacing one. It deliberately does not provide general Python typing, formatting, refactoring, or workspace symbols.

- Repository: https://github.com/amirhasanzadehpy/Pogo
- Extension source: `client/zed`
- Extension docs: [`client/zed/README.md`](https://github.com/amirhasanzadehpy/Pogo/blob/main/client/zed/README.md)
- License: MIT, at `client/zed/LICENSE`

### Compliance notes

- **Language server only**, so the ID carries the `-lsp` suffix. No grammar is included; it attaches to Zed's built-in Python language.
- **The server is not bundled.** The extension resolves `lsp.pogo.binary.path`, then a `pogo` on the worktree `$PATH`, then downloads the archive for the current platform from the project's GitHub releases into the extension work directory. Superseded downloads are removed.
- **Nothing outside the extension environment is read or written.** Project inspection goes through the extension API (`worktree.read_text_file`, `which`, `shell_env`); the only filesystem writes are the downloaded server under the work directory.
- Configuration is forwarded to the server as `djangoOrm` initialization options; the extension implements no Django logic of its own.
- Requires Zed 1.17 or newer, the first version to honor the LSP `filterText` that ORM path completion depends on.

Tested manually as a dev extension in Zed 1.18.1 against a production Django project: completion and hover inside `filter()` paths, go-to-definition on fields and relations, and diagnostics on invalid lookups.
