### PR TITLE
Add Zero Preview (zero-live-preview)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5826,6 +5826,10 @@
 	path = extensions/zeraphim-theme
 	url = https://github.com/Zeraphim/zed-theme.git
 
+[submodule "extensions/zero-live-preview"]
+	path = extensions/zero-live-preview
+	url = https://github.com/kuozher/zed-zero-preview.git
+
 [submodule "extensions/zero-trust-theme"]
 	path = extensions/zero-trust-theme
 	url = https://github.com/yannickboog/zero-trust-theme.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -5935,6 +5935,10 @@ version = "1.0.0"
 submodule = "extensions/zeraphim-theme"
 version = "0.1.0"
 
+[zero-live-preview]
+submodule = "extensions/zero-live-preview"
+version = "0.1.0"
+
 [zero-trust-theme]
 submodule = "extensions/zero-trust-theme"
 version = "0.2.1"


### PR DESCRIPTION
## Summary
- Add the [Zero Preview](https://github.com/kuozher/zed-zero-preview) extension (`zero-live-preview` v0.1.0): a zero-config HTML live preview for Zed with path-resilient `/raw/` serving, SSE reload, and hot CSS.
- Submodule is pinned to tag `v0.1.0` (commit on `master`). GitHub Release ships six platform binaries; the WASM shell downloads them at install time.
- Tested locally as a Zed dev extension on macOS (CJK paths, Open/Stop, reload, hot CSS, `/__open`, second window). CI is green on Ubuntu, macOS, and Windows.

## Test plan
- [ ] `extension.toml` id `zero-live-preview` version `0.1.0` matches `extensions.toml`
- [ ] Submodule URL is HTTPS and the commit exists on `master`
- [ ] Install from this PR / packaged extension and open an HTML file via code action (`Cmd + .`)
- [ ] Confirm the matching GitHub Release asset downloads for the host platform


Conceived and designed by @kuozher. This PR was prepared in collaboration with [Cursor](https://cursor.com).