### PR TITLE
Add ANTLR4 language support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -166,6 +166,10 @@
 	path = extensions/anticuus
 	url = https://codeberg.org/juanmilkah/anticuus.git
 
+[submodule "extensions/antlr4"]
+	path = extensions/antlr4
+	url = https://github.com/jaddenki/zed-antlr4.git
+
 [submodule "extensions/anysphere-theme"]
 	path = extensions/anysphere-theme
 	url = https://github.com/stpn48/anysphere-zed-theme

--- a/extensions.toml
+++ b/extensions.toml
@@ -170,6 +170,10 @@ version = "1.0.0"
 submodule = "extensions/anticuus"
 version = "0.0.1"
 
+[antlr4]
+submodule = "extensions/antlr4"
+version = "0.1.0"
+
 [anysphere-theme]
 submodule = "extensions/anysphere-theme"
 version = "0.0.1"


### PR DESCRIPTION
Adds ANTLR4 support for `.g4` files: syntax highlighting, indentation, bracket matching, and comment toggling.

The extension uses a pinned revision of `lakitu/tree-sitter-antlr4` and is MIT licensed. It has been installed and tested locally in Zed. Parser compilation and query checks pass on three example grammars.

Validation: `pnpm sort-extensions`, `pnpm build`, and `pnpm test` (115 tests passed).

- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
