### PR TITLE
Add Shopware LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4602,6 +4602,10 @@
 	path = extensions/shizukajapan-theme
 	url = https://github.com/BinaryLeo/Shizuka_japan.git
 
+[submodule "extensions/shopware-lsp"]
+	path = extensions/shopware-lsp
+	url = https://github.com/BrocksiNet/zed-shopware-lsp.git
+
 [submodule "extensions/short-giraffe-theme"]
 	path = extensions/short-giraffe-theme
 	url = https://github.com/kumamaki/Short-Giraffe.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4688,6 +4688,10 @@ version = "1.52.0"
 submodule = "extensions/shizukajapan-theme"
 version = "0.0.2"
 
+[shopware-lsp]
+submodule = "extensions/shopware-lsp"
+version = "0.1.0"
+
 [short-giraffe-theme]
 submodule = "extensions/short-giraffe-theme"
 path = "zed"


### PR DESCRIPTION
Adds `shopware-lsp`, a language-server extension for [Shopware 6](https://github.com/shopware/shopware) projects.

It runs [shopware-lsp](https://github.com/shopware/shopware-lsp), the server behind Shopware's official VS Code extension, giving Zed completion for feature flags, service ids, route names, system config keys, snippet keys and Twig templates; navigation from a service id to its class or a Twig block to the template it overrides; Shopware-aware diagnostics; and the server's MCP tools in the Agent Panel.

Repository: https://github.com/BrocksiNet/zed-shopware-lsp

## Checklist against the prerequisites

- **Tested in Zed at the submitted commit.** Manually, as a dev extension, against a `shopware/shopware` trunk checkout: download and start, completion, hover, go-to-definition, diagnostics, organize-imports, the `codeAction/resolve` round trip, Twig attachment, the Agent Panel context server, and a multi-root workspace. The checklist and results live in [TESTING.md](https://github.com/BrocksiNet/zed-shopware-lsp/blob/main/TESTING.md).
- **Not already available.** No Shopware extension in the registry.
- **ID.** `shopware-lsp` — kebab-case, unique, no `zed` or `extension`, and suffixed `-lsp` as the rules ask for a language-server-only extension.
- **Does not bundle the server.** It is downloaded from Open VSX into the extension work directory, or taken from `binary.path` / `PATH` if the user has one.
- **Stays in its own environment.** Only the work directory Zed provides. Nothing else is read or written.
- **License.** MIT at the extension root, and it passes `src/lib/license.js`.
- **English throughout.**

Only `extension.toml`, `src/`, `snippets/` and two embedded files under `docs/` end up in the built extension; the rest of the repo is documentation and maintenance tooling.

## Notes for review

**Languages.** It declares no grammars and defines no languages — it attaches a language server to PHP, Twig, XML, YAML, JSON, JS/TS, SCSS and Vue, all provided by other extensions. Twig support additionally needs the `twig` extension installed, which the README says.

**Context server.** It also registers the server's MCP endpoint, reusing the same binary rather than downloading a second one. I am aware of #59351 and that MCP server extensions are intended to be superseded by the registry; the language server half is unaffected either way.

**Upstream state.** Two protocol-shape bugs that broke Zed specifically were fixed upstream and released in `0.3.58` ([shopware/shopware-lsp#65](https://github.com/shopware/shopware-lsp/pull/65)) — completion responses emitted an invalid `documentation.kind` that strict clients reject, and `documentColor` returned `null` where an array is required. The extension resolves `0.3.58` or newer, and I verified against the published artifact that both are gone before opening this.
