### PR TITLE
Add Notion theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3534,6 +3534,10 @@
 	path = extensions/noted-theme
 	url = https://github.com/sergeevalera/noted-theme.git
 
+[submodule "extensions/notion-theme"]
+	path = extensions/notion-theme
+	url = https://github.com/amantibrewal310/zed-notion-theme.git
+
 [submodule "extensions/nova-theme"]
 	path = extensions/nova-theme
 	url = https://github.com/overstarry/zed-nova.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3601,6 +3601,10 @@ version = "0.1.0"
 submodule = "extensions/noted-theme"
 version = "0.1.0"
 
+[notion-theme]
+submodule = "extensions/notion-theme"
+version = "0.1.0"
+
 [nova-theme]
 submodule = "extensions/nova-theme"
 version = "0.1.0"


### PR DESCRIPTION
Adds **Notion**, a light and dark theme built from Notion's own colour palette (its text and icon colours and interface surfaces), mapped onto Zed's syntax and UI slots.

Every colour is lifted until it clears WCAG AA against the editor background (5.4:1 for syntax, 4.6:1 for comments and hints), so it stays readable at small sizes. Both themes define every style key Zed currently reads and all 102 syntax keys.

Repository: https://github.com/amantibrewal310/zed-notion-theme
Licence: MIT

Tested manually in Zed as a dev extension at the submodule commit.