### PR TITLE
Add Inkit extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2298,6 +2298,10 @@
 	path = extensions/ink
 	url = https://github.com/yuna0x0/zed-ink.git
 
+[submodule "extensions/inkit"]
+	path = extensions/inkit
+	url = https://github.com/waterblower/inkit.git
+
 [submodule "extensions/inko"]
 	path = extensions/inko
 	url = https://github.com/inko-lang/zed.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2350,6 +2350,10 @@ version = "0.0.9"
 submodule = "extensions/ink"
 version = "0.0.2"
 
+[inkit]
+submodule = "extensions/inkit"
+version = "0.3.0"
+
 [inko]
 submodule = "extensions/inko"
 version = "0.0.1"


### PR DESCRIPTION
Adds Inkit (`inkit`) 0.3.0 for the Ink narrative scripting language.

Includes an original Tree-sitter grammar, highlighting, outline, definition/reference navigation, completion, and local image hover previews. The Rust adapter downloads platform-specific `ink-lsp` binaries from https://github.com/waterblower/inkit/releases; no server executable is bundled in the extension. The repository includes an MIT license and a public, pinned grammar source.

There is already an `ink` extension in the registry. But this project does not seem active and is missing some features that I need.

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md). The overlap and remaining release-installation validation are disclosed above.
