### PR TITLE
Update ifc to v0.6.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2320,7 +2320,7 @@ version = "0.1.0"
 
 [ifc]
 submodule = "extensions/ifc"
-version = "0.1.0"
+version = "0.6.0"
 
 [immigrant]
 submodule = "extensions/immigrant"


### PR DESCRIPTION
## Extension

**Name:** IFC
**ID:** `ifc`
**Repository:** https://github.com/Finradon/zed-ifc

Follow-up to #5723, updating the pinned language server version.

## Changes

- Bumps `IFC-Language-Server` to [v0.6.0](https://github.com/NepomukWolf/IFC-Language-Server/releases/tag/v0.6.0)
- Removes the extension's stderr-to-file logging wrapper — the language server now runs directly, so its output shows up in Zed's own "View Logs" panel instead of a separate log file
- `extensions/ifc` submodule bumped to `Finradon/zed-ifc@b111218`
- `extensions.toml` version bumped `0.1.0` → `0.6.0`

## Checklist

- [x] `extensions.toml` version bumped to match the extension's `extension.toml`
- [x] Submodule pinned to the latest commit on `main`
