### PR TITLE
Update kanagawa-wave-blur-theme to v0.2.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -2200,7 +2200,7 @@ version = "0.1.2"
 
 [kanagawa-wave-blur-theme]
 submodule = "extensions/kanagawa-wave-blur-theme"
-version = "0.1.0"
+version = "0.2.0"
 
 [kanso]
 submodule = "extensions/kanso"


### PR DESCRIPTION
Updates `kanagawa-wave-blur-theme` from 0.1.0 to 0.2.0.

- Advances the extension submodule to funsaized/kanagawa-zed-theme@7ddc54d
- Adds Kanagawa Wave, Wave Blur, Dragon, and Lotus updates
- Keeps the registry version aligned with `extension.toml`

Validation:
- `pnpm sort-extensions`
- `pnpm test` (111 tests passed)