### PR TITLE
Add blackout-engine-theme extension

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5857,3 +5857,6 @@
 [submodule "extensions/zwirn"]
 	path = extensions/zwirn
 	url = https://codeberg.org/polymorphicengine/zwirn-zed-extension.git
+[submodule "extensions/blackout-engine"]
+	path = extensions/blackout-engine
+	url = https://github.com/erik-praznovsky/zed-blackout-engine.git

--- a/extensions.toml
+++ b/extensions.toml
@@ -489,6 +489,10 @@ version = "0.4.0"
 submodule = "extensions/blacknpink-theme"
 version = "0.1.0"
 
+[blackout-engine]
+submodule = "extensions/blackout-engine"
+version = "0.1.1"
+
 [blackrain-theme]
 submodule = "extensions/blackrain-theme"
 version = "0.1.3"


### PR DESCRIPTION
- [x] I've read [the contribution guidelines](https://github.com/zed-industries/extensions/blob/main/CONTRIBUTING.md) and followed the relevant guidance for adding or updating my extension.

Resubmission of #7531 — extension ID updated to `blackout-engine-theme` to follow the required `-theme` suffix for theme extensions.