### PR TITLE
Add Hexaly extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2122,6 +2122,10 @@
 	path = extensions/hex-light-theme
 	url = https://github.com/coghost/light-zed-theme
 
+[submodule "extensions/hexaly"]
+	path = extensions/hexaly
+	url = https://github.com/ashenwolf/zed-hexaly.git
+
 [submodule "extensions/hexpeek"]
 	path = extensions/hexpeek
 	url = https://github.com/A-23187/zed-hexpeek.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -2169,6 +2169,10 @@ path = "packages/zed"
 submodule = "extensions/hex-light-theme"
 version = "0.0.4"
 
+[hexaly]
+submodule = "extensions/hexaly"
+version = "0.1.0"
+
 [hexpeek]
 submodule = "extensions/hexpeek"
 version = "0.1.0"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds syntax highlighting for Hexaly Modeler models (`.hxm`), the modeling language of the [Hexaly](https://www.hexaly.com) optimization solver.

- [tree-sitter-hexaly](https://github.com/ashenwolf/tree-sitter-hexaly). It was validated by parsing a production Hexaly model (12 files, ~2500 lines) with zero errors and corrected against the official [HXM BNF](https://www.hexaly.com/docs/last/modelerreference/appendix.html#bnf-syntax).

Provides highlights, brackets, indents, outline, overrides and textobjects queries.

Tested manually in Zed as a dev extension at the submitted commit (3eae49f): grammar compiles, highlighting and outline behave as expected.