### PR TITLE
Update minizinc to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -3257,7 +3257,7 @@ version = "1.0.0"
 
 [minizinc]
 submodule = "extensions/minizinc"
-version = "0.1.0"
+version = "0.2.0"
 
 [mint-theme]
 submodule = "extensions/mint-theme"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Updates the MiniZinc extension from 0.1.0 to 0.2.0.

The extension now runs `shackle-ls`, the language server published alongside the shackle
compiler, giving MiniZinc files diagnostics, hover, go to definition, find references, rename,
completion, signature help, inlay hints, semantic highlighting and formatting. The binary is
resolved from the `lsp.shackle-ls.binary.path` setting, then `PATH`, and otherwise downloaded
from the shackle releases.

Also adds an outline, auto-indent matching the language server's formatter, tasks for solving and
compiling models through the `minizinc` CLI, and improved highlighting for doc comments, unicode
operators and several missing keywords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
