### PR TITLE
Update synthwave84 to v0.3.0

### DIFF
--- a/extensions.toml
+++ b/extensions.toml
@@ -5113,7 +5113,7 @@ version = "0.1.1"
 
 [synthwave84]
 submodule = "extensions/synthwave84"
-version = "0.2.0"
+version = "0.3.0"
 
 [sysml-v2]
 submodule = "extensions/sysml-v2"


### PR DESCRIPTION
Bumps the `synthwave84` theme extension from 0.2.0 to 0.3.0.

Changes since 0.2.0 (https://github.com/DROOdotFOO/synthwave84-zed/pull/2):
- New **Delta** variant, a standalone palette with its own hues for backgrounds, syntax, and terminal colors
- Generalized the variant build so variants are declared in `src/base.json`
- Refreshed preview screenshots for all variants

Release tag: https://github.com/DROOdotFOO/synthwave84-zed/releases/tag/0.3.0
