### PR TITLE
Update mcp-server-zuraffa to v6.2.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3192,7 +3192,7 @@ version = "0.0.1"
 
 [mcp-server-zuraffa]
 submodule = "extensions/mcp-server-zuraffa"
-version = "6.1.0"
+version = "6.2.2"
 
 [mdias-oled-theme]
 submodule = "extensions/mdias-oled-theme"


### PR DESCRIPTION
Release notes:

https://github.com/arrrrny/zuraffa-zed/releases/tag/v6.2.2