### PR TITLE
Update cartan to v0.8.3

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -689,7 +689,7 @@ version = "0.4.1"
 
 [cartan]
 submodule = "extensions/cartan"
-version = "0.8.0"
+version = "0.8.3"
 
 [carve]
 submodule = "extensions/carve"


### PR DESCRIPTION
Updates the cartan extension at 0.8.1: language support for cartan documents (`.cart`) — the tree-sitter grammar from cartan-lang/tree-sitter-cartan and the `cartan lsp` language server, which the extension starts from the user's PATH. The extension repository (https://github.com/cartan-lang/zed-cartan) is refreshed per release of the language, in lockstep with its version.