### PR TITLE
Update `eh-web-themes` to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1417,7 +1417,7 @@ version = "0.0.6"
 
 [eh-web-themes]
 submodule = "extensions/eh-web-themes"
-version = "1.0"
+version = "1.0.0"
 
 [eiffel-theme]
 submodule = "extensions/eiffel-theme"


### PR DESCRIPTION
<!-- Please confirm the checklist below, then remove this comment. -->

It seems like 1.0 was disliked by the marketplace, so it is now 1.0.0
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.
