### PR TITLE
Update cartan to v0.7.2

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -681,7 +681,7 @@ version = "0.4.1"
 
 [cartan]
 submodule = "extensions/cartan"
-version = "0.7.1"
+version = "0.7.2"
 
 [carve]
 submodule = "extensions/carve"


### PR DESCRIPTION
Updates the cartan extension at 0.7.2: language support for cartan documents (`.cart`) — the tree-sitter grammar from cartan-lang/tree-sitter-cartan and the `cartan lsp` language server, which the extension starts from the user's PATH. The extension repository (https://github.com/cartan-lang/zed-cartan) is refreshed per release of the language, in lockstep with its version.