### PR TITLE
Update deps-language-server to v1.0.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -1242,7 +1242,7 @@ version = "1.11.0"
 
 [deps-language-server]
 submodule = "extensions/deps-language-server"
-version = "0.1.8"
+version = "1.0.0"
 
 [depsy-lsp]
 submodule = "extensions/depsy-lsp"


### PR DESCRIPTION
## Summary
- Syncs with a deps-lsp release verification fix: the extraction step now verifies the archive that is actually extracted, instead of a second unverified download
- Documents deps-lsp 0.12-0.14 additions: GitHub Actions and GitLab CI/CD ecosystem coverage, license hover with SPDX allow/deny-list diagnostics, and pnpm-lock.yaml lock file support
- Bumps the version in `extensions.toml` from 0.1.8 to 1.0.0