### PR TITLE
Add OpenAPI LSP extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3718,6 +3718,10 @@
 	path = extensions/open-dylan
 	url = https://github.com/ganderzz/zed-dylan.git
 
+[submodule "extensions/openapi-lsp"]
+	path = extensions/openapi-lsp
+	url = https://github.com/Dyqer/openapi.git
+
 [submodule "extensions/openfga"]
 	path = extensions/openfga
 	url = https://github.com/rosnovsky/zed-extension-fga.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -3786,6 +3786,10 @@ version = "0.1.0"
 submodule = "extensions/open-dylan"
 version = "0.0.1"
 
+[openapi-lsp]
+submodule = "extensions/openapi-lsp"
+version = "0.2.1"
+
 [openfga]
 submodule = "extensions/openfga"
 version = "0.2.0"


### PR DESCRIPTION
Adds `openapi-lsp`, a language server extension for OpenAPI/Swagger specs.

It attaches to YAML and JSON files, detects whether they are OpenAPI 2.0/3.0/3.1 documents, and then provides `$ref` go-to-definition, hover, completion, and schema diagnostics.

- Repository: https://github.com/Dyqer/openapi
- License: MIT
- The language server is **not** bundled: a `openapi-lsp` binary on `PATH` is preferred, otherwise the matching release archive is downloaded from GitHub releases.
