### PR TITLE
Add LazyVim Icons icon theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2626,6 +2626,10 @@
 	path = extensions/latte
 	url = https://github.com/josbeir/zed-latte.git
 
+[submodule "extensions/lazyvim-icons"]
+	path = extensions/lazyvim-icons
+	url = https://github.com/gabrielrcosta1/lazyvim-icons.git
+
 [submodule "extensions/lazyvim-theme"]
 	path = extensions/lazyvim-theme
 	url = https://github.com/BadRat-in/zed-lazyvim-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2682,6 +2682,11 @@ version = "0.0.1"
 submodule = "extensions/latte"
 version = "0.1.0"
 
+[lazyvim-icons]
+submodule = "extensions/lazyvim-icons"
+path = "dist/lazyvim-icons"
+version = "0.1.0"
+
 [lazyvim-theme]
 submodule = "extensions/lazyvim-theme"
 version = "0.1.0"


### PR DESCRIPTION
## LazyVim Icons

An icon theme that reproduces what a LazyVim user sees in their file explorer:
the glyphs [mini.icons](https://github.com/nvim-mini/mini.icons) returns for
each file type, in the colours
[tokyonight.nvim](https://github.com/folke/tokyonight.nvim) gives their
highlight groups. Nothing in the registry covers this — the published icon
themes are ports of other icon sets.

Nothing is hand-drawn. The mappings and colours are dumped out of headless
Neovim running the real plugins (LazyVim, mini.icons, snacks.nvim,
tokyonight.nvim at pinned commits), and each glyph's outline is traced from a
Nerd Font with fontTools — one polychrome SVG per (glyph, colour) pair, since
Zed renders icon-theme icons as images and therefore keeps their colours. The
generator lives in the same repository (`scripts/`), outside the extension
directory, so the whole thing can be regenerated when upstream changes.

- 1387 file suffixes, 570 exact file names, 68 named directories
- 596 SVGs, ~1 MB
- Tested as a dev extension at this commit on Zed 1.18.0 (stable), macOS 15 / arm64

Licence: MIT for the extension. `NOTICE` credits every upstream icon set with
its version and licence — MaterialDesign (Apache-2.0, 239 glyphs), Seti and
original (MIT, 43), Devicons (MIT, 13), Octicons (MIT, 5), Font Logos
(Unlicense, 4), Font Awesome (CC BY 4.0, 1). That file is generated by mapping
every shipped codepoint through Nerd Fonts' own `glyphnames.json` and reading
the licence table from `src/glyphs/README.md` in the nerd-fonts repository, so
the attribution matches exactly what is in the package.

Only icon-set codepoints are traced (U+E000–U+F8FF, U+F0000+); no letterform of
the underlying typeface is included or redistributed.
