### PR TITLE
Add razor extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5877,3 +5877,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/razor"]
+	path = extensions/razor
+	url = https://github.com/Meeksoft/zed-razor.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -4371,6 +4371,10 @@ version = "1.0.1"
 submodule = "extensions/rasi"
 version = "0.1.1"
 
+[razor]
+submodule = "extensions/razor"
+version = "0.0.1"
+
 [rcl]
 submodule = "extensions/rcl"
 version = "0.12.0"


### PR DESCRIPTION
Adds the `razor` extension: syntax highlighting for Blazor components (`.razor`) and ASP.NET Core Razor Pages / MVC views (`.cshtml`).

- C# highlighting via tree-sitter-razor (a superset of tree-sitter-c-sharp), including @-expressions, directives, and control-flow blocks
- Markup highlighted by injecting an HTML grammar into elements, which also covers CSS and JS inside <style>/<script>
- Repository: https://github.com/Meeksoft/zed-razor (MIT)
- Grammars: https://github.com/Meeksoft/tree-sitter-razor and https://github.com/Meeksoft/tree-sitter-html — forks of the upstream grammars adding attribute-expression parsing and queryable attribute names; upstream PRs planned

**Why standalone rather than part of the C# extension** (responding to feedback on #7562):

- VS Code ships Razor as its own extension (ASP.NET Core Razor Language Services), separate from C# Dev Kit — this follows that split
- `.razor`/`.cshtml` are markup languages embedding C#; similar HTML-superset languages (Vue, ERB, Svelte) ship as separate extensions rather than folding into the host language
- Ships two patched tree-sitter grammars; adding that weight to the csharp extension expands its maintainers' scope without their sign-off
- Decoupled release cadence: Razor fixes ship without touching C# releases

Happy to coordinate with the csharp maintainers on a middle path (cross-linking, shared conventions) if preferred.