### PR TITLE
Add mdrev-language-server extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3134,6 +3134,10 @@
 	path = extensions/mdias-oled-theme
 	url = https://github.com/mcdays94/zed-vaporware-oled-theme.git
 
+[submodule "extensions/mdrev-language-server"]
+	path = extensions/mdrev-language-server
+	url = https://github.com/esivres/mdrev.git
+
 [submodule "extensions/mdx"]
 	path = extensions/mdx
 	url = https://github.com/srazzak/zed-mdx.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3198,6 +3198,11 @@ version = "6.1.0"
 submodule = "extensions/mdias-oled-theme"
 version = "0.1.0"
 
+[mdrev-language-server]
+submodule = "extensions/mdrev-language-server"
+path = "zed-extension"
+version = "0.1.1"
+
 [mdx]
 submodule = "extensions/mdx"
 version = "0.4.0"


### PR DESCRIPTION
Adds [mdrev](https://github.com/esivres/mdrev), a language server that brings review comments to Markdown documents.

Comments live in a sidecar file next to the document ([MRSF](https://sidemark.org)), so the Markdown itself is never modified — diagrams and tables survive a review untouched. The server publishes each open comment as a diagnostic anchored to the text it is about, and offers code actions to apply a suggested edit, close a thread, or move a comment typed into the document as CriticMarkup into the review.

The extension itself is thin: it resolves the `mdrev` binary from LSP settings, then `PATH` (Homebrew, Scoop, `go install`), and otherwise downloads the release matching the platform. Nothing is bundled.

- Tested as a dev extension at the submitted commit, including on a machine with no `mdrev` on `PATH`, where it downloads the release and starts.
- Licensed MIT, with the licence in the extension subdirectory.
- The id says it provides only a language server.
- Zed runs several servers per language, so this works alongside marksman or markdownlint rather than replacing them.