### PR TITLE
Add Postdare theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4070,6 +4070,10 @@
 	path = extensions/poryscript
 	url = https://github.com/chris-wilson-1/zed-poryscript.git
 
+[submodule "extensions/postdare-theme"]
+	path = extensions/postdare-theme
+	url = https://github.com/postdare/zed-postdare.git
+
 [submodule "extensions/postgres-context-server"]
 	path = extensions/postgres-context-server
 	url = https://github.com/zed-extensions/postgres-context-server.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4143,6 +4143,10 @@ version = "1.0.3"
 submodule = "extensions/poryscript"
 version = "0.2.0"
 
+[postdare-theme]
+submodule = "extensions/postdare-theme"
+version = "0.1.0"
+
 [postgres-context-server]
 submodule = "extensions/postgres-context-server"
 version = "0.0.5"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Adds **Postdare Light** and **Postdare Dark**, a warm low-contrast theme family for the Zed editor.

- Extension ID: `postdare-theme`
- Repository: https://github.com/postdare/zed-postdare
- License: MIT
- Theme-only extension (`schema_version = 1`); both theme files conform to the [`v0.2.0` theme schema](https://zed.dev/schema/themes/v0.2.0.json)
