### PR TITLE
Add Catthode theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -714,6 +714,11 @@
 	path = extensions/catppuccin-icons
 	url = https://github.com/catppuccin/zed-icons.git
 
+[submodule "extensions/catthode-theme"]
+	path = extensions/catthode-theme
+	url = https://github.com/catthode/zed.git
+	branch = main
+
 [submodule "extensions/cds-lsp"]
 	path = extensions/cds-lsp
 	url = https://github.com/doxblek/zed-cds-lsp

--- a/extensions.toml
+++ b/extensions.toml
@@ -727,6 +727,10 @@ version = "0.1.1"
 submodule = "extensions/catppuccin-icons"
 version = "1.24.0"
 
+[catthode-theme]
+submodule = "extensions/catthode-theme"
+version = "0.1.1"
+
 [cds-lsp]
 submodule = "extensions/cds-lsp"
 version = "0.0.2"


### PR DESCRIPTION
## Summary

- Add the Catthode theme extension as `catthode-theme`.
- Point the registry at the public `catthode/zed` repository and tested `v0.1.1` source commit `9248879`.
- Register version `0.1.1` in `extensions.toml`.

## Validation

- Installed the repository as a dev extension in Zed 1.19.2 on Apple Silicon macOS.
- Applied Catthode and inspected workbench surfaces, JSON syntax highlighting, terminal ANSI colors, and diagnostic/error styling.
- Captured a genuine native-size Zed screenshot and added its cursor-free, pixel-verified version to the repository README.
- Confirmed all seven collaboration cursor and selection color slots are present and schema-valid.
- Ran `pnpm build` successfully.
- Ran the registry test suite: 115 tests passed.
- Ran `pnpm sort-extensions` and verified `.gitmodules` and `extensions.toml` remain sorted.

Extension repository: https://github.com/catthode/zed
